### PR TITLE
Adds deps to Test CLI install instructions.

### DIFF
--- a/crates/test-cli/README.md
+++ b/crates/test-cli/README.md
@@ -28,6 +28,34 @@ When using the local docker compose setup, be aware you need to set the TSS host
 127.0.0.1 bob-tss-server
 ```
 
+You'll also need the following packages:
+
+1. OpenSSL:
+
+    ```shell
+    # Debian/Ubuntu
+    sudo apt install libssl-dev
+    ```
+
+    ```shell
+    # Arch
+    # OpenSSL comes pre-installed on most Arch releases.
+    # However, to install a specific version run:
+    sudo pacman -S openss3-3.0
+    ```
+    
+2. `pkg-config`:
+
+    ```shell
+    # Debian/Ubuntu
+    sudo apt install pkg-config
+    ```
+
+    ```shell
+    # Arch
+    sudo pacman -S pkgconf
+    ```
+
 ## Installation
 
 `cargo install entropy-test-cli`

--- a/crates/test-cli/README.md
+++ b/crates/test-cli/README.md
@@ -38,10 +38,8 @@ You'll also need the following packages:
     ```
 
     ```shell
-    # Arch
-    # OpenSSL comes pre-installed on most Arch releases.
-    # However, to install a specific version run:
-    sudo pacman -S openss3-3.0
+    # MacOS
+    brew install openssl 
     ```
     
 2. `pkg-config`:
@@ -52,8 +50,8 @@ You'll also need the following packages:
     ```
 
     ```shell
-    # Arch
-    sudo pacman -S pkgconf
+    # MacOS
+    brew install pkg-config
     ```
 
 ## Installation


### PR DESCRIPTION
Tell the reader to install OpenSSL and PKG Config, along with Debian/Ubuntu and Arch pasteables.

Closes https://github.com/entropyxyz/entropy-core/issues/855