### PR TITLE
Fix failing kvdb tests

### DIFF
--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -34,7 +34,7 @@ pub fn get_db_path(testing: bool) -> String {
 }
 
 pub fn clean_tests() {
-    if  fs::metadata(get_db_path(true)).is_ok() {
+    if fs::metadata(get_db_path(true)).is_ok() {
         let _result = std::fs::remove_dir_all(get_db_path(true));
     }
 }

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -35,7 +35,7 @@ pub fn get_db_path(testing: bool) -> String {
 
 pub fn clean_tests() {
     let db_path = get_db_path(true);
-    if fs::metadata(db_path).is_ok() {
+    if fs::metadata(db_path.clone()).is_ok() {
         let _result = std::fs::remove_dir_all(db_path);
     }
 }

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -34,5 +34,7 @@ pub fn get_db_path(testing: bool) -> String {
 }
 
 pub fn clean_tests() {
-    let _result = std::fs::remove_dir_all(get_db_path(true));
+    if  fs::metadata(get_db_path(true)).is_ok() {
+        let _result = std::fs::remove_dir_all(get_db_path(true));
+    }
 }

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -34,7 +34,8 @@ pub fn get_db_path(testing: bool) -> String {
 }
 
 pub fn clean_tests() {
-    if fs::metadata(get_db_path(true)).is_ok() {
-        let _result = std::fs::remove_dir_all(get_db_path(true));
+    let db_path = get_db_path(true);
+    if fs::metadata(db_path).is_ok() {
+        let _result = std::fs::remove_dir_all(db_path);
     }
 }

--- a/crates/threshold-signature-server/src/health/tests.rs
+++ b/crates/threshold-signature-server/src/health/tests.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use axum::http::StatusCode;
+use entropy_kvdb::clean_tests;
 use serial_test::serial;
 
 use crate::helpers::tests::{initialize_test_logger, setup_client};
@@ -21,10 +22,12 @@ use crate::helpers::tests::{initialize_test_logger, setup_client};
 #[tokio::test]
 #[serial]
 async fn health() {
+    clean_tests();
     initialize_test_logger().await;
     setup_client().await;
 
     let client = reqwest::Client::new();
     let response = client.get("http://127.0.0.1:3001/healthz").send().await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    clean_tests();
 }

--- a/crates/threshold-signature-server/src/node_info/tests.rs
+++ b/crates/threshold-signature-server/src/node_info/tests.rs
@@ -27,6 +27,7 @@ use serial_test::serial;
 #[tokio::test]
 #[serial]
 async fn version_test() {
+    clean_tests();
     initialize_test_logger().await;
     setup_client().await;
     let client = reqwest::Client::new();
@@ -35,11 +36,13 @@ async fn version_test() {
         response.text().await.unwrap(),
         format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_DESCRIBE"))
     );
+    clean_tests();
 }
 
 #[tokio::test]
 #[serial]
 async fn hashes_test() {
+    clean_tests();
     initialize_test_logger().await;
     setup_client().await;
     let response = reqwest::get("http://127.0.0.1:3001/hashes").await.unwrap();
@@ -56,6 +59,7 @@ async fn hashes_test() {
             HashingAlgorithm::Custom(0),
         ]
     );
+    clean_tests();
 }
 
 #[tokio::test]

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -333,7 +333,6 @@ async fn test_get_and_store_values() {
 #[tokio::test]
 async fn test_get_random_server_info() {
     initialize_test_logger().await;
-    clean_tests();
 
     let cxt = testing_context().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
@@ -352,16 +351,12 @@ async fn test_get_random_server_info() {
     let error =
         get_random_server_info(&api, &rpc, my_subgroup, validator_address).await.unwrap_err();
     assert_eq!(error.to_string(), ValidatorErr::SubgroupError("Index out of bounds").to_string());
-
-    clean_tests();
 }
 
 #[tokio::test]
 #[should_panic = "Account does not exist, add balance"]
 async fn test_check_balance_for_fees() {
     initialize_test_logger().await;
-    clean_tests();
-
     let cxt = testing_context().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
@@ -378,13 +373,11 @@ async fn test_check_balance_for_fees() {
     assert!(!result_2);
 
     let _ = check_balance_for_fees(&api, &rpc, &RANDOM_ACCOUNT, MIN_BALANCE).await.unwrap();
-    clean_tests();
 }
 
 #[tokio::test]
 async fn test_tell_chain_syncing_is_done() {
     initialize_test_logger().await;
-    clean_tests();
 
     let cxt = testing_context().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
@@ -395,7 +388,6 @@ async fn test_tell_chain_syncing_is_done() {
     // expect this to fail in the proper way
     let result = tell_chain_syncing_is_done(&api, &rpc, &signer_alice).await;
     assert!(result.is_err());
-    clean_tests();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Turns out there were clean_test() in functions that did not spin up a kvdb causing sometimes (if the kvdb was not cleared in the previous test) a panic and failing test issue. The clean_test() function now checks before trying to delete the file and has been removed when not needed