### PR TITLE
t of n key generation and signing at the `entropy-protocol` level 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
+ "serial_test",
  "snow",
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
  "js-sys",
+ "num",
  "num_cpus",
  "rand_core 0.6.4",
  "schnorrkel",

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -31,6 +31,7 @@ zeroize            ="1.7.0"
 hpke-rs            ="0.2.0"
 hpke-rs-crypto     ="0.2.0"
 hpke-rs-rust-crypto="0.2.0"
+num                ="0.4.3"
 
 # Used only with the `server` feature to implement the WsConnection trait
 axum             ={ version="0.7.5", features=["ws"], optional=true }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -47,10 +47,10 @@ base64              ={ version="0.22.1", optional=true }
 schnorrkel          ={ version="0.11.4", default-features=false, features=["std"], optional=true }
 
 [dev-dependencies]
-serial_test ="3.1.1"
-sp-keyring="34.0.0"
-anyhow    ="1.0.86"
-num_cpus  ="1.16.0"
+serial_test="3.1.1"
+sp-keyring ="34.0.0"
+anyhow     ="1.0.86"
+num_cpus   ="1.16.0"
 
 [features]
 default=["server"]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -47,6 +47,7 @@ base64              ={ version="0.22.1", optional=true }
 schnorrkel          ={ version="0.11.4", default-features=false, features=["std"], optional=true }
 
 [dev-dependencies]
+serial_test ="3.1.1"
 sp-keyring="34.0.0"
 anyhow    ="1.0.86"
 num_cpus  ="1.16.0"

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -63,6 +63,7 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
 
 impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
