### PR TITLE
Update release checklist to reflect current process

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,8 +1,11 @@
 # Release Checklist
 
+This is instructions for creating a release candidate, which on finding it works successfully can be
+tagged as the final release.
+
 ## Pre-Prep
 - [ ] Inform relevant parties that you're preparing a release (e.g, by posting on Discord)
-- [ ] Create a release branch (e.g `hc-release-vX.X.X`)
+- [ ] Create a release branch (e.g `hc-release-vX.X.X-rc1`)
 
 ## Prep the Runtime and Node
 - [ ] If runtime behaviour has changed, bump `spec_version` and set `impl_version` to `0`
@@ -47,13 +50,18 @@
 - [ ] Ensure **all** CI checks on `master` pass
 - [ ] Create a Git tag From the squashed release PR commit on `master`
     - Make sure to follow [release tag naming conventions](https://github.com/entropyxyz/meta/wiki/Release-management)
-    - `git tag release/vX.X.X`
+    - `git tag release/vX.X.X-rc1` - meaning release candidate number 1. If all goes well this can
+      later by tagged as `release/vX.X.X`
     - Nice to have: sign the tag with an offline GPG key (`git tag -s ...`)
 - [ ] Push tag to build and publish artifacts
-    - `git push origin release/vX.X.X`
+    - `git push origin release/vX.X.X-rc1`
     - Binaries and Docker images for `entropy` and `server` packages will be published by the CI
 - [ ] Publish necessary crates to crates.io
 - [ ] Publish a release on GitHub
     - When a release tag was pushed, a draft release was also created by the CI, use this
     - For the release body, copy the changes from the `CHANGELOG`
 - [ ] Inform relevant parties (e.g, by posting on Discord)
+- [ ] If something turns out to not work correctly when using the release, make a fix and then make
+  a new tag with a new release candidate - eg: `release/vX.X.X-rc2`.
+- [ ] At some point when it is clear that everything works, tag the chosen release candidate as
+  `release/vX.X.X-rc2`.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -38,7 +38,18 @@ tagged as the final release.
       well documented in the `CHANGELOG`
 - [ ] Move entries from `[Unreleased]` header to the new version header (`[X.X.X]`)
 
-## Merge Release Branch
+## Release Branch and Local Network Checks
+- [ ] Publish a test release tag
+    - E.g `git tag test/hc/release/vX.Y.Z-rc.1 && git push origin test/hc/release/vX.Y.Z-rc.1`
+- [ ] Sanity check the release using the local Docker Compose network and the `entropy-test-cli`
+    - Change the `image` in `docker-compose-common.yaml` to use the published ones from above
+    - Spin up the network using `docker compose up`
+    - Register an account using:
+        - `cargo run -p entropy-test-cli -- register \
+            One public ./crates/testing-utils/template_barebones.wasm`
+    - Request a signature using:
+        - `cargo run -p entropy-test-cli -- sign \
+            $VERIFYING_KEY "Hello, Docker Compose"`
 - [ ] Open a PR targeting `master`
 - [ ] Get approvals from Entropy core devs
 - [ ] Merge release PR into `master`
@@ -56,18 +67,21 @@ tagged as the final release.
     - `git push origin release/vX.Y.Z-rc.1`
     - Binaries and Docker images for `entropy` and `entropy-tss` packages will be published by the
       CI (images can be found at https://hub.docker.com/u/entropyxyz)
-- [ ] Verify that the network can be run with Ansible
-    - TODO (Nando): Add instructions or link for this
-- [ ] Using the `entropy-test-cli`, check that registration and signature requests work as expected
-    - TODO (Nando): Add instructions or link for this
 - [ ] Publish necessary crates to crates.io
+    - There is a required ordering here, e.g you cannot simply publish `entropy-tss` without first
+      publishing all its dependencies
 
 ## Publish Release
 - [ ] Publish a release on GitHub
     - When a release tag was pushed, a draft release was also created by the CI, use this
     - For the release body, copy the changes from the `CHANGELOG`
 - [ ] Inform relevant parties (e.g, by posting on Discord)
-- [ ] If something turns out to not work correctly when using the release, make a fix and then make
-  a new tag with a new release candidate - eg: `release/vX.X.X-rc2`.
-- [ ] At some point when it is clear that everything works, tag the chosen release candidate as
-      `release/vX.X.X`.
+
+## Promote Release Candidate
+- [ ] If something turns out to not work correctly when using the release, follow this checklist
+      again to make a new release candidate, e.g `release/vX.Y.Z-rc.2`
+- [ ] At some point when it is clear that everything works, open a PR changing the workspace version
+      numbers from `X.Y.Z-rc.N` to `X.Y.Z`
+- [ ] Get approvals from one Core member and other teams (e.g DevOps and SDK)
+- [ ] Follow the `Publish Artifacts` steps to make new artifacts
+- [ ] Follow the `Publish Release` steps again to make a new release

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -39,17 +39,20 @@ tagged as the final release.
 - [ ] Move entries from `[Unreleased]` header to the new version header (`[X.X.X]`)
 
 ## Release Branch and Local Network Checks
-- [ ] Publish a test release tag
-    - E.g `git tag test/hc/release/vX.Y.Z-rc.1 && git push origin test/hc/release/vX.Y.Z-rc.1`
 - [ ] Sanity check the release using the local Docker Compose network and the `entropy-test-cli`
-    - Change the `image` in `docker-compose-common.yaml` to use the published ones from above
-    - Spin up the network using `docker compose up`
+    - Change the `image` fields in `docker-compose-common.yaml` to a local build, e.g
+      `entropyxyz/entropy:local-vX.Y.Z-rc.1`
+    - Build the images and spin up the network using `docker compose up`
     - Register an account using:
         - `cargo run -p entropy-test-cli -- register \
             One public ./crates/testing-utils/template_barebones.wasm`
     - Request a signature using:
         - `cargo run -p entropy-test-cli -- sign \
             $VERIFYING_KEY "Hello, Docker Compose"`
+- [ ] Publish a test release tag
+    - E.g `git tag test/hc/release/vX.Y.Z-rc.1 && git push origin test/hc/release/vX.Y.Z-rc.1`
+- [ ] Double check that the _published_ images still run correctly using the Docker compose from
+      above
 - [ ] Open a PR targeting `master`
 - [ ] Get approvals from Entropy core devs
 - [ ] Merge release PR into `master`

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -64,4 +64,4 @@ tagged as the final release.
 - [ ] If something turns out to not work correctly when using the release, make a fix and then make
   a new tag with a new release candidate - eg: `release/vX.X.X-rc2`.
 - [ ] At some point when it is clear that everything works, tag the chosen release candidate as
-  `release/vX.X.X-rc2`.
+  `release/vX.X.X`.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -68,8 +68,15 @@ tagged as the final release.
     - Binaries and Docker images for `entropy` and `entropy-tss` packages will be published by the
       CI (images can be found at https://hub.docker.com/u/entropyxyz)
 - [ ] Publish necessary crates to crates.io
-    - There is a required ordering here, e.g you cannot simply publish `entropy-tss` without first
-      publishing all its dependencies
+    - Use the `cargo publish --dry-run` command before actually publishing!
+    - Here is the recommended ordering for publishing:
+        - `entropy-shared`
+        - `entropy-protocol`
+        - `entropy-kvdb`
+        - `entropy-client`
+        - `entropy-tss`
+        - `entropy-testing-utils`
+        - `entropy-test-cli`
 
 ## Publish Release
 - [ ] Publish a release on GitHub

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -5,7 +5,7 @@ tagged as the final release.
 
 ## Pre-Prep
 - [ ] Inform relevant parties that you're preparing a release (e.g, by posting on Discord)
-- [ ] Create a release branch, e.g., for release candidate number one: `release/vX.Y.Z-rc1`.
+- [ ] Create a release branch, e.g., for release candidate `1`: `release/vX.Y.Z-rc.1`.
 
 ## Prep the Runtime and Node
 - [ ] If runtime behaviour has changed, bump `spec_version` and set `impl_version` to `0`
@@ -16,17 +16,16 @@ tagged as the final release.
 - [ ] If you're confused about what to bump, read [this](https://paritytech.github.io/polkadot-sdk/master/sp_version/struct.RuntimeVersion.html)
 - [ ] Update runtime benchmarks
     - `cargo build -p entropy --release --features runtime-benchmarks && ./scripts/benchmarks.sh`
+    - Note: These should ideally be run on [reference hardware](https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#reference-hardware) (i.e `c6i.4xlarge` on AWS)
 - [ ] Bump `version` in TOML manifests
-    - For crates with `publish = false`, bump `PATCH` version
-    - For crates with `publish = true`, bump based off [SemVer](https://semver.org/)
+    - If there are breaking changes, bump the `MINOR` version, otherwise bump the `PATCH` version
 - [ ] Update runtime metadata
     - `cargo run -p entropy -- --dev`
     - `./scripts/pull_entropy_metadata.sh`
 
 ## Prep the Threshold Signing Server (TSS)
 - [ ] Bump `version` in TOML manifests
-    - For crates with `publish = false`, bump `PATCH` version
-    - For crates with `publish = true`, bump based off [SemVer](https://semver.org/)
+    - If there are breaking changes, bump the `MINOR` version, otherwise bump the `PATCH` version
 
 ## Prep the `CHANGELOG`
 - [ ] Ensure `CHANGELOG` entries are up to date
@@ -46,17 +45,24 @@ tagged as the final release.
     - Make sure nothing has gone into `master` in the meantime or you may have you repeat the
       previous steps!
 
-## Publish Artifacts and Release
+## Publish Artifacts
 - [ ] Ensure **all** CI checks on `master` pass
 - [ ] Create a Git tag From the squashed release PR commit on `master`
     - Make sure to follow [release tag naming conventions](https://github.com/entropyxyz/meta/wiki/Release-management)
-    - `git tag release/vX.X.X-rc1` - meaning release candidate number 1. If all goes well this can
-      later by tagged as `release/vX.X.X`
+    - `git tag release/vX.Y.Z-rc.1` - meaning release candidate number 1. If all goes well this can
+      later by tagged as `release/vX.Y.Z`
     - Nice to have: sign the tag with an offline GPG key (`git tag -s ...`)
 - [ ] Push tag to build and publish artifacts
-    - `git push origin release/vX.X.X-rc1`
-    - Binaries and Docker images for `entropy` and `server` packages will be published by the CI
+    - `git push origin release/vX.Y.Z-rc.1`
+    - Binaries and Docker images for `entropy` and `entropy-tss` packages will be published by the
+      CI (images can be found at https://hub.docker.com/u/entropyxyz)
+- [ ] Verify that the network can be run with Ansible
+    - TODO (Nando): Add instructions or link for this
+- [ ] Using the `entropy-test-cli`, check that registration and signature requests work as expected
+    - TODO (Nando): Add instructions or link for this
 - [ ] Publish necessary crates to crates.io
+
+## Publish Release
 - [ ] Publish a release on GitHub
     - When a release tag was pushed, a draft release was also created by the CI, use this
     - For the release body, copy the changes from the `CHANGELOG`
@@ -64,4 +70,4 @@ tagged as the final release.
 - [ ] If something turns out to not work correctly when using the release, make a fix and then make
   a new tag with a new release candidate - eg: `release/vX.X.X-rc2`.
 - [ ] At some point when it is clear that everything works, tag the chosen release candidate as
-  `release/vX.X.X`.
+      `release/vX.X.X`.


### PR DESCRIPTION
Because needing to make fixes when a release either does not build or does not immediately seem to work, update the release checklist to propose having the release candidate number in the tag name.

We should probably also propose this on the wiki page we link to in the release checklist: https://github.com/entropyxyz/meta/wiki/Release-management 