### PR TITLE
Bump synedrion to unreleased git version ahead of adding t-of-n in Migrate-To-Threshold branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "sha3",
  "sp-core 31.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2474,7 +2474,7 @@ dependencies = [
  "serial_test",
  "sled",
  "sp-core 31.0.0",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2532,7 +2532,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=25373111cbb01e1a25d8a5c5bb8f4652c725b3f1)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -2681,7 +2681,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
+ "synedrion",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2734,7 +2734,7 @@ dependencies = [
  "sp-keyring 34.0.0",
  "strum 0.26.2",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -13871,27 +13871,6 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 name = "synedrion"
 version = "0.1.0"
 source = "git+https://github.com/entropyxyz/synedrion?rev=25373111cbb01e1a25d8a5c5bb8f4652c725b3f1#25373111cbb01e1a25d8a5c5bb8f4652c725b3f1"
-dependencies = [
- "base64 0.21.7",
- "bincode",
- "cfg-if",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.10.7",
- "displaydoc",
- "hex",
- "k256",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.8",
- "sha3",
- "signature",
-]
-
-[[package]]
-name = "synedrion"
-version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a#7df95fe72781797dc369db00b68c27907559f31a"
 dependencies = [
  "base64 0.21.7",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
  "sha3",
  "sp-core 31.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
  "thiserror",
  "tokio",
  "tracing",
@@ -2474,7 +2474,7 @@ dependencies = [
  "serial_test",
  "sled",
  "sp-core 31.0.0",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
  "thiserror",
  "tokio",
  "tracing",
@@ -2532,7 +2532,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=25373111cbb01e1a25d8a5c5bb8f4652c725b3f1)",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -2681,7 +2681,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2734,7 +2734,7 @@ dependencies = [
  "sp-keyring 34.0.0",
  "strum 0.26.2",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a)",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -13866,6 +13866,27 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synedrion"
+version = "0.1.0"
+source = "git+https://github.com/entropyxyz/synedrion?rev=25373111cbb01e1a25d8a5c5bb8f4652c725b3f1#25373111cbb01e1a25d8a5c5bb8f4652c725b3f1"
+dependencies = [
+ "base64 0.21.7",
+ "bincode",
+ "cfg-if",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.10.7",
+ "displaydoc",
+ "hex",
+ "k256",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "signature",
+]
 
 [[package]]
 name = "synedrion"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13870,8 +13870,7 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 [[package]]
 name = "synedrion"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719bd87aad0150020e25ba8a91e1766c6c67aa2f1b94ce71dba13a3a1bf16b6d"
+source = "git+https://github.com/entropyxyz/synedrion?rev=7df95fe72781797dc369db00b68c27907559f31a#7df95fe72781797dc369db00b68c27907559f31a"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -13879,6 +13878,7 @@ dependencies = [
  "crypto-bigint",
  "crypto-primes",
  "digest 0.10.7",
+ "displaydoc",
  "hex",
  "k256",
  "rand_core 0.6.4",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.1.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.4", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ version="0.1", optional=true }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a", optional=true }
 hex             ={ version="0.4.3", optional=true }
 
 # Only for the browser

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.1.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.4", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a", optional=true }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1", optional=true }
 hex             ={ version="0.4.3", optional=true }
 
 # Only for the browser

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -62,8 +62,6 @@ pub enum ClientError {
     StashFetch,
     #[error("UTF8: {0}")]
     Utf8(#[from] std::str::Utf8Error),
-    #[error("User running protocol: {0}")]
-    UserRunningProtocol(#[from] entropy_protocol::errors::UserRunningProtocolErr),
     #[error("Subxt: {0}")]
     Subxt(#[from] subxt::Error),
     #[error("Timed out waiting for register confirmation")]

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.7", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 
 # Async
 tokio  ={ version="1.16", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.7", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ="0.1"
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
 
 # Async
 tokio  ={ version="1.16", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.80"
 entropy-shared     ={ version="0.1.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.80"
 entropy-shared     ={ version="0.1.0", path="../shared", default-features=false }
-synedrion          ="0.1"
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use synedrion::{sessions, InteractiveSigningResult, KeyGenResult, KeyRefreshResult, MappedResult};
+use synedrion::{
+    sessions, InteractiveSigningResult, KeyGenResult, KeyResharingResult, MappedResult,
+};
 use thiserror::Error;
 
 use crate::{protocol_message::ProtocolMessage, KeyParams, PartyId};
@@ -68,10 +70,10 @@ impl From<GenericProtocolError<KeyGenResult<KeyParams>>> for ProtocolExecutionEr
     }
 }
 
-impl From<GenericProtocolError<KeyRefreshResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<KeyRefreshResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<KeyResharingResult<KeyParams>>) -> Self {
         match err {
-            GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyRefreshProtocolError(err),
+            GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyReshareProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
         }
@@ -89,8 +91,8 @@ pub enum ProtocolExecutionErr {
     SigningProtocolError(Box<sessions::Error<InteractiveSigningResult<KeyParams>, PartyId>>),
     #[error("Synedrion keygen session error")]
     KeyGenProtocolError(Box<sessions::Error<KeyGenResult<KeyParams>, PartyId>>),
-    #[error("Synedrion key refresh session error")]
-    KeyRefreshProtocolError(Box<sessions::Error<KeyRefreshResult<KeyParams>, PartyId>>),
+    #[error("Synedrion key reshare session error")]
+    KeyReshareProtocolError(Box<sessions::Error<KeyResharingResult<KeyParams>, PartyId>>),
     #[error("Broadcast error: {0}")]
     Broadcast(#[from] Box<tokio::sync::broadcast::error::SendError<ProtocolMessage>>),
     #[error("Bad keyshare error {0}")]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -99,6 +99,8 @@ pub enum ProtocolExecutionErr {
     BadKeyShare(String),
     #[error("Cannot serialize session ID {0}")]
     Bincode(#[from] bincode::Error),
+    #[error("No output from reshare protocol")]
+    NoOutputFromReshareProtocol,
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -31,12 +31,11 @@ use crate::{
     errors::{GenericProtocolError, ProtocolExecutionErr},
     protocol_message::ProtocolMessage,
     protocol_transport::Broadcaster,
-    KeyParams, PartyId, SessionId,
+    KeyParams, KeyShareWithAuxInfo, PartyId, SessionId,
 };
 
 pub type ChannelIn = mpsc::Receiver<ProtocolMessage>;
 pub type ChannelOut = Broadcaster;
-type KeyShareWithAuxInfo = (ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>);
 
 /// Thin wrapper broadcasting channel out and messages from other nodes in
 pub struct Channels(pub ChannelOut, pub ChannelIn);

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -142,7 +142,7 @@ pub async fn execute_signing_protocol(
     threshold_accounts: Vec<AccountId32>,
 ) -> Result<RecoverableSignature, ProtocolExecutionErr> {
     tracing::debug!("Executing signing protocol");
-    // tracing::trace!("Using key share {:?}", &key_share);
+    tracing::trace!("Using key share with verifying key {:?}", &key_share.verifying_key());
 
     let party_ids: Vec<PartyId> = threshold_accounts.iter().cloned().map(PartyId::new).collect();
 

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -36,6 +36,7 @@ use crate::{
 
 pub type ChannelIn = mpsc::Receiver<ProtocolMessage>;
 pub type ChannelOut = Broadcaster;
+type KeyShareWithAuxData = (KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>);
 
 /// Thin wrapper broadcasting channel out and messages from other nodes in
 pub struct Channels(pub ChannelOut, pub ChannelIn);
@@ -175,7 +176,7 @@ pub async fn execute_dkg(
     chans: Channels,
     threshold_pair: &sr25519::Pair,
     threshold_accounts: Vec<AccountId32>,
-) -> Result<(KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>), ProtocolExecutionErr> {
+) -> Result<KeyShareWithAuxData, ProtocolExecutionErr> {
     tracing::debug!("Executing DKG");
 
     let party_ids: Vec<PartyId> = threshold_accounts.iter().cloned().map(PartyId::new).collect();

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -217,11 +217,11 @@ pub async fn execute_proactive_refresh(
         old_holder: Some(OldHolder { key_share: old_key }),
         new_holder: Some(NewHolder {
             verifying_key,
-            old_threshold: 2,
+            old_threshold: party_ids.len(),
             old_holders: party_ids.clone(),
         }),
         new_holders: party_ids.clone(),
-        new_threshold: 2,
+        new_threshold: party_ids.len(),
     };
     let session =
         make_key_resharing_session(&mut OsRng, &shared_randomness, pair, &party_ids, &inputs)

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -229,5 +229,5 @@ pub async fn execute_proactive_refresh(
 
     let new_key_share = execute_protocol_generic(chans, session).await?;
 
-    Ok(new_key_share.ok_or(ProtocolExecutionErr::NoOutputFromReshareProtocol)?)
+    new_key_share.ok_or(ProtocolExecutionErr::NoOutputFromReshareProtocol)
 }

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -19,12 +19,10 @@ use rand_core::{CryptoRngCore, OsRng};
 use sp_core::{sr25519, Pair};
 use subxt::utils::AccountId32;
 use synedrion::{
-    sessions::{
-        make_interactive_signing_session, make_key_gen_session, make_key_refresh_session,
-        FinalizeOutcome, PrehashedMessage, Session,
-    },
+    make_interactive_signing_session, make_key_gen_session, make_key_refresh_session,
+    sessions::{FinalizeOutcome, Session},
     signature::{self, hazmat::RandomizedPrehashSigner},
-    KeyShare, ProtocolResult, RecoverableSignature,
+    KeyShare, PrehashedMessage, RecoverableSignature,
 };
 use tokio::sync::mpsc;
 
@@ -62,10 +60,10 @@ impl RandomizedPrehashSigner<sr25519::Signature> for PairWrapper {
     }
 }
 
-async fn execute_protocol_generic<Res: ProtocolResult>(
+async fn execute_protocol_generic<Res: synedrion::MappedResult<PartyId>>(
     mut chans: Channels,
     session: Session<Res, sr25519::Signature, PairWrapper, PartyId>,
-) -> Result<Res::Success, GenericProtocolError<Res>> {
+) -> Result<Res::MappedSuccess, GenericProtocolError<Res>> {
     let tx = &chans.0;
     let rx = &mut chans.1;
 
@@ -77,29 +75,15 @@ async fn execute_protocol_generic<Res: ProtocolResult>(
     loop {
         let mut accum = session.make_accumulator();
 
-        // Send out broadcasts
-        let destinations = session.broadcast_destinations();
-        if let Some(destinations) = destinations {
-            // TODO (#641): this can happen in a spawned task
-            let message = session.make_broadcast(&mut OsRng)?;
-            for destination in destinations.iter() {
-                tx.send(ProtocolMessage::new(&my_id, destination, message.clone()))?;
-            }
-        }
+        // Send out messages
+        let destinations = session.message_destinations();
+        // TODO (#641): this can happen in a spawned task
+        for destination in destinations.iter() {
+            let (message, artifact) = session.make_message(&mut OsRng, destination)?;
+            tx.send(ProtocolMessage::new(&my_id, destination, message))?;
 
-        // Send out direct messages
-        let destinations = session.direct_message_destinations();
-        if let Some(destinations) = destinations {
-            for destination in destinations.iter() {
-                // TODO (#641): this can happen in a spawned task.
-                // The artefact will be sent back to the host task
-                // to be added to the accumulator.
-                let (message, artifact) = session.make_direct_message(&mut OsRng, destination)?;
-                tx.send(ProtocolMessage::new(&my_id, destination, message))?;
-
-                // This will happen in a host task
-                accum.add_artifact(artifact)?;
-            }
+            // This will happen in a host task
+            accum.add_artifact(artifact)?;
         }
 
         for preprocessed in cached_messages {
@@ -150,13 +134,13 @@ async fn execute_protocol_generic<Res: ProtocolResult>(
 pub async fn execute_signing_protocol(
     session_id: SessionId,
     chans: Channels,
-    key_share: &KeyShare<KeyParams>,
+    key_share: &KeyShare<KeyParams, PartyId>,
     prehashed_message: &PrehashedMessage,
     threshold_pair: &sr25519::Pair,
     threshold_accounts: Vec<AccountId32>,
 ) -> Result<RecoverableSignature, ProtocolExecutionErr> {
     tracing::debug!("Executing signing protocol");
-    tracing::trace!("Using key share {:?}", &key_share);
+    // tracing::trace!("Using key share {:?}", &key_share);
 
     let party_ids: Vec<PartyId> = threshold_accounts.iter().cloned().map(PartyId::new).collect();
 
@@ -188,7 +172,7 @@ pub async fn execute_dkg(
     chans: Channels,
     threshold_pair: &sr25519::Pair,
     threshold_accounts: Vec<AccountId32>,
-) -> Result<KeyShare<KeyParams>, ProtocolExecutionErr> {
+) -> Result<KeyShare<KeyParams, PartyId>, ProtocolExecutionErr> {
     tracing::debug!("Executing DKG");
 
     let party_ids: Vec<PartyId> = threshold_accounts.iter().cloned().map(PartyId::new).collect();
@@ -214,11 +198,10 @@ pub async fn execute_proactive_refresh(
     chans: Channels,
     threshold_pair: &sr25519::Pair,
     threshold_accounts: Vec<AccountId32>,
-    old_key: KeyShare<KeyParams>,
-) -> Result<KeyShare<KeyParams>, ProtocolExecutionErr> {
+    old_key: KeyShare<KeyParams, PartyId>,
+) -> Result<KeyShare<KeyParams, PartyId>, ProtocolExecutionErr> {
     tracing::debug!("Executing proactive refresh");
     tracing::debug!("Signing with {:?}", &threshold_pair.public());
-    tracing::trace!("Previous key {:?}", &old_key);
 
     let party_ids: Vec<PartyId> = threshold_accounts.iter().cloned().map(PartyId::new).collect();
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -39,6 +39,7 @@ use subxt::utils::AccountId32;
 use synedrion::{
     k256::ecdsa::{RecoveryId, Signature},
     signature::{self, hazmat::PrehashVerifier},
+    AuxInfo, ThresholdKeyShare,
 };
 
 /// Identifies a party participating in a protocol session
@@ -125,6 +126,9 @@ use synedrion::TestParams;
 pub type KeyParams = TestParams;
 
 pub use synedrion::KeyShare;
+
+/// This is the keyshare payload which gets stored by entropy-tss
+pub type KeyShareWithAuxInfo = (ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>);
 
 /// A secp256k1 signature from which we can recover the public key of the keypair used to create it
 #[derive(Clone, Debug)]

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -23,7 +23,6 @@ use crate::{protocol_transport::errors::ProtocolMessageErr, PartyId};
 
 /// A Message send during the signing or DKG protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-// #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ProtocolMessage {
     /// Identifier of the author of this message
     pub from: PartyId,

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -17,20 +17,20 @@ use std::str;
 
 use serde::{Deserialize, Serialize};
 use sp_core::sr25519;
-use synedrion::sessions::SignedMessage;
+use synedrion::sessions::CombinedMessage;
 
 use crate::{protocol_transport::errors::ProtocolMessageErr, PartyId};
 
 /// A Message send during the signing or DKG protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+// #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct ProtocolMessage {
     /// Identifier of the author of this message
     pub from: PartyId,
     /// Identifier of the destination of this message
     pub to: PartyId,
     /// The signed protocol message
-    pub payload: SignedMessage<sr25519::Signature>,
+    pub payload: CombinedMessage<sr25519::Signature>,
 }
 
 impl TryFrom<&[u8]> for ProtocolMessage {
@@ -46,7 +46,7 @@ impl ProtocolMessage {
     pub(crate) fn new(
         from: &PartyId,
         to: &PartyId,
-        payload: SignedMessage<sr25519::Signature>,
+        payload: CombinedMessage<sr25519::Signature>,
     ) -> Self {
         Self { from: from.clone(), to: to.clone(), payload }
     }

--- a/crates/protocol/src/protocol_transport/mod.rs
+++ b/crates/protocol/src/protocol_transport/mod.rs
@@ -27,12 +27,11 @@ use futures::{SinkExt, StreamExt};
 use noise::EncryptedWsConnection;
 pub use subscribe_message::SubscribeMessage;
 #[cfg(feature = "server")]
-use tokio::net::TcpStream;
 use tokio::sync::{broadcast, mpsc};
 #[cfg(feature = "server")]
-use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{tungstenite, MaybeTlsStream, WebSocketStream};
 
-use crate::{errors::UserRunningProtocolErr, PartyId, ProtocolMessage};
+use crate::{PartyId, ProtocolMessage};
 
 /// Channels between a remote party and the signing or DKG protocol
 pub struct WsChannels {
@@ -176,27 +175,6 @@ pub async fn ws_to_channels<T: WsConnection>(
             }
         }
     }
-}
-
-/// Open a ws connection in a native environment
-#[cfg(feature = "server")]
-pub async fn open_ws_connection(
-    address: String,
-) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, UserRunningProtocolErr> {
-    let (ws_stream, _response) = connect_async(address)
-        .await
-        .map_err(|e| UserRunningProtocolErr::Connection(e.to_string()))?;
-    Ok(ws_stream)
-}
-
-/// Open a ws connection on wasm with the JS websocket API
-#[cfg(feature = "wasm")]
-pub async fn open_ws_connection(
-    address: String,
-) -> Result<gloo_net::websocket::futures::WebSocket, UserRunningProtocolErr> {
-    let ws_stream = gloo_net::websocket::futures::WebSocket::open(&address)
-        .map_err(|e| UserRunningProtocolErr::Connection(e.to_string()))?;
-    Ok(ws_stream)
 }
 
 // This dummy trait is only needed because we cant add #[cfg] to where clauses

--- a/crates/protocol/src/protocol_transport/mod.rs
+++ b/crates/protocol/src/protocol_transport/mod.rs
@@ -26,7 +26,6 @@ use errors::WsError;
 use futures::{SinkExt, StreamExt};
 use noise::EncryptedWsConnection;
 pub use subscribe_message::SubscribeMessage;
-#[cfg(feature = "server")]
 use tokio::sync::{broadcast, mpsc};
 #[cfg(feature = "server")]
 use tokio_tungstenite::{tungstenite, MaybeTlsStream, WebSocketStream};

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -30,11 +30,12 @@ use entropy_shared::X25519PublicKey;
 use futures::future;
 use sp_core::{sr25519, Pair};
 use std::{
+    fmt,
     sync::{Arc, Mutex},
     time::Duration,
 };
 use subxt::utils::AccountId32;
-use synedrion::KeyShare;
+use synedrion::{AuxInfo, KeyShare};
 use tokio::{
     net::{TcpListener, TcpStream},
     time::timeout,
@@ -50,11 +51,16 @@ struct ServerState {
 }
 
 /// Output of a successful protocol run
-#[derive(Debug)]
 pub enum ProtocolOutput {
     Sign(RecoverableSignature),
-    ProactiveRefresh(KeyShare<KeyParams>),
-    Dkg(KeyShare<KeyParams>),
+    ProactiveRefresh(KeyShare<KeyParams, PartyId>),
+    Dkg((KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)),
+}
+
+impl fmt::Debug for ProtocolOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Success")
+    }
 }
 
 /// A websocket server handling a single test protocol session
@@ -64,7 +70,8 @@ pub async fn server(
     pair: sr25519::Pair,
     x25519_secret_key: StaticSecret,
     session_id: SessionId,
-    keyshare: Option<KeyShare<KeyParams>>,
+    keyshare: Option<KeyShare<KeyParams, PartyId>>,
+    aux_info: Option<AuxInfo<KeyParams, PartyId>>,
 ) -> anyhow::Result<ProtocolOutput> {
     let account_id = AccountId32(pair.public().0);
 
@@ -109,6 +116,7 @@ pub async fn server(
                 session_id,
                 channels,
                 &keyshare.unwrap(),
+                &aux_info.unwrap(),
                 &session_info.message_hash,
                 &pair,
                 tss_accounts,
@@ -130,8 +138,9 @@ pub async fn server(
             Ok(ProtocolOutput::ProactiveRefresh(new_keyshare))
         },
         SessionId::Dkg { .. } => {
-            let keyshare = execute_dkg(session_id, channels, &pair, tss_accounts).await?;
-            Ok(ProtocolOutput::Dkg(keyshare))
+            let keyshare_and_aux_info =
+                execute_dkg(session_id, channels, &pair, tss_accounts).await?;
+            Ok(ProtocolOutput::Dkg(keyshare_and_aux_info))
         },
     }
 }

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -35,7 +35,7 @@ use std::{
     time::Duration,
 };
 use subxt::utils::AccountId32;
-use synedrion::{AuxInfo, KeyShare};
+use synedrion::{AuxInfo, ThresholdKeyShare};
 use tokio::{
     net::{TcpListener, TcpStream},
     time::timeout,
@@ -53,8 +53,8 @@ struct ServerState {
 /// Output of a successful protocol run
 pub enum ProtocolOutput {
     Sign(RecoverableSignature),
-    ProactiveRefresh(KeyShare<KeyParams, PartyId>),
-    Dkg((KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)),
+    ProactiveRefresh(ThresholdKeyShare<KeyParams, PartyId>),
+    Dkg((ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)),
 }
 
 impl fmt::Debug for ProtocolOutput {
@@ -70,7 +70,7 @@ pub async fn server(
     pair: sr25519::Pair,
     x25519_secret_key: StaticSecret,
     session_id: SessionId,
-    keyshare: Option<KeyShare<KeyParams, PartyId>>,
+    keyshare: Option<ThresholdKeyShare<KeyParams, PartyId>>,
     aux_info: Option<AuxInfo<KeyParams, PartyId>>,
 ) -> anyhow::Result<ProtocolOutput> {
     let account_id = AccountId32(pair.public().0);

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -24,7 +24,8 @@ use entropy_protocol::{
         noise::{noise_handshake_initiator, noise_handshake_responder},
         ws_to_channels, SubscribeMessage, WsChannels,
     },
-    KeyParams, Listener, PartyId, RecoverableSignature, SessionId, ValidatorInfo,
+    KeyParams, KeyShareWithAuxInfo, Listener, PartyId, RecoverableSignature, SessionId,
+    ValidatorInfo,
 };
 use entropy_shared::X25519PublicKey;
 use futures::future;
@@ -54,7 +55,7 @@ struct ServerState {
 pub enum ProtocolOutput {
     Sign(RecoverableSignature),
     ProactiveRefresh(ThresholdKeyShare<KeyParams, PartyId>),
-    Dkg((ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)),
+    Dkg(KeyShareWithAuxInfo),
 }
 
 impl fmt::Debug for ProtocolOutput {

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -23,7 +23,7 @@ use rand_core::OsRng;
 use sp_core::{sr25519, Pair};
 use std::time::Instant;
 use subxt::utils::AccountId32;
-use synedrion::{ecdsa::VerifyingKey, AuxInfo, KeyShare};
+use synedrion::{ecdsa::VerifyingKey, AuxInfo, KeyShare, ThresholdKeyShare};
 use tokio::{net::TcpListener, runtime::Runtime, sync::oneshot};
 use x25519_dalek::StaticSecret;
 
@@ -146,7 +146,7 @@ async fn test_protocol_with_parties(
         let x25519_public_key = x25519_dalek::PublicKey::from(&x25519_secret_key).to_bytes();
 
         validator_secrets.push(ValidatorSecretInfo {
-            keyshare: keyshares.as_ref().map(|k| k[i].clone()),
+            keyshare: keyshares.as_ref().map(|k| k[i].to_threshold_key_share()),
             aux_info: aux_infos.as_ref().map(|a| a[i].clone()),
             pair: parties[i].clone(),
             x25519_secret_key,
@@ -194,7 +194,7 @@ async fn test_protocol_with_parties(
 
 /// Details of an individual party
 struct ValidatorSecretInfo {
-    keyshare: Option<KeyShare<KeyParams, PartyId>>,
+    keyshare: Option<ThresholdKeyShare<KeyParams, PartyId>>,
     aux_info: Option<AuxInfo<KeyParams, PartyId>>,
     pair: sr25519::Pair,
     x25519_secret_key: StaticSecret,

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -55,13 +55,7 @@ fn dkg_protocol_with_time_logged() {
 }
 
 async fn test_sign_with_parties(num_parties: usize) {
-    let mut parties = Vec::new();
-    let mut ids = Vec::new();
-    for _ in 0..num_parties {
-        let (pair, _) = sr25519::Pair::generate();
-        ids.push(PartyId::new(AccountId32(pair.public().0)));
-        parties.push(pair);
-    }
+    let (parties, ids) = get_keypairs_and_ids(num_parties);
     let keyshares = KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, None);
     let aux_infos = AuxInfo::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids);
     let verifying_key = keyshares[0].verifying_key();
@@ -89,13 +83,7 @@ async fn test_sign_with_parties(num_parties: usize) {
 }
 
 async fn test_refresh_with_parties(num_parties: usize) {
-    let mut parties = Vec::new();
-    let mut ids = Vec::new();
-    for _ in 0..num_parties {
-        let (pair, _) = sr25519::Pair::generate();
-        ids.push(PartyId::new(AccountId32(pair.public().0)));
-        parties.push(pair);
-    }
+    let (parties, ids) = get_keypairs_and_ids(num_parties);
     let keyshares = KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, None);
     let verifying_key = keyshares[0].verifying_key();
 
@@ -112,13 +100,7 @@ async fn test_refresh_with_parties(num_parties: usize) {
 }
 
 async fn test_dkg_with_parties(num_parties: usize) {
-    let mut parties = Vec::new();
-    let mut ids = Vec::new();
-    for _ in 0..num_parties {
-        let (pair, _) = sr25519::Pair::generate();
-        ids.push(PartyId::new(AccountId32(pair.public().0)));
-        parties.push(pair);
-    }
+    let (parties, _ids) = get_keypairs_and_ids(num_parties);
     let session_id = SessionId::Dkg { user: AccountId32([0; 32]), block_number: 0 };
     let output = test_protocol_with_parties(parties, None, None, session_id).await;
     if let ProtocolOutput::Dkg(_keyshare) = output {
@@ -208,4 +190,12 @@ fn get_tokio_runtime(num_cpus: usize) -> Runtime {
         .enable_all()
         .build()
         .unwrap()
+}
+
+/// Generate keypair and make PartyId from public key
+fn get_keypairs_and_ids(num_parties: usize) -> (Vec<sr25519::Pair>, Vec<PartyId>) {
+    let pairs = (0..num_parties).map(|_| sr25519::Pair::generate().0).collect::<Vec<_>>();
+    let ids =
+        pairs.iter().map(|pair| PartyId::new(AccountId32(pair.public().0))).collect::<Vec<_>>();
+    (pairs, ids)
 }

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -7,8 +7,12 @@ use sp_std::vec::Vec;
 
 pub const DEFAULT_VERIFYING_KEY_NOT_REGISTERED: EncodedVerifyingKey =
     [10; VERIFICATION_KEY_LENGTH as usize];
-pub const DAVE_VERIFYING_KEY: EncodedVerifyingKey = [1; VERIFICATION_KEY_LENGTH as usize];
-// This key is associated with a constant key share generation from DETERMINISTIC_KEY_SHARE
+// This key is associated with a constant key share generation from DETERMINISTIC_KEY_SHARE_DAVE
+pub const DAVE_VERIFYING_KEY: EncodedVerifyingKey = [
+    3, 42, 97, 187, 199, 208, 95, 166, 102, 15, 38, 146, 173, 111, 175, 123, 62, 132, 178, 237,
+    150, 199, 194, 240, 153, 30, 113, 104, 57, 63, 54, 2, 65,
+];
+// This key is associated with a constant key share generation from DETERMINISTIC_KEY_SHARE_EVE
 pub const EVE_VERIFYING_KEY: EncodedVerifyingKey = [
     2, 78, 59, 129, 175, 156, 34, 52, 202, 208, 157, 103, 156, 230, 3, 94, 209, 57, 35, 71, 206,
     100, 206, 64, 95, 93, 205, 54, 34, 138, 37, 222, 110,
@@ -17,8 +21,10 @@ pub const FERDIE_VERIFYING_KEY: EncodedVerifyingKey = [3; VERIFICATION_KEY_LENGT
 pub const DEFAULT_VERIFYING_KEY: EncodedVerifyingKey = [0; VERIFICATION_KEY_LENGTH as usize];
 
 lazy_static! {
-    // key used to create a deterministic key share taken from here https://docs.rs/k256/latest/k256/ecdsa/index.html
-    pub static ref DETERMINISTIC_KEY_SHARE: [u8; 32] =  hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318");
+    // key used to create a deterministic key share for EVE taken from here https://docs.rs/k256/latest/k256/ecdsa/index.html
+    pub static ref DETERMINISTIC_KEY_SHARE_EVE: [u8; 32] =  hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318");
+    // key used to create a deterministic key for DAVE - this is random 32 bytes
+    pub static ref DETERMINISTIC_KEY_SHARE_DAVE: [u8; 32] =  hex!("06b07fd12cdfb94fbde3ff2098e9f19bb11b00959680cfbd15c914b025f298d7");
     // hash used to find DEVICE_KEY_PROXY onchain
     pub static ref DEVICE_KEY_HASH: H256 =  H256::zero();
     // Device key config struct seralized by generate types in programs repo

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.1.0", path="../shared" }
 entropy-kvdb      ={ version="0.1.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.1.0", path="../threshold-signature-server" }
 entropy-protocol  ={ version="0.1.0", path="../protocol" }
-synedrion         ="0.1"
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.1.0", path="../shared" }
 entropy-kvdb      ={ version="0.1.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.1.0", path="../threshold-signature-server" }
 entropy-protocol  ={ version="0.1.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 

--- a/crates/testing-utils/src/tss_server_process.rs
+++ b/crates/testing-utils/src/tss_server_process.rs
@@ -16,7 +16,7 @@
 use axum::{routing::IntoMakeService, Router};
 use entropy_kvdb::{encrypted_sled::PasswordMethod, kv_manager::KvManager};
 use entropy_protocol::{KeyParams, PartyId};
-use entropy_shared::DETERMINISTIC_KEY_SHARE;
+use entropy_shared::DETERMINISTIC_KEY_SHARE_EVE;
 use entropy_tss::{
     app, get_signer,
     launch::{setup_latest_block_number, setup_mnemonic, Configuration, ValidatorName},
@@ -83,7 +83,7 @@ pub async fn spawn_testing_validators(
     let user_keyshare_option = if passed_verifying_key.is_some() {
         // creates a deterministic keyshare if requiered
         let signing_key = if deterministic_key_share {
-            Some(SigningKey::from_bytes((&*DETERMINISTIC_KEY_SHARE).into()).unwrap())
+            Some(SigningKey::from_bytes((&*DETERMINISTIC_KEY_SHARE_EVE).into()).unwrap())
         } else {
             None
         };

--- a/crates/testing-utils/src/tss_server_process.rs
+++ b/crates/testing-utils/src/tss_server_process.rs
@@ -62,7 +62,7 @@ pub async fn spawn_testing_validators(
     extra_private_keys: bool,
     // If true keyshare and verifying key is deterministic
     deterministic_key_share: bool,
-) -> (Vec<String>, Vec<PartyId>, Option<KeyShare<KeyParams>>) {
+) -> (Vec<String>, Vec<PartyId>, Option<KeyShare<KeyParams, PartyId>>) {
     // spawn threshold servers
     let ports = [3001i64, 3002];
 
@@ -78,8 +78,9 @@ pub async fn spawn_testing_validators(
         *get_signer(&bob_kv).await.unwrap().account_id().clone().as_ref(),
     ));
 
+    let ids = vec![alice_id, bob_id];
+
     let user_keyshare_option = if passed_verifying_key.is_some() {
-        let number_of_shares = if extra_private_keys { 3 } else { 2 };
         // creates a deterministic keyshare if requiered
         let signing_key = if deterministic_key_share {
             Some(SigningKey::from_bytes((&*DETERMINISTIC_KEY_SHARE).into()).unwrap())
@@ -87,11 +88,8 @@ pub async fn spawn_testing_validators(
             None
         };
 
-        let shares = KeyShare::<KeyParams>::new_centralized(
-            &mut OsRng,
-            number_of_shares,
-            signing_key.as_ref(),
-        );
+        let shares =
+            KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, signing_key.as_ref());
         let validator_1_threshold_keyshare: Vec<u8> =
             entropy_kvdb::kv_manager::helpers::serialize(&shares[0]).unwrap();
         let validator_2_threshold_keyshare: Vec<u8> =
@@ -137,6 +135,5 @@ pub async fn spawn_testing_validators(
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let ips = ports.iter().map(|port| format!("127.0.0.1:{port}")).collect();
-    let ids = vec![alice_id, bob_id];
     (ips, ids, user_keyshare_option)
 }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.7.0"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 strum              ="0.26.2"
 
 # Async

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.7.0"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ="0.1"
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="7df95fe72781797dc369db00b68c27907559f31a" }
 strum              ="0.26.2"
 
 # Async

--- a/crates/threshold-signature-server/src/helpers/signing.rs
+++ b/crates/threshold-signature-server/src/helpers/signing.rs
@@ -96,7 +96,14 @@ pub async fn do_signing(
     };
 
     let result = signing_service
-        .execute_sign(session_id, &sign_context.key_share, channels, signer, tss_accounts)
+        .execute_sign(
+            session_id,
+            &sign_context.key_share,
+            &sign_context.aux_info,
+            channels,
+            signer,
+            tss_accounts,
+        )
         .await?;
     increment_or_wipe_request_limit(
         rpc,

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -48,7 +48,7 @@ use subxt::{
     backend::legacy::LegacyRpcMethods, ext::sp_core::sr25519, tx::PairSigner,
     utils::AccountId32 as SubxtAccountId32, Config, OnlineClient,
 };
-use synedrion::{k256::ecdsa::SigningKey, KeyShare};
+use synedrion::{k256::ecdsa::SigningKey, AuxInfo, KeyShare, ThresholdKeyShare};
 use tokio::sync::OnceCell;
 
 /// A shared reference to the logger used for tests.
@@ -123,7 +123,7 @@ pub async fn spawn_testing_validators(
     extra_private_keys: bool,
     // If true keyshare and verifying key is deterministic
     deterministic_key_share: bool,
-) -> (Vec<String>, Vec<PartyId>, Option<KeyShare<KeyParams, PartyId>>) {
+) -> (Vec<String>, Vec<PartyId>, Option<ThresholdKeyShare<KeyParams, PartyId>>) {
     // spawn threshold servers
     let ports = [3001i64, 3002];
 
@@ -151,10 +151,16 @@ pub async fn spawn_testing_validators(
 
         let shares =
             KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, signing_key.as_ref());
-        let validator_1_threshold_keyshare: Vec<u8> =
-            entropy_kvdb::kv_manager::helpers::serialize(&shares[0]).unwrap();
-        let validator_2_threshold_keyshare: Vec<u8> =
-            entropy_kvdb::kv_manager::helpers::serialize(&shares[1]).unwrap();
+        let aux_infos = AuxInfo::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids);
+
+        let validator_1_threshold_keyshare: Vec<u8> = entropy_kvdb::kv_manager::helpers::serialize(
+            &(shares[0].to_threshold_key_share(), &aux_infos[0]),
+        )
+        .unwrap();
+        let validator_2_threshold_keyshare: Vec<u8> = entropy_kvdb::kv_manager::helpers::serialize(
+            &(shares[1].to_threshold_key_share(), &aux_infos[1]),
+        )
+        .unwrap();
         // uses the deterministic verifying key if requested
         let verifying_key = if deterministic_key_share {
             hex::encode(shares[0].verifying_key().to_encoded_point(true).as_bytes().to_vec())
@@ -170,9 +176,9 @@ pub async fn spawn_testing_validators(
         bob_kv.kv().put(bob_reservation, validator_2_threshold_keyshare).await.unwrap();
 
         if extra_private_keys {
-            Some(shares[2].clone())
+            Some(shares[2].to_threshold_key_share())
         } else {
-            Some(shares[1].clone())
+            Some(shares[1].to_threshold_key_share())
         }
     } else {
         None

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -41,8 +41,8 @@ use crate::{
 };
 use axum::{routing::IntoMakeService, Router};
 use entropy_kvdb::{encrypted_sled::PasswordMethod, get_db_path, kv_manager::KvManager};
-use entropy_protocol::{KeyParams, PartyId};
-use entropy_shared::DETERMINISTIC_KEY_SHARE;
+use entropy_protocol::{KeyParams, KeyShareWithAuxInfo, PartyId};
+use entropy_shared::DETERMINISTIC_KEY_SHARE_EVE;
 use rand_core::OsRng;
 use sp_core::Pair;
 use subxt::{
@@ -124,11 +124,7 @@ pub async fn spawn_testing_validators(
     extra_private_key: Option<sr25519::Pair>,
     // If true keyshare and verifying key is deterministic
     deterministic_key_share: bool,
-) -> (
-    Vec<String>,
-    Vec<PartyId>,
-    Option<(ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)>,
-) {
+) -> (Vec<String>, Vec<PartyId>, Option<KeyShareWithAuxInfo>) {
     // spawn threshold servers
     let ports = [3001i64, 3002];
 
@@ -152,7 +148,7 @@ pub async fn spawn_testing_validators(
     let user_keyshare_option = if passed_verifying_key.is_some() {
         // creates a deterministic keyshare if requiered
         let signing_key = if deterministic_key_share {
-            Some(SigningKey::from_bytes((&*DETERMINISTIC_KEY_SHARE).into()).unwrap())
+            Some(SigningKey::from_bytes((&*DETERMINISTIC_KEY_SHARE_EVE).into()).unwrap())
         } else {
             None
         };

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use entropy_programs_runtime::Runtime;
 use entropy_protocol::{
     execute_protocol::{execute_dkg, Channels},
-    KeyParams, Listener, SessionId, ValidatorInfo,
+    KeyParams, Listener, PartyId, SessionId, ValidatorInfo,
 };
 use entropy_shared::{HashingAlgorithm, SETUP_TIMEOUT_SECONDS};
 
@@ -28,7 +28,7 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use sha3::{Digest as Sha3Digest, Keccak256, Sha3_256};
 use sp_core::{sr25519, Pair};
 use subxt::{backend::legacy::LegacyRpcMethods, tx::PairSigner, utils::AccountId32, OnlineClient};
-use synedrion::KeyShare;
+use synedrion::{AuxInfo, KeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 
@@ -46,7 +46,7 @@ pub async fn do_dkg(
     state: &ListenerState,
     sig_request_account: AccountId32,
     block_number: u32,
-) -> Result<KeyShare<KeyParams>, UserErr> {
+) -> Result<(KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>), UserErr> {
     let session_id = SessionId::Dkg { user: sig_request_account.clone(), block_number };
     let account_id = AccountId32(signer.signer().public().0);
     let mut converted_validator_info = vec![];

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use entropy_programs_runtime::Runtime;
 use entropy_protocol::{
     execute_protocol::{execute_dkg, Channels},
-    KeyParams, Listener, PartyId, SessionId, ValidatorInfo,
+    KeyParams, KeyShareWithAuxInfo, Listener, PartyId, SessionId, ValidatorInfo,
 };
 use entropy_shared::{HashingAlgorithm, SETUP_TIMEOUT_SECONDS};
 
@@ -46,7 +46,7 @@ pub async fn do_dkg(
     state: &ListenerState,
     sig_request_account: AccountId32,
     block_number: u32,
-) -> Result<(ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>), UserErr> {
+) -> Result<KeyShareWithAuxInfo, UserErr> {
     let session_id = SessionId::Dkg { user: sig_request_account.clone(), block_number };
     let account_id = AccountId32(signer.signer().public().0);
     let mut converted_validator_info = vec![];

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -28,7 +28,7 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use sha3::{Digest as Sha3Digest, Keccak256, Sha3_256};
 use sp_core::{sr25519, Pair};
 use subxt::{backend::legacy::LegacyRpcMethods, tx::PairSigner, utils::AccountId32, OnlineClient};
-use synedrion::{AuxInfo, KeyShare};
+use synedrion::{AuxInfo, ThresholdKeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 
@@ -46,7 +46,7 @@ pub async fn do_dkg(
     state: &ListenerState,
     sig_request_account: AccountId32,
     block_number: u32,
-) -> Result<(KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>), UserErr> {
+) -> Result<(ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>), UserErr> {
     let session_id = SessionId::Dkg { user: sig_request_account.clone(), block_number };
     let account_id = AccountId32(signer.signer().public().0);
     let mut converted_validator_info = vec![];

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use entropy_programs_runtime::Runtime;
 use entropy_protocol::{
     execute_protocol::{execute_dkg, Channels},
-    KeyParams, KeyShareWithAuxInfo, Listener, PartyId, SessionId, ValidatorInfo,
+    KeyShareWithAuxInfo, Listener, SessionId, ValidatorInfo,
 };
 use entropy_shared::{HashingAlgorithm, SETUP_TIMEOUT_SECONDS};
 
@@ -28,7 +28,6 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use sha3::{Digest as Sha3Digest, Keccak256, Sha3_256};
 use sp_core::{sr25519, Pair};
 use subxt::{backend::legacy::LegacyRpcMethods, tx::PairSigner, utils::AccountId32, OnlineClient};
-use synedrion::{AuxInfo, ThresholdKeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -27,7 +27,7 @@ use axum::{
 use blake2::{Blake2s256, Digest};
 use entropy_protocol::{
     execute_protocol::{execute_proactive_refresh, Channels},
-    KeyParams, Listener, SessionId, ValidatorInfo,
+    KeyParams, Listener, PartyId, SessionId, ValidatorInfo,
 };
 use parity_scale_codec::Encode;
 
@@ -45,7 +45,7 @@ use subxt::{
     utils::{AccountId32 as SubxtAccountId32, Static},
     OnlineClient,
 };
-use synedrion::KeyShare;
+use synedrion::{AuxInfo, KeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 
@@ -96,7 +96,10 @@ pub async fn proactive_refresh(
         let exists_result = app_state.kv_store.kv().exists(&key).await?;
         if exists_result {
             let old_key_share = app_state.kv_store.kv().get(&key).await?;
-            let deserialized_old_key: KeyShare<KeyParams> = deserialize(&old_key_share)
+            let (deserialized_old_key, _aux_info): (
+                KeyShare<KeyParams, PartyId>,
+                AuxInfo<KeyParams, PartyId>,
+            ) = deserialize(&old_key_share)
                 .ok_or_else(|| ProtocolErr::Deserialization("Failed to load KeyShare".into()))?;
 
             let new_key_share = do_proactive_refresh(
@@ -148,9 +151,9 @@ pub async fn do_proactive_refresh(
     x25519_secret_key: &StaticSecret,
     state: &ListenerState,
     verifying_key: Vec<u8>,
-    old_key: KeyShare<KeyParams>,
+    old_key: KeyShare<KeyParams, PartyId>,
     block_number: u32,
-) -> Result<KeyShare<KeyParams>, ProtocolErr> {
+) -> Result<KeyShare<KeyParams, PartyId>, ProtocolErr> {
     tracing::debug!("Preparing to perform proactive refresh");
     tracing::debug!("Signing with {:?}", &signer.signer().public());
 

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -45,7 +45,7 @@ use subxt::{
     utils::{AccountId32 as SubxtAccountId32, Static},
     OnlineClient,
 };
-use synedrion::{AuxInfo, KeyShare};
+use synedrion::{AuxInfo, ThresholdKeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 
@@ -97,7 +97,7 @@ pub async fn proactive_refresh(
         if exists_result {
             let old_key_share = app_state.kv_store.kv().get(&key).await?;
             let (deserialized_old_key, _aux_info): (
-                KeyShare<KeyParams, PartyId>,
+                ThresholdKeyShare<KeyParams, PartyId>,
                 AuxInfo<KeyParams, PartyId>,
             ) = deserialize(&old_key_share)
                 .ok_or_else(|| ProtocolErr::Deserialization("Failed to load KeyShare".into()))?;
@@ -151,9 +151,9 @@ pub async fn do_proactive_refresh(
     x25519_secret_key: &StaticSecret,
     state: &ListenerState,
     verifying_key: Vec<u8>,
-    old_key: KeyShare<KeyParams, PartyId>,
+    old_key: ThresholdKeyShare<KeyParams, PartyId>,
     block_number: u32,
-) -> Result<KeyShare<KeyParams, PartyId>, ProtocolErr> {
+) -> Result<ThresholdKeyShare<KeyParams, PartyId>, ProtocolErr> {
     tracing::debug!("Preparing to perform proactive refresh");
     tracing::debug!("Signing with {:?}", &signer.signer().public());
 

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use entropy_protocol::{KeyParams, PartyId};
-use synedrion::{AuxInfo, KeyShare};
+use synedrion::{AuxInfo, ThresholdKeyShare};
 
 use crate::sign_init::SignInit;
 
@@ -24,14 +24,14 @@ pub struct SignContext {
     /// Party context from block proposer
     pub sign_init: SignInit,
     /// Signing key share
-    pub key_share: KeyShare<KeyParams, PartyId>,
+    pub key_share: ThresholdKeyShare<KeyParams, PartyId>,
     pub aux_info: AuxInfo<KeyParams, PartyId>,
 }
 
 impl SignContext {
     pub fn new(
         sign_init: SignInit,
-        key_share: KeyShare<KeyParams, PartyId>,
+        key_share: ThresholdKeyShare<KeyParams, PartyId>,
         aux_info: AuxInfo<KeyParams, PartyId>,
     ) -> Self {
         Self { sign_init, key_share, aux_info }

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
@@ -13,26 +13,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use entropy_protocol::KeyParams;
-use synedrion::{sessions::PrehashedMessage, KeyShare};
+use entropy_protocol::{KeyParams, PartyId};
+use synedrion::{AuxInfo, KeyShare};
 
 use crate::sign_init::SignInit;
 
 /// Context for Signing Protocol execution.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SignContext {
     /// Party context from block proposer
     pub sign_init: SignInit,
     /// Signing key share
-    pub key_share: KeyShare<KeyParams>,
+    pub key_share: KeyShare<KeyParams, PartyId>,
+    pub aux_info: AuxInfo<KeyParams, PartyId>,
 }
 
 impl SignContext {
-    pub fn new(sign_init: SignInit, key_share: KeyShare<KeyParams>) -> Self {
-        Self { sign_init, key_share }
+    pub fn new(
+        sign_init: SignInit,
+        key_share: KeyShare<KeyParams, PartyId>,
+        aux_info: AuxInfo<KeyParams, PartyId>,
+    ) -> Self {
+        Self { sign_init, key_share, aux_info }
     }
 
-    pub fn msg_to_sign(&self) -> &PrehashedMessage {
-        &self.sign_init.signing_session_info.message_hash
-    }
+    // pub fn msg_to_sign(&self) -> &PrehashedMessage {
+    //     &self.sign_init.signing_session_info.message_hash
+    // }
 }

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/context.rs
@@ -36,8 +36,4 @@ impl SignContext {
     ) -> Self {
         Self { sign_init, key_share, aux_info }
     }
-
-    // pub fn msg_to_sign(&self) -> &PrehashedMessage {
-    //     &self.sign_init.signing_session_info.message_hash
-    // }
 }

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
@@ -18,13 +18,14 @@
 mod context;
 
 use entropy_kvdb::kv_manager::KvManager;
+use entropy_protocol::PartyId;
 pub use entropy_protocol::{
     execute_protocol::{execute_signing_protocol, Channels},
     KeyParams, ProtocolMessage, RecoverableSignature, SessionId,
 };
 use sp_core::sr25519;
 use subxt::utils::AccountId32;
-use synedrion::KeyShare;
+use synedrion::{AuxInfo, KeyShare};
 
 pub use self::context::SignContext;
 use crate::{
@@ -62,15 +63,15 @@ impl<'a> ThresholdSigningService<'a> {
     )]
     pub async fn get_sign_context(&self, sign_init: SignInit) -> Result<SignContext, ProtocolErr> {
         tracing::debug!("Getting signing context");
-        let key_share_vec = self
+        let key_share_and_aux_info_vec = self
             .kv_manager
             .kv()
             .get(&hex::encode(sign_init.signing_session_info.signature_verifying_key.clone()))
             .await?;
-        let key_share: KeyShare<KeyParams> =
-            entropy_kvdb::kv_manager::helpers::deserialize(&key_share_vec)
+        let (key_share, aux_info): (KeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>) =
+            entropy_kvdb::kv_manager::helpers::deserialize(&key_share_and_aux_info_vec)
                 .ok_or_else(|| ProtocolErr::Deserialization("Failed to load KeyShare".into()))?;
-        Ok(SignContext::new(sign_init, key_share))
+        Ok(SignContext::new(sign_init, key_share, aux_info))
     }
 
     /// handle signing protocol execution.
@@ -81,7 +82,8 @@ impl<'a> ThresholdSigningService<'a> {
     pub async fn execute_sign(
         &self,
         session_id: SessionId,
-        key_share: &KeyShare<KeyParams>,
+        key_share: &KeyShare<KeyParams, PartyId>,
+        aux_info: &AuxInfo<KeyParams, PartyId>,
         channels: Channels,
         threshold_signer: &sr25519::Pair,
         threshold_accounts: Vec<AccountId32>,
@@ -98,6 +100,7 @@ impl<'a> ThresholdSigningService<'a> {
             session_id,
             channels,
             key_share,
+            aux_info,
             &message_hash,
             threshold_signer,
             threshold_accounts,

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
@@ -101,7 +101,7 @@ impl<'a> ThresholdSigningService<'a> {
         let rsig = execute_signing_protocol(
             session_id,
             channels,
-            &key_share,
+            key_share,
             aux_info,
             &message_hash,
             threshold_signer,

--- a/crates/threshold-signature-server/src/signing_client/tests.rs
+++ b/crates/threshold-signature-server/src/signing_client/tests.rs
@@ -43,8 +43,12 @@ async fn test_proactive_refresh() {
     clean_tests();
     let _cxt = test_node_process_testing_state(false).await;
 
-    let (validator_ips, _validator_ids, users_keyshare_option) =
-        spawn_testing_validators(Some(EVE_VERIFYING_KEY.to_vec()), true, false).await;
+    let (validator_ips, _validator_ids, users_keyshare_option) = spawn_testing_validators(
+        Some(EVE_VERIFYING_KEY.to_vec()),
+        Some(AccountKeyring::Dave.pair()),
+        false,
+    )
+    .await;
 
     let client = reqwest::Client::new();
     let converted_key_share = serialize(&users_keyshare_option.unwrap()).unwrap();

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -51,7 +51,7 @@ use subxt::{
     utils::{AccountId32 as SubxtAccountId32, MultiAddress},
     Config, OnlineClient,
 };
-use synedrion::KeyShare;
+use synedrion::ThresholdKeyShare;
 use tracing::instrument;
 use x25519_dalek::StaticSecret;
 use zeroize::Zeroize;
@@ -345,7 +345,7 @@ pub async fn receive_key(
     check_forbidden_key(&user_registration_info.key).map_err(|_| UserErr::ForbiddenKey)?;
 
     // Check this is a well-formed keyshare
-    let _: KeyShare<KeyParams, PartyId> =
+    let _: ThresholdKeyShare<KeyParams, PartyId> =
         entropy_kvdb::kv_manager::helpers::deserialize(&user_registration_info.value)
             .ok_or_else(|| UserErr::InputValidation("Not a valid keyshare"))?;
 

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -25,7 +25,7 @@ use entropy_kvdb::{
 use entropy_programs_runtime::{Runtime, SignatureRequest};
 use entropy_protocol::{
     protocol_transport::{noise::noise_handshake_initiator, SubscribeMessage, WsConnection},
-    KeyParams, PartyId, SessionId, SigningSessionInfo, ValidatorInfo,
+    KeyParams, KeyShareWithAuxInfo, PartyId, SessionId, SigningSessionInfo, ValidatorInfo,
 };
 use entropy_shared::{
     HashingAlgorithm, OcwMessageDkg, DAVE_VERIFYING_KEY, DEFAULT_VERIFYING_KEY,
@@ -603,7 +603,7 @@ async fn test_store_share() {
         .await
         .unwrap();
     // check to make sure keyshare is correct
-    let key_share: Option<(ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)> =
+    let key_share: Option<KeyShareWithAuxInfo> =
         entropy_kvdb::kv_manager::helpers::deserialize(&response_key.bytes().await.unwrap());
     assert_eq!(key_share.is_some(), true);
 

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -81,7 +81,7 @@ use subxt::{
 };
 use synedrion::{
     k256::ecdsa::{RecoveryId, Signature as k256Signature, VerifyingKey},
-    KeyShare,
+    ThresholdKeyShare,
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt},
@@ -601,7 +601,7 @@ async fn test_store_share() {
         .await
         .unwrap();
     // check to make sure keyshare is correct
-    let key_share: Option<KeyShare<KeyParams, PartyId>> =
+    let key_share: Option<ThresholdKeyShare<KeyParams, PartyId>> =
         entropy_kvdb::kv_manager::helpers::deserialize(&response_key.bytes().await.unwrap());
     assert_eq!(key_share.is_some(), true);
 
@@ -732,7 +732,7 @@ async fn test_check_hash_pointer_out_of_bounds() {
 pub async fn verify_signature(
     test_user_res: Vec<Result<reqwest::Response, reqwest::Error>>,
     message_should_succeed_hash: [u8; 32],
-    keyshare_option: Option<KeyShare<KeyParams, PartyId>>,
+    keyshare_option: Option<ThresholdKeyShare<KeyParams, PartyId>>,
 ) {
     let mut i = 0;
     for res in test_user_res {

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -601,7 +601,7 @@ async fn test_store_share() {
         .await
         .unwrap();
     // check to make sure keyshare is correct
-    let key_share: Option<KeyShare<KeyParams>> =
+    let key_share: Option<KeyShare<KeyParams, PartyId>> =
         entropy_kvdb::kv_manager::helpers::deserialize(&response_key.bytes().await.unwrap());
     assert_eq!(key_share.is_some(), true);
 
@@ -732,7 +732,7 @@ async fn test_check_hash_pointer_out_of_bounds() {
 pub async fn verify_signature(
     test_user_res: Vec<Result<reqwest::Response, reqwest::Error>>,
     message_should_succeed_hash: [u8; 32],
-    keyshare_option: Option<KeyShare<KeyParams>>,
+    keyshare_option: Option<KeyShare<KeyParams, PartyId>>,
 ) {
     let mut i = 0;
     for res in test_user_res {

--- a/node/cli/src/chain_spec/integration_tests.rs
+++ b/node/cli/src/chain_spec/integration_tests.rs
@@ -199,7 +199,7 @@ pub fn integration_tests_genesis_config(
                         x25519_public_key: crate::chain_spec::tss_x25519_public_key::BOB,
                     },
                 ],
-                vec![EVE_VERIFYING_KEY.to_vec(), DAVE_VERIFYING_KEY.to_vec()],
+                vec![EVE_VERIFYING_KEY.to_vec()],
             ),
         },
         "elections": ElectionsConfig {

--- a/node/cli/src/chain_spec/integration_tests.rs
+++ b/node/cli/src/chain_spec/integration_tests.rs
@@ -199,7 +199,7 @@ pub fn integration_tests_genesis_config(
                         x25519_public_key: crate::chain_spec::tss_x25519_public_key::BOB,
                     },
                 ],
-                vec![EVE_VERIFYING_KEY.to_vec()],
+                vec![EVE_VERIFYING_KEY.to_vec(), DAVE_VERIFYING_KEY.to_vec()],
             ),
         },
         "elections": ElectionsConfig {


### PR DESCRIPTION
This updates synedrion with the latest changes - moving towards adding threshold signing but not actually functionally changing things for now.

Stored keyshares in the kvdb are now no longer `KeyShare<KeyParams>` but `(ThresholdKeyShare<KeyParams, PartyId>, AuxInfo<KeyParams, PartyId>)`. `entropy-protcol` has a type alias for this, `entropy_protocol::KeyShareWithAuxData`.  But we could also make a struct with some nice helpers.

The proactive refresh protocol is still called proactive refresh in our code, but under the hood it is now a key reshare with the same participants as before. This is to distinguish it from a key reshare which changes participants, which we may want to add at some point.