### PR TITLE
Release `v0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ At the moment this project **does not** adhere to
   case that an unknown variant is added in the future.
 - In [#900](https://github.com/entropyxyz/entropy-core/pull/900) the subgroup signer selection was
   sorted to ensure a predicatble order across libraries, languages and clients.
+- In [#901](https://github.com/entropyxyz/entropy-core/pull/901) the network's currency units were
+  changed. This resulted in a change to the existential deposit as well as balances of endowed
+  accounts (e.g development accounts like `//Alice`).
 
 ### Added
 - Add a way to change program modification account ([#843](https://github.com/entropyxyz/entropy-core/pull/843))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 At the moment this project **does not** adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0-rc.1...master)
+## [Unreleased](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0...master)
 
-## [0.2.0-rc.1](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0-rc.1) - 2024-06-24
+## [0.2.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0) - 2024-07-11
 
 ### Breaking Changes
 - In [#853](https://github.com/entropyxyz/entropy-core/pull/853) the responsibility of generating a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "entropy-runtime",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-client"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-kvdb"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "chacha20poly1305 0.9.1",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-protocol"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-runtime"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-shared"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "hex-literal",
  "lazy_static",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-test-cli"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-testing-utils"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "axum",
  "entropy-kvdb",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-tss"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7023,7 +7023,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-programs"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7041,7 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-propagation"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7106,7 +7106,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registry"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7195,7 +7195,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-slashing"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7245,7 +7245,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-extension"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7342,7 +7342,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-pause"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-client"
-version    ="0.2.0-rc.1"
+version    ="0.2.0"
 edition    ="2021"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -11,7 +11,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 [dependencies]
 sha3          ="0.10.8"
 serde         ={ version="1.0", default-features=false, features=["derive"] }
-entropy-shared={ version="0.2.0-rc.1", path="../shared", default-features=false }
+entropy-shared={ version="0.2.0", path="../shared", default-features=false }
 subxt         ={ version="0.35.3", default-features=false, features=["jsonrpsee"] }
 num           ="0.4.3"
 thiserror     ="1.0.61"
@@ -24,7 +24,7 @@ blake2          ={ version="0.10.4", optional=true }
 rand_core       ={ version="0.6.4", optional=true }
 serde_json      ={ version="1.0", optional=true }
 x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
-entropy-protocol={ version="0.2.0-rc.1", path="../protocol", optional=true, default-features=false }
+entropy-protocol={ version="0.2.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.5", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
 synedrion       ={ version="0.1", optional=true }

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-kvdb"
 description="Encrypted key-value database for the Entropy Theshold Signing Server"
-version    ="0.2.0-rc.1"
+version    ="0.2.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -32,7 +32,7 @@ tracing={ version="0.1", default-features=false }
 # Misc
 sled            ="0.34.7"
 bincode         ="1.3.3"
-entropy-protocol={ version="0.2.0-rc.1", path="../protocol" }
+entropy-protocol={ version="0.2.0", path="../protocol" }
 
 [dev-dependencies]
 serial_test="3.1.1"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy-protocol'
-version    ='0.2.0-rc.1'
+version    ='0.2.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 description="Entropy Signing and DKG protocol execution and transport logic"
 homepage   ='https://entropy.xyz/'
@@ -10,7 +10,7 @@ edition    ='2021'
 
 [dependencies]
 async-trait        ="0.1.81"
-entropy-shared     ={ version="0.2.0-rc.1", path="../shared", default-features=false }
+entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
 synedrion          ="0.1"
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-shared"
 description="Shared types used by the Entropy chain node and Entropy Threshold Signing Server"
-version    ="0.2.0-rc.1"
+version    ="0.2.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-test-cli"
 description="Simple command line interface client for testing Entropy"
-version    ='0.2.0-rc.1'
+version    ='0.2.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -9,7 +9,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-entropy-client={ version="0.2.0-rc.1", path="../client" }
+entropy-client={ version="0.2.0", path="../client" }
 clap          ={ version="4.5.9", features=["derive"] }
 colored       ="2.0.4"
 subxt         ="0.35.3"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-testing-utils"
 description="Utilities for testing the Entropy Threshold Signature Server"
-version    ='0.2.0-rc.1'
+version    ='0.2.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -18,10 +18,10 @@ lazy_static       ="1.5.0"
 hex-literal       ="0.4.1"
 tokio             ={ version="1.38", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
 axum              ={ version="0.7.5" }
-entropy-shared    ={ version="0.2.0-rc.1", path="../shared" }
-entropy-kvdb      ={ version="0.2.0-rc.1", path="../kvdb", default-features=false }
-entropy-tss       ={ version="0.2.0-rc.1", path="../threshold-signature-server" }
-entropy-protocol  ={ version="0.2.0-rc.1", path="../protocol" }
+entropy-shared    ={ version="0.2.0", path="../shared" }
+entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
+entropy-tss       ={ version="0.2.0", path="../threshold-signature-server" }
+entropy-protocol  ={ version="0.2.0", path="../protocol" }
 synedrion         ="0.1"
 hex               ="0.4.3"
 rand_core         ="0.6.4"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -38,12 +38,10 @@ parity-scale-codec="3.6.12"
 sp-core           ={ version="31.0.0", default-features=false }
 
 # Entropy
-entropy-shared={ version="0.2.0", path="../shared" }
-entropy-kvdb={ version="0.2.0", path="../kvdb", default-features=false }
+entropy-shared  ={ version="0.2.0", path="../shared" }
+entropy-kvdb    ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-protocol={ version="0.2.0", path="../protocol", features=["server"] }
-entropy-client={ version="0.2.0", path="../client", default-features=false, features=[
-  "native",
-] }
+entropy-client  ={ version="0.2.0", path="../client", default-features=false, features=["native"] }
 
 # Programs
 entropy-programs-runtime="0.10.0"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-tss"
-version    ="0.2.0-rc.1"
+version    ="0.2.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 description='Entropy threshold signature scheme (TSS) server'
@@ -38,10 +38,10 @@ parity-scale-codec="3.6.12"
 sp-core           ={ version="31.0.0", default-features=false }
 
 # Entropy
-entropy-shared={ version="0.2.0-rc.1", path="../shared" }
-entropy-kvdb={ version="0.2.0-rc.1", path="../kvdb", default-features=false }
-entropy-protocol={ version="0.2.0-rc.1", path="../protocol", features=["server"] }
-entropy-client={ version="0.2.0-rc.1", path="../client", default-features=false, features=[
+entropy-shared={ version="0.2.0", path="../shared" }
+entropy-kvdb={ version="0.2.0", path="../kvdb", default-features=false }
+entropy-protocol={ version="0.2.0", path="../protocol", features=["server"] }
+entropy-client={ version="0.2.0", path="../client", default-features=false, features=[
   "native",
 ] }
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy'
-version    ='0.2.0-rc.1'
+version    ='0.2.0'
 description="Entropy substrate node"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -90,12 +90,12 @@ pallet-transaction-payment    ={ version="29.0.0" }
 pallet-transaction-payment-rpc={ version="31.0.0" }
 
 # Entropy Dependencies
-entropy-runtime={ version="0.2.0-rc.1", path="../../runtime" }
-entropy-shared={ version="0.2.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-runtime={ version="0.2.0", path="../../runtime" }
+entropy-shared={ version="0.2.0", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-registry={ version="0.2.0-rc.1", path="../../pallets/registry" }
-pallet-staking-extension={ version="0.2.0-rc.1", path="../../pallets/staking" }
+pallet-registry={ version="0.2.0", path="../../pallets/registry" }
+pallet-staking-extension={ version="0.2.0", path="../../pallets/staking" }
 project-root="0.2.2"
 
 [build-dependencies]

--- a/pallets/parameters/Cargo.toml
+++ b/pallets/parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-parameters"
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/programs/Cargo.toml
+++ b/pallets/programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-programs'
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/propagation/Cargo.toml
+++ b/pallets/propagation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-propagation'
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -26,12 +26,12 @@ sp-io                ={ version="31.0.0", default-features=false }
 sp-runtime           ={ version="32.0.0", default-features=false }
 sp-staking           ={ version="27.0.0", default-features=false }
 
-entropy-shared={ version="0.2.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.2.0", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-registry={ version="0.2.0-rc.1", path="../registry", default-features=false }
-pallet-programs={ version="0.2.0-rc.1", path="../programs", default-features=false }
-pallet-staking-extension={ version="0.2.0-rc.1", path="../staking", default-features=false }
+pallet-registry={ version="0.2.0", path="../registry", default-features=false }
+pallet-programs={ version="0.2.0", path="../programs", default-features=false }
+pallet-staking-extension={ version="0.2.0", path="../staking", default-features=false }
 
 [dev-dependencies]
 parking_lot="0.12.3"

--- a/pallets/registry/Cargo.toml
+++ b/pallets/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-registry'
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -26,11 +26,11 @@ sp-core           ={ version="29.0.0", default-features=false }
 sp-runtime        ={ version="32.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 
-entropy-shared={ version="0.2.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.2.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-pallet-programs={ version="0.2.0-rc.1", path="../programs", default-features=false }
-pallet-staking-extension={ version="0.2.0-rc.1", path="../staking", default-features=false }
+pallet-programs={ version="0.2.0", path="../programs", default-features=false }
+pallet-staking-extension={ version="0.2.0", path="../staking", default-features=false }
 
 [dev-dependencies]
 frame-election-provider-support={ version="29.0.0", default-features=false }

--- a/pallets/slashing/Cargo.toml
+++ b/pallets/slashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-slashing'
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-staking-extension'
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -27,7 +27,7 @@ sp-runtime        ={ version="32.0.0", default-features=false }
 sp-staking        ={ version="27.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 
-entropy-shared={ version="0.2.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.2.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 

--- a/pallets/transaction-pause/Cargo.toml
+++ b/pallets/transaction-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-transaction-pause"
-version   ='0.2.0-rc.1'
+version   ='0.2.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -25,7 +25,7 @@ pallet-balances={ version="29.0.0" }
 sp-core        ={ version="29.0.0" }
 sp-io          ={ version="31.0.0" }
 
-pallet-programs={ version="0.2.0-rc.1", default-features=false, path="../programs" }
+pallet-programs={ version="0.2.0", default-features=false, path="../programs" }
 
 [features]
 default=["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ='entropy-runtime'
 description="The substrate runtime for the Entropy chain node"
-version    ='0.2.0-rc.1'
+version    ='0.2.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -95,15 +95,15 @@ pallet-utility                               ={ version="29.0.0", default-featur
 pallet-vesting                               ={ version="29.0.0", default-features=false }
 
 # Entropy Pallets
-pallet-programs         ={ version='0.2.0-rc.1', path='../pallets/programs', default-features=false }
-pallet-propagation      ={ version='0.2.0-rc.1', path='../pallets/propagation', default-features=false }
-pallet-registry         ={ version='0.2.0-rc.1', path='../pallets/registry', default-features=false }
-pallet-slashing         ={ version='0.2.0-rc.1', path='../pallets/slashing', default-features=false }
-pallet-staking-extension={ version='0.2.0-rc.1', path='../pallets/staking', default-features=false }
-pallet-transaction-pause={ version='0.2.0-rc.1', path='../pallets/transaction-pause', default-features=false }
-pallet-parameters       ={ version='0.2.0-rc.1', path='../pallets/parameters', default-features=false }
+pallet-programs         ={ version='0.2.0', path='../pallets/programs', default-features=false }
+pallet-propagation      ={ version='0.2.0', path='../pallets/propagation', default-features=false }
+pallet-registry         ={ version='0.2.0', path='../pallets/registry', default-features=false }
+pallet-slashing         ={ version='0.2.0', path='../pallets/slashing', default-features=false }
+pallet-staking-extension={ version='0.2.0', path='../pallets/staking', default-features=false }
+pallet-transaction-pause={ version='0.2.0', path='../pallets/transaction-pause', default-features=false }
+pallet-parameters       ={ version='0.2.0', path='../pallets/parameters', default-features=false }
 
-entropy-shared={ version="0.2.0-rc.1", path="../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.2.0", path="../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
 


### PR DESCRIPTION
Follow up to #910.

Only changes since then are some dependency bumps from Dependabot and #929.

:shipit: 