### PR TITLE
Skip password prompt for TSS development accounts

### DIFF
--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -97,11 +97,28 @@ pub async fn load_kv_store(
         )
         .unwrap();
     }
+
+    if validator_name == &Some(ValidatorName::Alice) {
+        return KvManager::new(root, PasswordMethod::NoPassword.execute().unwrap()).unwrap();
+    };
+
     if validator_name == &Some(ValidatorName::Bob) {
         root.push("bob");
         return KvManager::new(root, PasswordMethod::NoPassword.execute().unwrap()).unwrap();
     };
-    if validator_name == &Some(ValidatorName::Alice) {
+
+    if validator_name == &Some(ValidatorName::Charlie) {
+        root.push("charlie");
+        return KvManager::new(root, PasswordMethod::NoPassword.execute().unwrap()).unwrap();
+    };
+
+    if validator_name == &Some(ValidatorName::Dave) {
+        root.push("dave");
+        return KvManager::new(root, PasswordMethod::NoPassword.execute().unwrap()).unwrap();
+    };
+
+    if validator_name == &Some(ValidatorName::Eve) {
+        root.push("eve");
         return KvManager::new(root, PasswordMethod::NoPassword.execute().unwrap()).unwrap();
     };
 


### PR DESCRIPTION
In #902 a couple more TSS development accounts were added. However, they were not checked when
running through the password prompt code, meaning that a password had to be added when using these
accounts.

For running some of our development flows (e.g `docker compose up`) this isn't ideal.

I've made a quick fix for this in the interest of getting the `v0.2.0` release out today, but the
proper solution here would be to use something like Clap's [`ValueEnum`](https://docs.rs/clap/latest/clap/trait.ValueEnum.html)
and ensure that we check all variants every time they're used.