+        println!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -124,6 +124,8 @@ pub enum ProtocolExecutionErr {
     IndexOutOfBounds,
     #[error("Received bad validating key {0}")]
     BadVerifyingKey(String),
+    #[error("Expected verifying key but got a protocol message")]
+    UnexpectedMessage,
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -121,6 +121,10 @@ pub enum ProtocolExecutionErr {
     BigIntConversion(#[from] num::bigint::TryFromBigIntError<num::bigint::BigUint>),
     #[error("Index out of bounds when selecting DKG committee")]
     IndexOutOfBounds,
+    #[error("Received bad validating key - cannot convert to EncodedPoint")]
+    EncodedPoint,
+    #[error("Received bad validating key: {0}")]
+    Ecdsa(#[from] synedrion::ecdsa::Error),
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -53,7 +53,7 @@ impl<Res: MappedResult<PartyId>> From<sessions::Error<Res, PartyId>> for Generic
 
 impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<InteractiveSigningResult<KeyParams>>) -> Self {
-        println!("{:?}", err);
+        tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::SigningProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
@@ -64,7 +64,7 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
 
 impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
-        println!("{:?}", err);
+        tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
@@ -75,7 +75,7 @@ impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionE
 
 impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyResharingResult<KeyParams>>) -> Self {
-        println!("{:?}", err);
+        tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyReshareProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
@@ -86,6 +86,7 @@ impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecu
 
 impl From<GenericProtocolError<AuxGenResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<AuxGenResult<KeyParams>>) -> Self {
+        tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::AuxGenProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -122,10 +122,8 @@ pub enum ProtocolExecutionErr {
     BigIntConversion(#[from] num::bigint::TryFromBigIntError<num::bigint::BigUint>),
     #[error("Index out of bounds when selecting DKG committee")]
     IndexOutOfBounds,
-    #[error("Received bad validating key - cannot convert to EncodedPoint")]
-    EncodedPoint,
-    #[error("Received bad validating key: {0}")]
-    Ecdsa(#[from] synedrion::ecdsa::Error),
+    #[error("Received bad validating key {0}")]
+    BadVerifyingKey(String),
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -53,6 +53,7 @@ impl<Res: MappedResult<PartyId>> From<sessions::Error<Res, PartyId>> for Generic
 
 impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<InteractiveSigningResult<KeyParams>>) -> Self {
+        println!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::SigningProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
@@ -63,6 +64,7 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
 
 impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
+        println!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
@@ -73,6 +75,7 @@ impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionE
 
 impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyResharingResult<KeyParams>>) -> Self {
+        println!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyReshareProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -14,7 +14,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use synedrion::{
-    sessions, InteractiveSigningResult, KeyGenResult, KeyResharingResult, MappedResult,
+    sessions, AuxGenResult, InteractiveSigningResult, KeyInitResult, KeyResharingResult,
+    MappedResult,
 };
 use thiserror::Error;
 
@@ -60,10 +61,10 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
     }
 }
 
-impl From<GenericProtocolError<KeyGenResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<KeyGenResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
         match err {
-            GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyGenProtocolError(err),
+            GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
         }
@@ -80,6 +81,16 @@ impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecu
     }
 }
 
+impl From<GenericProtocolError<AuxGenResult<KeyParams>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<AuxGenResult<KeyParams>>) -> Self {
+        match err {
+            GenericProtocolError::Joined(err) => ProtocolExecutionErr::AuxGenProtocolError(err),
+            GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
+            GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
+        }
+    }
+}
+
 /// An error during or while setting up a protocol session
 #[derive(Debug, Error)]
 pub enum ProtocolExecutionErr {
@@ -89,10 +100,12 @@ pub enum ProtocolExecutionErr {
     SessionCreation(sessions::LocalError),
     #[error("Synedrion signing session error")]
     SigningProtocolError(Box<sessions::Error<InteractiveSigningResult<KeyParams>, PartyId>>),
-    #[error("Synedrion keygen session error")]
-    KeyGenProtocolError(Box<sessions::Error<KeyGenResult<KeyParams>, PartyId>>),
+    #[error("Synedrion key init session error")]
+    KeyInitProtocolError(Box<sessions::Error<KeyInitResult<KeyParams>, PartyId>>),
     #[error("Synedrion key reshare session error")]
     KeyReshareProtocolError(Box<sessions::Error<KeyResharingResult<KeyParams>, PartyId>>),
+    #[error("Synedrion aux generation session error")]
+    AuxGenProtocolError(Box<sessions::Error<AuxGenResult<KeyParams>, PartyId>>),
     #[error("Broadcast error: {0}")]
     Broadcast(#[from] Box<tokio::sync::broadcast::error::SendError<ProtocolMessage>>),
     #[error("Bad keyshare error {0}")]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -117,6 +117,10 @@ pub enum ProtocolExecutionErr {
     Bincode(#[from] bincode::Error),
     #[error("No output from reshare protocol")]
     NoOutputFromReshareProtocol,
+    #[error("BigInt conversion: {0}")]
+    BigIntConversion(#[from] num::bigint::TryFromBigIntError<num::bigint::BigUint>),
+    #[error("Index out of bounds when selecting DKG committee")]
+    IndexOutOfBounds,
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -63,7 +63,6 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
 
 impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
     fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
-        println!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -182,7 +182,7 @@ pub async fn execute_signing_protocol(
 /// Execute dkg.
 #[tracing::instrument(
     skip_all,
-    fields(threshold_accounts, my_idx),
+    fields(threshold_accounts, my_idx, threshold),
     level = tracing::Level::DEBUG
 )]
 pub async fn execute_dkg(

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -202,9 +202,6 @@ pub async fn execute_dkg(
     // Setup channels for the next session
     let chans = Channels(broadcaster.clone(), rx);
 
-    let old_threshold = init_keyshare.to_threshold_key_share().threshold();
-    println!("Old threshold {}", old_threshold);
-
     // If were a member of t, send verifying_key to others
     // Otherwise receive verifying_key from another
     let verifying_key = init_keyshare.verifying_key();

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -15,22 +15,25 @@
 
 //! A wrapper for the threshold signing library to handle sending and receiving messages.
 
+use num::bigint::BigUint;
 use rand_core::{CryptoRngCore, OsRng};
 use sp_core::{sr25519, Pair};
 use subxt::utils::AccountId32;
 use synedrion::{
+    ecdsa::VerifyingKey,
+    k256::EncodedPoint,
     make_aux_gen_session, make_interactive_signing_session, make_key_init_session,
     make_key_resharing_session,
     sessions::{FinalizeOutcome, Session},
     signature::{self, hazmat::RandomizedPrehashSigner},
-    AuxInfo, KeyResharingInputs, NewHolder, OldHolder, PrehashedMessage, RecoverableSignature,
-    ThresholdKeyShare,
+    AuxInfo, KeyResharingInputs, KeyShare, NewHolder, OldHolder, PrehashedMessage,
+    RecoverableSignature, ThresholdKeyShare,
 };
 use tokio::sync::mpsc;
 
 use crate::{
     errors::{GenericProtocolError, ProtocolExecutionErr},
-    protocol_message::ProtocolMessage,
+    protocol_message::{MessageOrVerifyingKey, ProtocolMessage},
     protocol_transport::Broadcaster,
     KeyParams, KeyShareWithAuxInfo, PartyId, SessionId,
 };
@@ -98,13 +101,25 @@ async fn execute_protocol_generic<Res: synedrion::MappedResult<PartyId>>(
         }
 
         while !session.can_finalize(&accum)? {
-            let message = rx.recv().await.ok_or_else(|| {
-                GenericProtocolError::IncomingStream(format!("{:?}", session.current_round()))
-            })?;
+            let (from, payload) = loop {
+                let message = rx.recv().await.ok_or_else(|| {
+                    GenericProtocolError::<Res>::IncomingStream(format!(
+                        "{:?}",
+                        session.current_round()
+                    ))
+                })?;
+
+                if let MessageOrVerifyingKey::CombinedMessage(payload) =
+                    message.message_or_verifying_key
+                {
+                    break (message.from, payload);
+                } else {
+                    tracing::warn!("Got verifying key during protocol - ignoring");
+                }
+            };
 
             // Perform quick checks before proceeding with the verification.
-            let preprocessed =
-                session.preprocess_message(&mut accum, &message.from, message.payload)?;
+            let preprocessed = session.preprocess_message(&mut accum, &from, payload)?;
 
             if let Some(preprocessed) = preprocessed {
                 // TODO (#641): this may happen in a spawned task.
@@ -137,7 +152,7 @@ async fn execute_protocol_generic<Res: synedrion::MappedResult<PartyId>>(
 pub async fn execute_signing_protocol(
     session_id: SessionId,
     chans: Channels,
-    key_share: &ThresholdKeyShare<KeyParams, PartyId>,
+    key_share: &KeyShare<KeyParams, PartyId>,
     aux_info: &AuxInfo<KeyParams, PartyId>,
     prehashed_message: &PrehashedMessage,
     threshold_pair: &sr25519::Pair,
@@ -157,7 +172,7 @@ pub async fn execute_signing_protocol(
         &shared_randomness,
         pair,
         &party_ids,
-        &key_share.to_key_share(&party_ids),
+        &key_share,
         aux_info,
         prehashed_message,
     )
@@ -186,33 +201,75 @@ pub async fn execute_dkg(
 
     let pair = PairWrapper(threshold_pair.clone());
 
+    let my_party_id = PartyId::new(AccountId32(threshold_pair.public().0));
+
     let shared_randomness = session_id.blake2()?;
+    let (key_init_parties, includes_me) =
+        get_key_init_parties(&my_party_id, threshold, &party_ids, &shared_randomness)?;
 
-    // First run the key init session.
-    let session = make_key_init_session(
-        &mut OsRng,
-        &shared_randomness,
-        pair.clone(),
-        &party_ids[..threshold],
-    )
-    .map_err(ProtocolExecutionErr::SessionCreation)?;
+    let (verifying_key, old_holder, chans) = if includes_me {
+        // First run the key init session.
+        let session =
+            make_key_init_session(&mut OsRng, &shared_randomness, pair.clone(), &key_init_parties)
+                .map_err(ProtocolExecutionErr::SessionCreation)?;
 
-    let (init_keyshare, rx) = execute_protocol_generic(chans, session).await?;
+        let (init_keyshare, rx) = execute_protocol_generic(chans, session).await?;
 
-    // Setup channels for the next session
-    let chans = Channels(broadcaster.clone(), rx);
+        // Setup channels for the next session
+        let chans = Channels(broadcaster.clone(), rx);
 
-    // If were a member of t, send verifying_key to others
-    // Otherwise receive verifying_key from another
-    let verifying_key = init_keyshare.verifying_key();
+        // Send verifying key
+        let verifying_key = init_keyshare.verifying_key();
+        for party_id in party_ids.iter() {
+            if !key_init_parties.contains(party_id) {
+                let message = ProtocolMessage {
+                    from: my_party_id.clone(),
+                    to: party_id.clone(),
+                    message_or_verifying_key: MessageOrVerifyingKey::VerifyingKey(
+                        verifying_key.to_encoded_point(true).as_bytes().to_vec(),
+                    ),
+                };
+                chans.0.send(message)?;
+            }
+        }
+        (
+            verifying_key,
+            Some(OldHolder { key_share: init_keyshare.to_threshold_key_share() }),
+            chans,
+        )
+    } else {
+        // Wait to receive verifying_key
+        let mut rx = chans.1;
+        let message = rx
+            .recv()
+            .await
+            // .ok_or_else(|| {
+            //     GenericProtocolError::<KeyShareWithAuxInfo>::IncomingStream(
+            //         "Waiting for validating key".to_string(),
+            //     )
+            // })
+            .unwrap();
+        if let MessageOrVerifyingKey::VerifyingKey(verifing_key_encoded) =
+            message.message_or_verifying_key
+        {
+            let point = EncodedPoint::from_bytes(verifing_key_encoded).unwrap();
+            let verifying_key = VerifyingKey::from_encoded_point(&point).unwrap();
+
+            // Setup channels for the next session
+            let chans = Channels(broadcaster.clone(), rx);
+            (verifying_key, None, chans)
+        } else {
+            panic!("Unexpected message");
+        }
+    };
 
     // Now reshare to all n parties
     let inputs = KeyResharingInputs {
-        old_holder: Some(OldHolder { key_share: init_keyshare.to_threshold_key_share() }),
+        old_holder,
         new_holder: Some(NewHolder {
             verifying_key,
-            old_threshold: party_ids.len(),
-            old_holders: party_ids.clone(),
+            old_threshold: threshold,
+            old_holders: key_init_parties.clone(),
         }),
         new_holders: party_ids.clone(),
         new_threshold: threshold,
@@ -280,4 +337,29 @@ pub async fn execute_proactive_refresh(
     let new_key_share = execute_protocol_generic(chans, session).await?.0;
 
     new_key_share.ok_or(ProtocolExecutionErr::NoOutputFromReshareProtocol)
+}
+
+/// Psuedo-randomly select a subset of the parties of size t
+fn get_key_init_parties(
+    my_party_id: &PartyId,
+    threshold: usize,
+    validators: &Vec<PartyId>,
+    shared_randomness: &[u8],
+) -> Result<(Vec<PartyId>, bool), ProtocolExecutionErr> {
+    let mut parties = vec![];
+    let mut includes_self = false;
+    let number = BigUint::from_bytes_be(shared_randomness);
+    let start_index_big = &number % validators.len();
+    let start_index: usize = start_index_big.try_into().unwrap(); //.to_usize().unwrap(); //.ok_or(SubgroupGetError::Usize("Usize error"))?;
+
+    for i in start_index..start_index + threshold {
+        let index = i % validators.len();
+        let member = validators.get(index).unwrap();
+        if member == my_party_id {
+            includes_self = true;
+        }
+        parties.push(validators.get(index).unwrap().clone());
+    }
+
+    Ok((parties, includes_self))
 }

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -182,7 +182,7 @@ pub async fn execute_signing_protocol(
 /// Execute dkg.
 #[tracing::instrument(
     skip_all,
-    fields(threshold_accounts, my_idx, threshold),
+    fields(threshold_accounts, session_id, threshold),
     level = tracing::Level::DEBUG
 )]
 pub async fn execute_dkg(
@@ -335,7 +335,7 @@ pub async fn execute_proactive_refresh(
     new_key_share.ok_or(ProtocolExecutionErr::NoOutputFromReshareProtocol)
 }
 
-/// Psuedo-randomly select a subset of the parties of size t
+/// Psuedo-randomly select a subset of the parties of size `threshold`
 fn get_key_init_parties(
     my_party_id: &PartyId,
     threshold: usize,

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -112,7 +112,7 @@ async fn execute_protocol_generic<Res: synedrion::MappedResult<PartyId>>(
                 if let MessageOrVerifyingKey::CombinedMessage(payload) =
                     message.message_or_verifying_key
                 {
-                    break (message.from, payload);
+                    break (message.from, *payload);
                 } else {
                     tracing::warn!("Got verifying key during protocol - ignoring");
                 }
@@ -172,7 +172,7 @@ pub async fn execute_signing_protocol(
         &shared_randomness,
         pair,
         &party_ids,
-        &key_share,
+        key_share,
         aux_info,
         prehashed_message,
     )
@@ -343,7 +343,7 @@ pub async fn execute_proactive_refresh(
 fn get_key_init_parties(
     my_party_id: &PartyId,
     threshold: usize,
-    validators: &Vec<PartyId>,
+    validators: &[PartyId],
     shared_randomness: &[u8],
 ) -> Result<(Vec<PartyId>, bool), ProtocolExecutionErr> {
     let mut parties = vec![];

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -243,10 +243,10 @@ pub async fn execute_dkg(
         let message = rx.recv().await.ok_or_else(|| {
             ProtocolExecutionErr::IncomingStream("Waiting for validating key".to_string())
         })?;
-        if let MessageOrVerifyingKey::VerifyingKey(verifing_key_encoded) =
+        if let MessageOrVerifyingKey::VerifyingKey(verifying_key_encoded) =
             message.message_or_verifying_key
         {
-            let point = EncodedPoint::from_bytes(verifing_key_encoded).map_err(|_| {
+            let point = EncodedPoint::from_bytes(verifying_key_encoded).map_err(|_| {
                 ProtocolExecutionErr::BadVerifyingKey(
                     "Could not convert to encoded point".to_string(),
                 )

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -261,7 +261,7 @@ pub async fn execute_dkg(
             let chans = Channels(broadcaster.clone(), rx);
             (verifying_key, None, chans)
         } else {
-            panic!("Unexpected message");
+            return Err(ProtocolExecutionErr::UnexpectedMessage);
         }
     };
 

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -246,9 +246,16 @@ pub async fn execute_dkg(
         if let MessageOrVerifyingKey::VerifyingKey(verifing_key_encoded) =
             message.message_or_verifying_key
         {
-            let point = EncodedPoint::from_bytes(verifing_key_encoded)
-                .map_err(|_| ProtocolExecutionErr::EncodedPoint)?;
-            let verifying_key = VerifyingKey::from_encoded_point(&point)?;
+            let point = EncodedPoint::from_bytes(verifing_key_encoded).map_err(|_| {
+                ProtocolExecutionErr::BadVerifyingKey(
+                    "Could not convert to encoded point".to_string(),
+                )
+            })?;
+            let verifying_key = VerifyingKey::from_encoded_point(&point).map_err(|_| {
+                ProtocolExecutionErr::BadVerifyingKey(
+                    "Could not convert encoded point to verifying key".to_string(),
+                )
+            })?;
 
             // Setup channels for the next session
             let chans = Channels(broadcaster.clone(), rx);

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -350,15 +350,15 @@ fn get_key_init_parties(
     let mut includes_self = false;
     let number = BigUint::from_bytes_be(shared_randomness);
     let start_index_big = &number % validators.len();
-    let start_index: usize = start_index_big.try_into().unwrap(); //.to_usize().unwrap(); //.ok_or(SubgroupGetError::Usize("Usize error"))?;
+    let start_index: usize = start_index_big.try_into()?;
 
     for i in start_index..start_index + threshold {
         let index = i % validators.len();
-        let member = validators.get(index).unwrap();
+        let member = validators.get(index).ok_or(ProtocolExecutionErr::IndexOutOfBounds)?;
         if member == my_party_id {
             includes_self = true;
         }
-        parties.push(validators.get(index).unwrap().clone());
+        parties.push(member.clone());
     }
 
     Ok((parties, includes_self))

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -21,7 +21,7 @@ use synedrion::sessions::CombinedMessage;
 
 use crate::{protocol_transport::errors::ProtocolMessageErr, PartyId};
 
-/// A Message send during the signing or DKG protocol.
+/// A Message send during one of the synedrion protocols
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolMessage {
     /// Identifier of the author of this message
@@ -31,13 +31,15 @@ pub struct ProtocolMessage {
     /// Either a synedrion protocol message or a verifying key
     /// We need to send verifying keys during DKG to parties who were not present for the key init
     /// session
-    pub message_or_verifying_key: MessageOrVerifyingKey,
+    pub payload: ProtocolMessagePayload,
 }
 
+/// The payload of a message sent during one of the synedrion protocols
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MessageOrVerifyingKey {
+pub enum ProtocolMessagePayload {
     /// The signed protocol message
     CombinedMessage(Box<CombinedMessage<sr25519::Signature>>),
+    /// A verifying key for parties who were not present in the key init session
     VerifyingKey(Vec<u8>),
 }
 
@@ -59,7 +61,7 @@ impl ProtocolMessage {
         Self {
             from: from.clone(),
             to: to.clone(),
-            message_or_verifying_key: MessageOrVerifyingKey::CombinedMessage(Box::new(payload)),
+            payload: ProtocolMessagePayload::CombinedMessage(Box::new(payload)),
         }
     }
 }

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -28,8 +28,15 @@ pub struct ProtocolMessage {
     pub from: PartyId,
     /// Identifier of the destination of this message
     pub to: PartyId,
+    // pub payload: CombinedMessage<sr25519::Signature>,
+    pub message_or_verifying_key: MessageOrVerifyingKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MessageOrVerifyingKey {
     /// The signed protocol message
-    pub payload: CombinedMessage<sr25519::Signature>,
+    CombinedMessage(CombinedMessage<sr25519::Signature>),
+    VerifyingKey(Vec<u8>),
 }
 
 impl TryFrom<&[u8]> for ProtocolMessage {
@@ -47,6 +54,10 @@ impl ProtocolMessage {
         to: &PartyId,
         payload: CombinedMessage<sr25519::Signature>,
     ) -> Self {
-        Self { from: from.clone(), to: to.clone(), payload }
+        Self {
+            from: from.clone(),
+            to: to.clone(),
+            message_or_verifying_key: MessageOrVerifyingKey::CombinedMessage(payload),
+        }
     }
 }

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -28,7 +28,9 @@ pub struct ProtocolMessage {
     pub from: PartyId,
     /// Identifier of the destination of this message
     pub to: PartyId,
-    // pub payload: CombinedMessage<sr25519::Signature>,
+    /// Either a synedrion protocol message or a verifying key
+    /// We need to send verifying keys during DKG to parties who were not present for the key init
+    /// session
     pub message_or_verifying_key: MessageOrVerifyingKey,
 }
 

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -35,7 +35,7 @@ pub struct ProtocolMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageOrVerifyingKey {
     /// The signed protocol message
-    CombinedMessage(CombinedMessage<sr25519::Signature>),
+    CombinedMessage(Box<CombinedMessage<sr25519::Signature>>),
     VerifyingKey(Vec<u8>),
 }
 
@@ -57,7 +57,7 @@ impl ProtocolMessage {
         Self {
             from: from.clone(),
             to: to.clone(),
-            message_or_verifying_key: MessageOrVerifyingKey::CombinedMessage(payload),
+            message_or_verifying_key: MessageOrVerifyingKey::CombinedMessage(Box::new(payload)),
         }
     }
 }

--- a/crates/protocol/src/protocol_transport/broadcaster.rs
+++ b/crates/protocol/src/protocol_transport/broadcaster.rs
@@ -19,7 +19,7 @@ use tokio::sync::broadcast::{self, error::SendError};
 use crate::protocol_message::ProtocolMessage;
 
 /// A wrapper around [broadcast::Sender] for broadcasting protocol messages
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Broadcaster(pub broadcast::Sender<ProtocolMessage>);
 
 impl Broadcaster {

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -139,8 +139,9 @@ pub async fn server(
             Ok(ProtocolOutput::ProactiveRefresh(new_keyshare))
         },
         SessionId::Dkg { .. } => {
+            let threshold = tss_accounts.len();
             let keyshare_and_aux_info =
-                execute_dkg(session_id, channels, &pair, tss_accounts).await?;
+                execute_dkg(session_id, channels, &pair, tss_accounts, threshold).await?;
             Ok(ProtocolOutput::Dkg(keyshare_and_aux_info))
         },
     }

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -49,6 +49,7 @@ fn refresh_protocol_with_time_logged() {
 #[test]
 fn dkg_protocol_with_time_logged() {
     let cpus = num_cpus::get();
+    println!("Running dkg protocol with {} parties", cpus);
     get_tokio_runtime(cpus).block_on(async {
         test_dkg_with_parties(cpus).await;
     })

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -157,16 +157,13 @@ async fn test_dkg_and_sign_with_parties(num_parties: usize) {
         pairs.iter().map(|pair| ValidatorSecretInfo::pair_only(pair.clone())).collect();
     let session_id = SessionId::Dkg { user: AccountId32([0; 32]), block_number: 0 };
     let outputs = test_protocol_with_parties(dkg_parties, session_id, threshold).await;
-    println!("Finished DKG");
     let signing_committee = &ids[..threshold];
 
-    println!("signing committee {:?}", signing_committee);
     let parties: Vec<ValidatorSecretInfo> = outputs
         .clone()
         .into_iter()
         .filter_map(|output| {
             if let ProtocolOutput::Dkg((threshold_keyshare, aux_info)) = output {
-                println!("Threshold {}", threshold_keyshare.threshold());
                 let keyshare = threshold_keyshare.to_key_share(&signing_committee);
                 if signing_committee.contains(keyshare.owner()) {
                     let pair = pairs

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -62,8 +62,10 @@ fn dkg_protocol_with_time_logged() {
 #[serial]
 fn t_of_n_dkg_and_sign() {
     let cpus = num_cpus::get();
+    // For this test we need at least 3 parties
+    let parties = std::cmp::max(cpus, 3);
     get_tokio_runtime(cpus).block_on(async {
-        test_dkg_and_sign_with_parties(cpus).await;
+        test_dkg_and_sign_with_parties(parties).await;
     })
 }
 

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -49,7 +49,6 @@ fn refresh_protocol_with_time_logged() {
 #[test]
 fn dkg_protocol_with_time_logged() {
     let cpus = num_cpus::get();
-    println!("Running dkg protocol with {} parties", cpus);
     get_tokio_runtime(cpus).block_on(async {
         test_dkg_with_parties(cpus).await;
     })

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -62,8 +62,10 @@ fn dkg_protocol_with_time_logged() {
 #[serial]
 fn t_of_n_dkg_and_sign() {
     let cpus = num_cpus::get();
+    println!("Cpus {}", cpus);
     // For this test we need at least 3 parties
-    let parties = std::cmp::max(cpus, 3);
+    // let parties = std::cmp::max(cpus, 3);
+    let parties = 3;
     get_tokio_runtime(cpus).block_on(async {
         test_dkg_and_sign_with_parties(parties).await;
     })

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -20,6 +20,7 @@
 use entropy_protocol::{KeyParams, PartyId, SessionId, SigningSessionInfo, ValidatorInfo};
 use futures::future;
 use rand_core::OsRng;
+use serial_test::serial;
 use sp_core::{sr25519, Pair};
 use std::time::Instant;
 use subxt::utils::AccountId32;
@@ -31,6 +32,7 @@ mod helpers;
 use helpers::{server, ProtocolOutput};
 
 #[test]
+#[serial]
 fn sign_protocol_with_time_logged() {
     let cpus = num_cpus::get();
     get_tokio_runtime(cpus).block_on(async {
@@ -39,6 +41,7 @@ fn sign_protocol_with_time_logged() {
 }
 
 #[test]
+#[serial]
 fn refresh_protocol_with_time_logged() {
     let cpus = num_cpus::get();
     get_tokio_runtime(cpus).block_on(async {
@@ -47,6 +50,7 @@ fn refresh_protocol_with_time_logged() {
 }
 
 #[test]
+#[serial]
 fn dkg_protocol_with_time_logged() {
     let cpus = num_cpus::get();
     get_tokio_runtime(cpus).block_on(async {
@@ -55,6 +59,7 @@ fn dkg_protocol_with_time_logged() {
 }
 
 #[test]
+#[serial]
 fn t_of_n_dkg_and_sign() {
     let cpus = num_cpus::get();
     get_tokio_runtime(cpus).block_on(async {

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -62,9 +62,7 @@ fn dkg_protocol_with_time_logged() {
 #[serial]
 fn t_of_n_dkg_and_sign() {
     let cpus = num_cpus::get();
-    println!("Cpus {}", cpus);
     // For this test we need at least 3 parties
-    // let parties = std::cmp::max(cpus, 3);
     let parties = 3;
     get_tokio_runtime(cpus).block_on(async {
         test_dkg_and_sign_with_parties(parties).await;

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -54,21 +54,39 @@ fn dkg_protocol_with_time_logged() {
     })
 }
 
+#[test]
+fn t_of_n_dkg_and_sign() {
+    let cpus = num_cpus::get();
+    get_tokio_runtime(cpus).block_on(async {
+        test_dkg_and_sign_with_parties(cpus).await;
+    })
+}
+
 async fn test_sign_with_parties(num_parties: usize) {
-    let (parties, ids) = get_keypairs_and_ids(num_parties);
+    let (pairs, ids) = get_keypairs_and_ids(num_parties);
     let keyshares = KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, None);
     let aux_infos = AuxInfo::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids);
     let verifying_key = keyshares[0].verifying_key();
 
+    let parties: Vec<_> = pairs
+        .iter()
+        .enumerate()
+        .map(|(i, pair)| ValidatorSecretInfo {
+            pair: pair.clone(),
+            keyshare: Some(keyshares[i].clone()),
+            threshold_keyshare: None,
+            aux_info: Some(aux_infos[i].clone()),
+        })
+        .collect();
     let message_hash = [0u8; 32];
     let session_id = SessionId::Sign(SigningSessionInfo {
         signature_verifying_key: verifying_key.to_encoded_point(true).as_bytes().to_vec(),
         message_hash,
         request_author: AccountId32([0u8; 32]),
     });
-    let output =
-        test_protocol_with_parties(parties, Some(keyshares), Some(aux_infos), session_id).await;
-    if let ProtocolOutput::Sign(recoverable_signature) = output {
+    let threshold = parties.len();
+    let mut outputs = test_protocol_with_parties(parties, session_id, threshold).await;
+    if let ProtocolOutput::Sign(recoverable_signature) = outputs.pop().unwrap() {
         // Check signature
         let recovery_key_from_sig = VerifyingKey::recover_from_prehash(
             &message_hash,
@@ -83,7 +101,7 @@ async fn test_sign_with_parties(num_parties: usize) {
 }
 
 async fn test_refresh_with_parties(num_parties: usize) {
-    let (parties, ids) = get_keypairs_and_ids(num_parties);
+    let (pairs, ids) = get_keypairs_and_ids(num_parties);
     let keyshares = KeyShare::<KeyParams, PartyId>::new_centralized(&mut OsRng, &ids, None);
     let verifying_key = keyshares[0].verifying_key();
 
@@ -91,8 +109,20 @@ async fn test_refresh_with_parties(num_parties: usize) {
         verifying_key: verifying_key.to_encoded_point(true).as_bytes().to_vec(),
         block_number: 0,
     };
-    let output = test_protocol_with_parties(parties, Some(keyshares), None, session_id).await;
-    if let ProtocolOutput::ProactiveRefresh(keyshare) = output {
+
+    let parties: Vec<_> = pairs
+        .iter()
+        .enumerate()
+        .map(|(i, pair)| ValidatorSecretInfo {
+            pair: pair.clone(),
+            keyshare: None,
+            threshold_keyshare: Some(keyshares[i].to_threshold_key_share()),
+            aux_info: None,
+        })
+        .collect();
+    let threshold = parties.len();
+    let mut outputs = test_protocol_with_parties(parties, session_id, threshold).await;
+    if let ProtocolOutput::ProactiveRefresh(keyshare) = outputs.pop().unwrap() {
         assert!(keyshare.verifying_key() == verifying_key);
     } else {
         panic!("Unexpected protocol output");
@@ -100,10 +130,77 @@ async fn test_refresh_with_parties(num_parties: usize) {
 }
 
 async fn test_dkg_with_parties(num_parties: usize) {
-    let (parties, _ids) = get_keypairs_and_ids(num_parties);
+    let (pairs, _ids) = get_keypairs_and_ids(num_parties);
+    let parties: Vec<_> =
+        pairs.iter().map(|pair| ValidatorSecretInfo::pair_only(pair.clone())).collect();
+    let threshold = parties.len();
     let session_id = SessionId::Dkg { user: AccountId32([0; 32]), block_number: 0 };
-    let output = test_protocol_with_parties(parties, None, None, session_id).await;
-    if let ProtocolOutput::Dkg(_keyshare) = output {
+    let mut outputs = test_protocol_with_parties(parties, session_id, threshold).await;
+    if let ProtocolOutput::Dkg(_keyshare) = outputs.pop().unwrap() {
+    } else {
+        panic!("Unexpected protocol output");
+    }
+}
+
+async fn test_dkg_and_sign_with_parties(num_parties: usize) {
+    let threshold = num_parties - 1;
+    if threshold < 2 {
+        panic!("Not enought parties to test threshold signing");
+    }
+    let (pairs, ids) = get_keypairs_and_ids(num_parties);
+    let dkg_parties =
+        pairs.iter().map(|pair| ValidatorSecretInfo::pair_only(pair.clone())).collect();
+    let session_id = SessionId::Dkg { user: AccountId32([0; 32]), block_number: 0 };
+    let outputs = test_protocol_with_parties(dkg_parties, session_id, threshold).await;
+    println!("Finished DKG");
+    let signing_committee = &ids[..threshold];
+
+    println!("signing committee {:?}", signing_committee);
+    let parties: Vec<ValidatorSecretInfo> = outputs
+        .clone()
+        .into_iter()
+        .filter_map(|output| {
+            if let ProtocolOutput::Dkg((threshold_keyshare, aux_info)) = output {
+                println!("Threshold {}", threshold_keyshare.threshold());
+                let keyshare = threshold_keyshare.to_key_share(&signing_committee);
+                if signing_committee.contains(keyshare.owner()) {
+                    let pair = pairs
+                        .iter()
+                        .find(|p| keyshare.owner() == &PartyId::new(AccountId32(p.public().0)))
+                        .unwrap();
+                    Some(ValidatorSecretInfo {
+                        pair: pair.clone(),
+                        keyshare: Some(keyshare),
+                        threshold_keyshare: None,
+                        aux_info: Some(aux_info),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                panic!("Unexpected protocol output");
+            }
+        })
+        .collect();
+
+    let verifying_key = parties[0].keyshare.clone().unwrap().verifying_key();
+
+    let message_hash = [0u8; 32];
+    let session_id = SessionId::Sign(SigningSessionInfo {
+        signature_verifying_key: verifying_key.to_encoded_point(true).as_bytes().to_vec(),
+        message_hash,
+        request_author: AccountId32([0u8; 32]),
+    });
+    let mut outputs = test_protocol_with_parties(parties, session_id, threshold).await;
+    if let ProtocolOutput::Sign(recoverable_signature) = outputs.pop().unwrap() {
+        // Check signature
+        let recovery_key_from_sig = VerifyingKey::recover_from_prehash(
+            &message_hash,
+            &recoverable_signature.signature,
+            recoverable_signature.recovery_id,
+        )
+        .unwrap();
+        assert_eq!(verifying_key, recovery_key_from_sig);
     } else {
         panic!("Unexpected protocol output");
     }
@@ -111,11 +208,10 @@ async fn test_dkg_with_parties(num_parties: usize) {
 
 /// Generic test for any of the 3 protocols
 async fn test_protocol_with_parties(
-    parties: Vec<sr25519::Pair>,
-    keyshares: Option<Box<[KeyShare<KeyParams, PartyId>]>>,
-    aux_infos: Option<Box<[AuxInfo<KeyParams, PartyId>]>>,
+    parties: Vec<ValidatorSecretInfo>,
     session_id: SessionId,
-) -> ProtocolOutput {
+    threshold: usize,
+) -> Vec<ProtocolOutput> {
     // Prepare information about each node
     let mut validator_secrets = Vec::new();
     let mut validators_info = Vec::new();
@@ -127,16 +223,15 @@ async fn test_protocol_with_parties(
         let x25519_secret_key = StaticSecret::random_from_rng(OsRng);
         let x25519_public_key = x25519_dalek::PublicKey::from(&x25519_secret_key).to_bytes();
 
-        validator_secrets.push(ValidatorSecretInfo {
-            keyshare: keyshares.as_ref().map(|k| k[i].to_threshold_key_share()),
-            aux_info: aux_infos.as_ref().map(|a| a[i].clone()),
-            pair: parties[i].clone(),
+        validator_secrets.push(ValidatorSecretInfoWithSocket::new(
+            parties[i].clone(),
             x25519_secret_key,
             socket,
-        });
+        ));
+
         // Public contact information that all parties know
         validators_info.push(ValidatorInfo {
-            tss_account: AccountId32(parties[i].public().0),
+            tss_account: AccountId32(parties[i].pair.public().0),
             x25519_public_key,
             ip_address: addr.to_string(),
         })
@@ -160,7 +255,9 @@ async fn test_protocol_with_parties(
                 secret.x25519_secret_key,
                 session_id_clone,
                 secret.keyshare,
+                secret.threshold_keyshare,
                 secret.aux_info,
+                threshold,
             )
             .await;
             if !tx.is_closed() {
@@ -168,19 +265,53 @@ async fn test_protocol_with_parties(
             }
         });
     }
-    let (result, _, _) = future::select_all(results_rx).await;
-    println!("Got first protocol result with {} parties in {:?}", parties.len(), now.elapsed());
+    let results =
+        future::join_all(results_rx).await.into_iter().map(|r| r.unwrap().unwrap()).collect();
+    println!("Got protocol results with {} parties in {:?}", parties.len(), now.elapsed());
 
-    result.unwrap().unwrap()
+    results
 }
 
 /// Details of an individual party
+#[derive(Clone)]
 struct ValidatorSecretInfo {
-    keyshare: Option<ThresholdKeyShare<KeyParams, PartyId>>,
-    aux_info: Option<AuxInfo<KeyParams, PartyId>>,
     pair: sr25519::Pair,
+    keyshare: Option<KeyShare<KeyParams, PartyId>>,
+    threshold_keyshare: Option<ThresholdKeyShare<KeyParams, PartyId>>,
+    aux_info: Option<AuxInfo<KeyParams, PartyId>>,
+}
+
+impl ValidatorSecretInfo {
+    fn pair_only(pair: sr25519::Pair) -> Self {
+        ValidatorSecretInfo { pair, keyshare: None, threshold_keyshare: None, aux_info: None }
+    }
+}
+
+/// Full details of an individual party, with a socket
+struct ValidatorSecretInfoWithSocket {
+    pair: sr25519::Pair,
+    keyshare: Option<KeyShare<KeyParams, PartyId>>,
+    threshold_keyshare: Option<ThresholdKeyShare<KeyParams, PartyId>>,
+    aux_info: Option<AuxInfo<KeyParams, PartyId>>,
     x25519_secret_key: StaticSecret,
     socket: TcpListener,
+}
+
+impl ValidatorSecretInfoWithSocket {
+    fn new(
+        secret_info: ValidatorSecretInfo,
+        x25519_secret_key: StaticSecret,
+        socket: TcpListener,
+    ) -> Self {
+        Self {
+            pair: secret_info.pair,
+            keyshare: secret_info.keyshare,
+            threshold_keyshare: secret_info.threshold_keyshare,
+            aux_info: secret_info.aux_info,
+            x25519_secret_key,
+            socket,
+        }
+    }
 }
 
 /// Helper to get the async runtime used for these tests

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -49,7 +49,7 @@ use subxt::{
     backend::legacy::LegacyRpcMethods, ext::sp_core::sr25519, tx::PairSigner,
     utils::AccountId32 as SubxtAccountId32, Config, OnlineClient,
 };
-use synedrion::{k256::ecdsa::SigningKey, AuxInfo, KeyShare, ThresholdKeyShare};
+use synedrion::{k256::ecdsa::SigningKey, AuxInfo, KeyShare};
 use tokio::sync::OnceCell;
 
 /// A shared reference to the logger used for tests.

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -89,7 +89,9 @@ pub async fn do_dkg(
         Channels(broadcast_out, rx_from_others)
     };
 
-    let result = execute_dkg(session_id, channels, signer.signer(), tss_accounts).await?;
+    let threshold = tss_accounts.len();
+    let result =
+        execute_dkg(session_id, channels, signer.signer(), tss_accounts, threshold).await?;
 
     Ok(result)
 }

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
@@ -98,10 +98,13 @@ impl<'a> ThresholdSigningService<'a> {
             return Err(ProtocolErr::BadSessionId);
         };
 
+        let parties: Vec<PartyId> =
+            threshold_accounts.iter().map(|t| PartyId::new(t.clone())).collect();
+
         let rsig = execute_signing_protocol(
             session_id,
             channels,
-            key_share,
+            &key_share.to_key_share(&parties),
             aux_info,
             &message_hash,
             threshold_signer,


### PR DESCRIPTION
This updates the DKG protocol to internally use the 3 protocols needed for setting up threshold keyshares (key init, reshare, and aux gen), and adds an integration test for `entropy-protocol` demonstrating t of n signing.

It is not yet possible to test this with `entropy-tss` because of not having enough nodes in our test setup, so currently `entropy-tss` always uses a threshold of n.

During the DKG protocols, we need to send the verifying key to the parties who were not present in the Key Init session. To be able to do this, the payload of a `ProtocolMessage` is now an enum which may either be a synedrion protocol message, or a verifying key.  This is a bit ugly - it might be nicer if this passing of the verifying key could be represented as a synedrion `CombinedMessage`.