### PR TITLE
Add sort to subgroup signer selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ At the moment this project **does not** adhere to
 - In [#881](https://github.com/entropyxyz/entropy-core/pull/881) the `HashingAlgorithm` enum is
   given an additional variant `Blake2_256` and marked as `non_exhaustive` meaning we must handle the
   case that an unknown variant is added in the future.
+  - In [#900](https://github.com/entropyxyz/entropy-core/pull/900) the subgroup signer selection now adds a ```.sort()``` function before selecting the index to ensure consistentcy across libraries languages and clients
 
 ### Added
 - Add a way to change program modification account  ([#843](https://github.com/entropyxyz/entropy-core/pull/843))
 - Add support for `--mnemonic-file` and `THRESHOLD_SERVER_MNEMONIC` ([#864](https://github.com/entropyxyz/entropy-core/pull/864))
 - Add validator helpers to cli ([#870](https://github.com/entropyxyz/entropy-core/pull/870))
-- Add blake2 as built in hash function and make HashingAlgorithm non-exhaustive ([#881](https://github.com/entropyxyz/entropy-core/pull/881)
+- Add blake2 as built in hash function and make HashingAlgorithm non-exhaustive ([#881](https://github.com/entropyxyz/entropy-core/pull/881))
+- Add sort to subgroup signer selection ([#900](https://github.com/entropyxyz/entropy-core/pull/900))
 
 ### Changed
 - Move TSS mnemonic out of keystore [#853](https://github.com/entropyxyz/entropy-core/pull/853)

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -61,11 +61,11 @@ pub async fn get_current_subgroup_signers(
             async move {
                 let subgroup_info_query =
                     entropy::storage().staking_extension().signing_groups(i as u8);
-                let subgroup_info =
-                    query_chain(api, rpc, subgroup_info_query, block_hash)
-                        .await?
-                        .ok_or_else(|| SubgroupGetError::ChainFetch("Subgroup Fetch Error"))?;
-
+                let mut subgroup_info = query_chain(api, rpc, subgroup_info_query, block_hash)
+                    .await?
+                    .ok_or_else(|| SubgroupGetError::ChainFetch("Subgroup Fetch Error"))?;
+                // sort subgroup for ease in client side calculations
+                subgroup_info.sort();
                 let index_of_signer_big = &*owned_number % subgroup_info.len();
                 let index_of_signer =
                     index_of_signer_big.to_usize().ok_or(SubgroupGetError::Usize("Usize error"))?;

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -151,7 +151,7 @@ use validator::api::get_random_server_info;
 use crate::{
     health::api::healthz,
     launch::Configuration,
-    node_info::api::{hashes, version as get_version},
+    node_info::api::{get_subgroup_signers, hashes, version as get_version},
     r#unsafe::api::{delete, put, remove_keys, unsafe_get},
     signing_client::{api::*, ListenerState},
     user::api::*,
@@ -185,6 +185,7 @@ pub fn app(app_state: AppState) -> Router {
         .route("/user/receive_key", post(receive_key))
         .route("/signer/proactive_refresh", post(proactive_refresh))
         .route("/validator/sync_kvdb", post(sync_kvdb))
+        .route("/subgroup_signers", post(get_subgroup_signers))
         .route("/healthz", get(healthz))
         .route("/version", get(get_version))
         .route("/hashes", get(hashes))

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -42,6 +42,7 @@ pub async fn get_subgroup_signers(
     State(app_state): State<AppState>,
     message_hash: String,
 ) -> Result<String, UserErr> {
+    tracing::debug!("Message hash {:?}", message_hash);
     let api = get_api(&app_state.configuration.endpoint).await?;
     let rpc = get_rpc(&app_state.configuration.endpoint).await?;
     let subgroup_signers = get_current_subgroup_signers(&api, &rpc, &message_hash).await?;

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -34,11 +34,13 @@ pub async fn hashes() -> Json<Vec<HashingAlgorithm>> {
     Json(hashing_algos)
 }
 
-/// message is stripped 0x keccak hex encoded hash of message
+/// Returns the list of subgroup signers given a message hash.
+///
+/// Note: the message hash should not include a preceding `0x`.
 #[tracing::instrument(skip_all)]
 pub async fn get_subgroup_signers(
     State(app_state): State<AppState>,
-    message_hash_keccak_hex: String,
+    message_hash: String,
 ) -> Result<String, UserErr> {
     let api = get_api(&app_state.configuration.endpoint).await?;
     let rpc = get_rpc(&app_state.configuration.endpoint).await?;

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -44,7 +44,6 @@ pub async fn get_subgroup_signers(
 ) -> Result<String, UserErr> {
     let api = get_api(&app_state.configuration.endpoint).await?;
     let rpc = get_rpc(&app_state.configuration.endpoint).await?;
-    let subgroup_signers =
-        get_current_subgroup_signers(&api, &rpc, &message_hash_keccak_hex).await?;
+    let subgroup_signers = get_current_subgroup_signers(&api, &rpc, &message_hash).await?;
     Ok(serde_json::to_string(&subgroup_signers)?)
 }

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -34,7 +34,7 @@ pub async fn hashes() -> Json<Vec<HashingAlgorithm>> {
     Json(hashing_algos)
 }
 
-/// message is keccak hex encoded hash of message
+/// message is stripped 0x keccak hex encoded hash of message
 #[tracing::instrument(skip_all)]
 pub async fn get_subgroup_signers(
     State(app_state): State<AppState>,

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -12,9 +12,16 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-use axum::Json;
+use crate::{
+    chain_api::{get_api, get_rpc},
+    user::UserErr,
+    AppState,
+};
+use axum::{extract::State, Json};
+pub use entropy_client::user::get_current_subgroup_signers;
 use entropy_shared::types::HashingAlgorithm;
 use strum::IntoEnumIterator;
+
 /// Returns the version and commit data
 #[tracing::instrument]
 pub async fn version() -> String {
@@ -25,4 +32,17 @@ pub async fn version() -> String {
 pub async fn hashes() -> Json<Vec<HashingAlgorithm>> {
     let hashing_algos = HashingAlgorithm::iter().collect::<Vec<_>>();
     Json(hashing_algos)
+}
+
+/// message is keccak hex encoded hash of message
+#[tracing::instrument(skip_all)]
+pub async fn get_subgroup_signers(
+    State(app_state): State<AppState>,
+    message_hash_keccak_hex: String,
+) -> Result<String, UserErr> {
+    let api = get_api(&app_state.configuration.endpoint).await?;
+    let rpc = get_rpc(&app_state.configuration.endpoint).await?;
+    let subgroup_signers =
+        get_current_subgroup_signers(&api, &rpc, &message_hash_keccak_hex).await?;
+    Ok(serde_json::to_string(&subgroup_signers)?)
 }

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -1760,7 +1760,7 @@ async fn test_faucet() {
     .await
     .unwrap();
 
-    let amount_to_send = 200000011;
+    let amount_to_send = 200000012;
     let faucet_user_config = UserConfig { max_transfer_amount: amount_to_send };
 
     update_programs(


### PR DESCRIPTION
Closes #890 

Adds a sort function to help with a more deterministic subgroup get across different libraries and languages, as well adds a helper endpoint to get the subgroup with hash