### PR TITLE
Improve `--no-sync` docs and tiny sync check

### DIFF
--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -113,7 +113,12 @@ pub async fn load_kv_store(
 #[derive(Parser, Debug, Clone)]
 #[command(about, version)]
 pub struct StartupArgs {
-    /// Wether to sync the keystore.
+    /// Indicates that a Threshold server **should not** ask its peers for key-share data.
+    ///
+    /// This is useful to avoid in cases where:
+    /// - The network is being bootstrapped and peers don't have any useful data yet.
+    /// - There is outdated information about peers (e.g, outdated IP addresses coming from the
+    ///   on-chain registry) and we don't want to sync outdated key-shares.
     #[arg(short = 's', long = "no-sync")]
     pub no_sync: bool,
     /// Use the developer key Bob.

--- a/crates/threshold-signature-server/src/main.rs
+++ b/crates/threshold-signature-server/src/main.rs
@@ -59,7 +59,11 @@ async fn main() {
     setup_latest_block_number(&kv_store).await.expect("Issue setting up Latest Block Number");
 
     // Below deals with syncing the kvdb
-    sync_validator(args.no_sync, args.dev, &configuration.endpoint, &kv_store).await;
+    let sync = !args.no_sync;
+    if sync {
+        sync_validator(args.dev, &configuration.endpoint, &kv_store).await;
+    }
+
     let addr = SocketAddr::from_str(&args.threshold_url).expect("failed to parse threshold url.");
 
     if args.setup_only {

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -447,7 +447,7 @@ async fn test_sync_validator() {
         axum::serve(listener_charlie, charlie_axum).await.unwrap();
     });
 
-    sync_validator(false, false, "ws://127.0.0.1:9944", &charlie_kv).await;
+    sync_validator(false, "ws://127.0.0.1:9944", &charlie_kv).await;
 
     for (i, key) in keys.iter().enumerate() {
         let val = charlie_kv.kv().get(key).await;


### PR DESCRIPTION
There's been some confusion around the usage of `--no-sync`. This PR adds some
documentation around when it should and shouldn't be used.

Admittedly, the crux of the issue stems from having TSS IP addresses on-chain without any
way to determine if they're properly synced or not. If we knew this status we could have
the TSS itself determine whether or not to accept a peers key-shares.

I've also done one little tidy of the logic check around syncing 🧹

cc @vitropy @mixmix 
