### PR TITLE
Exclude nomination pool benches

### DIFF
--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -10,6 +10,9 @@ entropyTemplate=.maintain/frame-weight-template.hbs
 licenseHeader=.maintain/AGPL-3.0-header.txt
 # Manually exclude some pallets.
 excluded_pallets=(
+    # FIXME (#914): Changes to the ED have broken these benchmarks, we need to address that before
+    # we can run them.
+    pallet_nomination_pools
 )
 
 # Load all pallet names in an array.


### PR DESCRIPTION
These broke after the ED changes from #901. I haven't been able to solve this in a satisfactory way,
so in order to keep the `v0.2.0` release pipeline moving I suggest we ignore this for now and
investigate later.

See #914 for more details.
