### PR TITLE
Remove duplicate `dead_code` lint

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -252,7 +252,7 @@ pub fn new_partial(
         other: (rpc_extensions_builder, import_setup, rpc_setup, telemetry),
     })
 }
-#[allow(dead_code)]
+
 /// Result of [`new_full_base`].
 #[allow(dead_code)]
 pub struct NewFullBase {


### PR DESCRIPTION
This was introduced in both #835 and #883. Having this duplicated causes the
Clippy linting step to fail.
