### PR TITLE
Use test params for keyshares when cfg(test) is true in entropy-tss

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -117,17 +117,13 @@ impl fmt::Display for PartyId {
     }
 }
 
-#[cfg(not(test))]
-use synedrion::ProductionParams;
 /// Parameters used for the threshold signing scheme in production
-#[cfg(not(test))]
-pub type KeyParams = ProductionParams;
+#[cfg(not(any(test, feature = "unsafe")))]
+pub type KeyParams = synedrion::ProductionParams;
 
-#[cfg(test)]
-use synedrion::TestParams;
 /// Parameters used for the threshold signing scheme in tests (faster but less secure)
-#[cfg(test)]
-pub type KeyParams = TestParams;
+#[cfg(any(test, feature = "unsafe"))]
+pub type KeyParams = synedrion::TestParams;
 
 pub use synedrion::KeyShare;
 

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -171,14 +171,14 @@ pub async fn spawn_testing_validators() -> (Vec<String>, Vec<PartyId>) {
 /// Add the pre-generated test keyshares to a kvdb
 async fn put_keyshares_in_db(holder_name: &str, kvdb: KvManager) {
     let user_names_and_verifying_keys = [("eve", EVE_VERIFYING_KEY), ("dave", DAVE_VERIFYING_KEY)];
-
+    let test_or_production = if cfg!(test) { "test" } else { "production" };
     for (user_name, user_verifying_key) in user_names_and_verifying_keys {
         let keyshare_bytes = {
             let project_root =
                 project_root::get_project_root().expect("Error obtaining project root.");
             let file_path = project_root.join(format!(
-                "crates/testing-utils/keyshares/production/{}-keyshare-held-by-{}.keyshare",
-                user_name, holder_name
+                "crates/testing-utils/keyshares/{}/{}-keyshare-held-by-{}.keyshare",
+                test_or_production, user_name, holder_name
             ));
             std::fs::read(file_path).unwrap()
         };


### PR DESCRIPTION
Just to see if this fixes the timeout issues i am getting testing DKG - use synedrion test params for `entropy-tss` unit tests.