### PR TITLE
Add blake2 as built in hash function and make `HashingAlgorithm` non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 At the moment this project **does not** adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[Unreleased]](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...master)
+## [Unreleased](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...master)
 
 ### Breaking Changes
 - In [#866](https://github.com/entropyxyz/entropy-core/pull/866) timestamp was removed from `UserSignatureRequest` and replaced with block_number. Thus check_stale now uses block_number for stale checks
@@ -16,6 +16,7 @@ At the moment this project **does not** adhere to
 - Add a way to change program modification account  ([#843](https://github.com/entropyxyz/entropy-core/pull/843))
 - Add support for `--mnemonic-file` and `THRESHOLD_SERVER_MNEMONIC` ([#864](https://github.com/entropyxyz/entropy-core/pull/864))
 - Add validator helpers to cli ([#870](https://github.com/entropyxyz/entropy-core/pull/870))
+- Add blake2 as built in hash function and make HashingAlgorithm non-exhaustive ([#881](https://github.com/entropyxyz/entropy-core/pull/881)
 
 ### Changed
 - Move TSS mnemonic out of keystore [#853](https://github.com/entropyxyz/entropy-core/pull/853)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ At the moment this project **does not** adhere to
 
 ### Breaking Changes
 - In [#866](https://github.com/entropyxyz/entropy-core/pull/866) timestamp was removed from `UserSignatureRequest` and replaced with block_number. Thus check_stale now uses block_number for stale checks
+- In [#881](https://github.com/entropyxyz/entropy-core/pull/881) the `HashingAlgorithm` enum is
+  given an additional variant `Blake2_256` and marked as `non_exhaustive` meaning we must handle the
+  case that an unknown variant is added in the future.
 
 ### Added
 - Add a way to change program modification account  ([#843](https://github.com/entropyxyz/entropy-core/pull/843))

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -91,11 +91,13 @@ pub struct OcwMessageProactiveRefresh {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "std", serde(rename = "hash"))]
 #[cfg_attr(feature = "std", serde(rename_all = "lowercase"))]
+#[non_exhaustive]
 pub enum HashingAlgorithm {
     Sha1,
     Sha2,
     Sha3,
     Keccak,
+    Blake2_256,
     Custom(usize),
 }
 

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -27,7 +27,7 @@ use reqwest::StatusCode;
 use sha1::{Digest as Sha1Digest, Sha1};
 use sha2::{Digest as Sha256Digest, Sha256};
 use sha3::{Digest as Sha3Digest, Keccak256, Sha3_256};
-use sp_core::{sr25519, Pair};
+use sp_core::{hashing::blake2_256, sr25519, Pair};
 use subxt::{backend::legacy::LegacyRpcMethods, tx::PairSigner, utils::AccountId32, OnlineClient};
 use synedrion::KeyShare;
 use tokio::time::timeout;
@@ -212,9 +212,11 @@ pub async fn compute_hash(
             hash.copy_from_slice(&result);
             Ok(hash)
         },
+        HashingAlgorithm::Blake2_256 => Ok(blake2_256(message)),
         HashingAlgorithm::Custom(i) => {
             let program = get_program(api, rpc, &programs_data[*i].program_pointer).await?;
             runtime.custom_hash(program.as_slice(), message).map_err(|e| e.into())
         },
+        _ => return Err(UserErr::UnknownHashingAlgorithm),
     }
 }

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -217,6 +217,6 @@ pub async fn compute_hash(
             let program = get_program(api, rpc, &programs_data[*i].program_pointer).await?;
             runtime.custom_hash(program.as_slice(), message).map_err(|e| e.into())
         },
-        _ => return Err(UserErr::UnknownHashingAlgorithm),
+        _ => Err(UserErr::UnknownHashingAlgorithm),
     }
 }

--- a/crates/threshold-signature-server/src/node_info/tests.rs
+++ b/crates/threshold-signature-server/src/node_info/tests.rs
@@ -45,6 +45,7 @@ async fn hashes_test() {
             HashingAlgorithm::Sha2,
             HashingAlgorithm::Sha3,
             HashingAlgorithm::Keccak,
+            HashingAlgorithm::Blake2_256,
             HashingAlgorithm::Custom(0),
         ]
     );

--- a/crates/threshold-signature-server/src/user/errors.rs
+++ b/crates/threshold-signature-server/src/user/errors.rs
@@ -161,6 +161,8 @@ pub enum UserErr {
     SubstrateClient(#[from] entropy_client::substrate::SubstrateError),
     #[error("Cannot get subgroup signers: {0}")]
     SubgroupGet(#[from] entropy_client::user::SubgroupGetError),
+    #[error("Unknown hashing algorthim - user is using a newer version than us")]
+    UnknownHashingAlgorithm,
 }
 
 impl From<hkdf::InvalidLength> for UserErr {


### PR DESCRIPTION
Blake2 is used to hash ECDSA signer payloads on substrate / polkadot. So i think it makes sense to have it as one of our built in hash functions. This PR does that.

Ive also marked the `HashingAlgorithm` enum as `non_exhaustive`.  This means we handle the case that it was some unknown variant and return a user error if it was.  The idea is to future proof - meaning we can add extra variants without breaking validators who didn't yet update their software.  There are probably arguments against doing this, so im willing to take it out if people think its a bad idea.