### PR TITLE
Run benchmarks as part of CI instead of just checking build

### DIFF
--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -104,7 +104,7 @@ jobs:
             - run:
                 command: |
                     pushd node
-                    ./scripts/benchmarks 2 1
+                    ../scripts/benchmarks 2 1
     node-test:
         machine:
             image: ubuntu-2204:2022.10.2

--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -101,7 +101,7 @@ jobs:
             resource_class: xlarge
         steps:
             - install-dependencies-and-checkout
-            - run: ./scripts/benchmarks 2 1
+            - run: ../scripts/benchmarks 2 1
 
     node-test:
         machine:

--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -101,7 +101,7 @@ jobs:
             resource_class: xlarge
         steps:
             - install-dependencies-and-checkout
-            - run: ../scripts/benchmarks 2 1
+            - run: pwd && ../scripts/benchmarks 2 1
 
     node-test:
         machine:

--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -101,7 +101,7 @@ jobs:
             resource_class: xlarge
         steps:
             - install-dependencies-and-checkout
-            - run: pwd && ../scripts/benchmarks 2 1
+            - run: pwd && ./scripts/benchmarks.sh 2 1
 
     node-test:
         machine:

--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -101,7 +101,10 @@ jobs:
             resource_class: xlarge
         steps:
             - install-dependencies-and-checkout
-            - run: pushd node && cargo check --features=runtime-benchmarks
+            - run:
+                command: |
+                    pushd node
+                    ./scripts/benchmarks 2 1
     node-test:
         machine:
             image: ubuntu-2204:2022.10.2

--- a/.circleci/then.yml
+++ b/.circleci/then.yml
@@ -101,10 +101,8 @@ jobs:
             resource_class: xlarge
         steps:
             - install-dependencies-and-checkout
-            - run:
-                command: |
-                    pushd node
-                    ../scripts/benchmarks 2 1
+            - run: ./scripts/benchmarks 2 1
+
     node-test:
         machine:
             image: ubuntu-2204:2022.10.2

--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -10,7 +10,7 @@ entropyTemplate=.maintain/frame-weight-template.hbs
 licenseHeader=.maintain/AGPL-3.0-header.txt
 # Manually exclude some pallets.
 excluded_pallets=(
-    pallet_nomination_pools,
+    pallet_nomination_pools
     pallet_treasury
 )
 

--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -2,14 +2,16 @@
 
 set -eux
 
-steps=50
-repeat=20
+steps=${1:-50}
+repeat=${2:-20}
 entropyOutput=./runtime/src/weights/
 entropyChain=dev
 entropyTemplate=.maintain/frame-weight-template.hbs
 licenseHeader=.maintain/AGPL-3.0-header.txt
 # Manually exclude some pallets.
 excluded_pallets=(
+    pallet_nomination_pools,
+    pallet_treasury
 )
 
 # Load all pallet names in an array.


### PR DESCRIPTION
It would be nice to see if the benchmarks actually run all the way through as opposed to
just checking if they simply build.

I'm curious to see how long this'll take to do. If it's too long to do on every PR then I
may change this to just run on `master` builds.
