### PR TITLE
Replace link to private repo with succinct explanation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ This repository provides a [Docker Compose](https://docs.docker.com/compose/) co
         ```sh
         docker compose logs --follow # Following is also optional.
         ```
-    * [use the Entropy CLI](https://docs.entropy.xyz/reference/cli#install) to interact with the locally running network:
+    * [use the Entropy Test CLI](https://docs.entropy.xyz/reference/rust-testing-interface) to interact with the locally running network:
         ```sh
-        cd /path/to/entropy/cli.source.code
-        yarn start --endpoint ws://127.0.0.1:9944
+        cargo run -p entropy-test-cli -- --chain-endpoint="ws://127.0.0.1:9944" status 
         ```
 
 ### Building from source

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ This repository provides a [Docker Compose](https://docs.docker.com/compose/) co
     ```sh
     docker compose up --detach # Detaching is optional.
     ```
-1. Once running, if you have `--detach`ed your terminal from the containers' output streams, you can view them again like so:
-    ```sh
-    docker compose logs --follow # Following is also optional.
-    ```
 1. If you need to communicate directly with the threshold signature scheme server from your Docker host machine, you may also need to include its address in your local `/etc/hosts` file:
     ```sh
     echo "127.0.0.1	alice-tss-server bob-tss-server" | sudo tee -a /etc/hosts
     ```
-
-Additional documentation on running a local network can be found [here](https://github.com/entropyxyz/meta/wiki/Local-devnet).
+1. Confirm your local development network is up and running. You can:
+    * look at server logs:
+        ```sh
+        docker compose logs --follow # Following is also optional.
+        ```
+    * [use the Entropy CLI](https://docs.entropy.xyz/reference/cli#install) to interact with the locally running network:
+        ```sh
+        cd /path/to/entropy/cli.source.code
+        yarn start --endpoint ws://127.0.0.1:9944
+        ```
 
 ### Building from source
 

--- a/docker-compose-common.yaml
+++ b/docker-compose-common.yaml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 name: entropy
 
 secrets: &common-secrets

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,6 @@
 # environment for their tests. Eventually, we will converge on
 # a more canonical set of environments and configuration files.
 ---
-version: "3.8"
 name: entropy-devnet-local
 
 secrets:


### PR DESCRIPTION
Issue #778 describes "fragmented" docs, but the documentation that was linked to does not actually describe in much detail how to run a development network. Rather, it describes the technical architecture of a development network's start up sequence, and at some length. For example, it included message sequence diagrams that are a bit outdated today.

A more immediately useful reference for a user who attempts to spin up an Entropy Network using the local Docker Compose configuration provided here may be to point them directly at the new Entropy CLI tool, and to reference the public-facing documentation that is current. Moreover, the private repository linked is intended for internal Entropy uses only. While that might have been sensible to link to in the past, it no longer is.

While moving some of technical details currently housed within the private repository's wiki might make sense at some point, as issue #778 suggests, I don't think that's of a high enough priority right now to justify the amount of time it would take to present that same material somewhere sensible here, in this repository, else find a new home for it.

For now, it seems more sensible to simply remove the link and provide a reference to the CLI. So, that's what I've done in this commit.

I've also removed the `version` key from the Docker Compose file because modern Docker Engines no longer consider that key when doing schema validation; the `version` key is deprecated and produces a warning to such effect when present. There's no need for it, so it's been removed.

Closes #778.