### PR TITLE
Fixes for publishing `entropy-tss` and `entropy-testing-utils`

### DIFF
--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -7,7 +7,6 @@ homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
 repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
-publish    =false
 
 [dependencies]
 subxt             ="0.35.3"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-testing-utils"
-description="Utiliites for testing the Entropy Threshold Signature Server"
+description="Utilities for testing the Entropy Threshold Signature Server"
 version    ='0.1.0-rc.1'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -72,19 +72,25 @@ sha2             ="0.10.8"
 hkdf             ="0.12.4"
 
 [dev-dependencies]
-entropy-testing-utils={ version="0.1.0-rc.1", path="../testing-utils" }
 serial_test          ="3.1.1"
 hex-literal          ="0.4.1"
 project-root         ="0.2.2"
 sp-keyring           ="34.0.0"
 more-asserts         ="0.3.1"
 lazy_static          ="1.4.0"
-entropy-protocol     ={ version="0.1.0-rc.1", path="../protocol", features=["unsafe"] }
 blake3               ="1.5.1"
 ethers-core          ="2.0.14"
 schnorrkel           ={ version="0.11.4", default-features=false, features=["std"] }
-entropy-client       ={ path="../client", features=["full-client-native"] }
 schemars             ={ version="0.8.19" }
+
+# Note: We don't specify versions here because otherwise it would case a small cyclical dependency
+# that Cargo can't resolve. By not specifying a version the crates get removed during the publishing
+# process, allowing it to succeed.
+#
+# See: https://github.com/rust-lang/cargo/issues/4242
+entropy-client       ={ path="../client", features=["full-client-native"] }
+entropy-protocol     ={ path="../protocol", features=["unsafe"] }
+entropy-testing-utils={ path="../testing-utils" }
 
 [build-dependencies]
 vergen={ version="8.0.0", features=["build", "git", "gitcl"] }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -83,9 +83,11 @@ ethers-core          ="2.0.14"
 schnorrkel           ={ version="0.11.4", default-features=false, features=["std"] }
 schemars             ={ version="0.8.19" }
 
-# Note: We don't specify versions here because otherwise it would case a small cyclical dependency
-# that Cargo can't resolve. By not specifying a version the crates get removed during the publishing
-# process, allowing it to succeed.
+# Note: We don't specify versions here because otherwise we run into a cyclical dependency between
+# `entropy-tss` and `entropy-testing-utils` when we try and publish the `entropy-tss` crate.
+#
+# By not specifying a version Cargo automatically removes these crates before publishing, allowing
+# the process to succeed.
 #
 # See: https://github.com/rust-lang/cargo/issues/4242
 entropy-client       ={ path="../client", features=["full-client-native"] }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -72,16 +72,16 @@ sha2             ="0.10.8"
 hkdf             ="0.12.4"
 
 [dev-dependencies]
-serial_test          ="3.1.1"
-hex-literal          ="0.4.1"
-project-root         ="0.2.2"
-sp-keyring           ="34.0.0"
-more-asserts         ="0.3.1"
-lazy_static          ="1.4.0"
-blake3               ="1.5.1"
-ethers-core          ="2.0.14"
-schnorrkel           ={ version="0.11.4", default-features=false, features=["std"] }
-schemars             ={ version="0.8.19" }
+serial_test ="3.1.1"
+hex-literal ="0.4.1"
+project-root="0.2.2"
+sp-keyring  ="34.0.0"
+more-asserts="0.3.1"
+lazy_static ="1.4.0"
+blake3      ="1.5.1"
+ethers-core ="2.0.14"
+schnorrkel  ={ version="0.11.4", default-features=false, features=["std"] }
+schemars    ={ version="0.8.19" }
 
 # Note: We don't specify versions here because otherwise we run into a cyclical dependency between
 # `entropy-tss` and `entropy-testing-utils` when we try and publish the `entropy-tss` crate.

--- a/deny.toml
+++ b/deny.toml
@@ -33,9 +33,10 @@ exceptions=[
   { allow=["AGPL-3.0"], name="entropy-kvdb" },
   { allow=["AGPL-3.0"], name="entropy-protocol" },
   { allow=["AGPL-3.0"], name="entropy-shared" },
-  { allow=["AGPL-3.0"], name="entropy-test-cli" },
   { allow=["AGPL-3.0"], name="entropy-tss" },
   { allow=["AGPL-3.0"], name="entropy-client" },
+  { allow=["AGPL-3.0"], name="entropy-testing-utils" },
+  { allow=["AGPL-3.0"], name="entropy-test-cli" },
 
   # Other Entropy crates
   { allow=["AGPL-3.0"], name="entropy-programs-core" },


### PR DESCRIPTION
I ran into https://github.com/rust-lang/cargo/issues/4242 while trying to publish the
`entropy-tss` crate due to a cyclical dependency with the `entropy-testing-utils` crate.

One solution here is to simply remove the specified version number from the
`dev-dependency` causing issues.

I've also changed the `publish` flag for `entropy-testing-utils` to allow it to be
published.
