### PR TITLE
Test CLI store program command no longer defaults to the barebones program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ At the moment this project **does not** adhere to
 ### Added
 - Add a way to change program modification account  ([#843](https://github.com/entropyxyz/entropy-core/pull/843))
 
+### Changed
+
+- Test-cli store program command no longer defaults to the barebones program ([#860](https://github.com/entropyxyz/entropy-core/pull/860))
+
 ## [0.1.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.0.12...release/v0.1.0) - 2024-05-20
 
 This is the first publicly available version of Entropy 🥳

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,7 +2654,6 @@ dependencies = [
  "clap",
  "colored",
  "entropy-client",
- "entropy-testing-utils",
  "hex",
  "sp-core 31.0.0",
  "sp-runtime 32.0.0",

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -9,15 +9,14 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-entropy-testing-utils={ version="0.1.0", path="../testing-utils" }
-entropy-client       ={ version="0.1.0", path="../client" }
-clap                 ={ version="4.4.6", features=["derive"] }
-colored              ="2.0.4"
-subxt                ="0.35.3"
-sp-core              ="31.0.0"
-anyhow               ="1.0.86"
-tokio                ={ version="1.16", features=["macros", "rt-multi-thread", "io-util", "process"] }
-hex                  ="0.4.3"
-bincode              ="1.3.3"
-x25519-dalek         ="2.0.1"
-sp-runtime           ={ version="32.0.0", default-features=false }
+entropy-client={ version="0.1.0", path="../client" }
+clap          ={ version="4.4.6", features=["derive"] }
+colored       ="2.0.4"
+subxt         ="0.35.3"
+sp-core       ="31.0.0"
+anyhow        ="1.0.86"
+tokio         ={ version="1.16", features=["macros", "rt-multi-thread", "io-util", "process"] }
+hex           ="0.4.3"
+bincode       ="1.3.3"
+x25519-dalek  ="2.0.1"
+sp-runtime    ={ version="32.0.0", default-features=false }

--- a/crates/test-cli/src/main.rs
+++ b/crates/test-cli/src/main.rs
@@ -36,7 +36,6 @@ use entropy_client::{
         update_programs, KeyParams, KeyShare, KeyVisibility, VERIFYING_KEY_LENGTH,
     },
 };
-use entropy_testing_utils::constants::TEST_PROGRAM_WASM_BYTECODE;
 use sp_core::{sr25519, DeriveJunction, Hasher, Pair};
 use sp_runtime::traits::BlakeTwo256;
 use subxt::{
@@ -133,7 +132,7 @@ enum CliCommand {
         /// Optionally may be preceeded with "//", eg: "//Alice"
         mnemonic: String,
         /// The path to a .wasm file containing the program (defaults to a test program)
-        program_file: Option<PathBuf>,
+        program_file: PathBuf,
         /// The path to a file containing the program config interface (defaults to empty)
         config_interface_file: Option<PathBuf>,
         /// The path to a file containing the program aux interface (defaults to empty)
@@ -280,10 +279,7 @@ async fn run_command() -> anyhow::Result<String> {
             let keypair = <sr25519::Pair as Pair>::from_string(&mnemonic, None)?;
             println!("Storing program using account: {}", keypair.public());
 
-            let program = match program_file {
-                Some(file_name) => fs::read(file_name)?,
-                None => TEST_PROGRAM_WASM_BYTECODE.to_owned(),
-            };
+            let program = fs::read(program_file)?;
 
             let config_interface = match config_interface_file {
                 Some(file_name) => fs::read(file_name)?,


### PR DESCRIPTION
The store program command in the test-cli now takes a program file as a mandatory positional argument. Before it was optional and fell back to the barebones program.

Removing this means we can remove the dependency `entropy-testing-utils` which in turn has `entropy-tss` as a dependency. This means we have quite a few less dependencies.

We do still need openssl so this doesn't fix https://github.com/entropyxyz/entropy-core/issues/855 - but it might reduce the need for some other packages.

See related discussion: https://github.com/entropyxyz/entropy-core/pull/856#issuecomment-2135631441