### PR TITLE
Make TSS startup checks more forgiving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.15",
+ "instant",
+ "pin-project-lite 0.2.14",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2724,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
+ "backoff",
  "base64 0.22.1",
  "bincode",
  "bip39",

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -23,6 +23,7 @@ reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
 synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 strum              ="0.26.2"
+backoff            ={ version = "0.4.0", features = ["tokio"] }
 
 # Async
 futures="0.3"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -23,7 +23,7 @@ reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
 synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
 strum              ="0.26.2"
-backoff            ={ version = "0.4.0", features = ["tokio"] }
+backoff            ={ version="0.4.0", features=["tokio"] }
 
 # Async
 futures="0.3"

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -268,7 +268,7 @@ pub fn development_mnemonic(validator_name: &Option<ValidatorName>) -> bip39::Mn
         .expect("Unable to parse given mnemonic.")
 }
 
-pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) -> String {
+pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) {
     if has_mnemonic(kv).await {
         tracing::warn!("Deleting account related keys from KVDB.");
 
@@ -334,7 +334,6 @@ pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) -> String
     fs::write(".entropy/account_id", format!("{id}")).expect("Failed to write account_id file");
 
     tracing::debug!("Starting process with account ID: `{id}`");
-    id.to_ss58check()
 }
 
 pub async fn threshold_account_id(kv: &KvManager) -> String {
@@ -396,7 +395,7 @@ pub async fn setup_only(kv: &KvManager) {
     println!("{}", output);
 }
 
-pub async fn check_node_connection(url: &str, account_id: &str) {
+pub async fn check_node_prerequisites(url: &str, account_id: &str) {
     use crate::chain_api::{get_api, get_rpc};
 
     let connect_to_substrate_node = || async {

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -339,7 +339,7 @@ pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) {
 pub async fn threshold_account_id(kv: &KvManager) -> String {
     let mnemonic = kv.kv().get(FORBIDDEN_KEY_MNEMONIC).await.expect("Issue getting mnemonic");
     let pair = <sr25519::Pair as Pair>::from_phrase(
-        &String::from_utf8(mnemonic).expect("Issue converting mnemonic to string"),
+        dbg!(&String::from_utf8(mnemonic).expect("Issue converting mnemonic to string")),
         None,
     )
     .expect("Issue converting mnemonic to pair");

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -339,7 +339,7 @@ pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) {
 pub async fn threshold_account_id(kv: &KvManager) -> String {
     let mnemonic = kv.kv().get(FORBIDDEN_KEY_MNEMONIC).await.expect("Issue getting mnemonic");
     let pair = <sr25519::Pair as Pair>::from_phrase(
-        dbg!(&String::from_utf8(mnemonic).expect("Issue converting mnemonic to string")),
+        &String::from_utf8(mnemonic).expect("Issue converting mnemonic to string"),
         None,
     )
     .expect("Issue converting mnemonic to pair");

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -241,16 +241,6 @@ pub struct StartupArgs {
     pub mnemonic_file: Option<PathBuf>,
 }
 
-pub async fn threshold_account_id(kv: &KvManager) -> String {
-    let mnemonic = kv.kv().get(FORBIDDEN_KEY_MNEMONIC).await.expect("Issue getting mnemonic");
-    let pair = <sr25519::Pair as Pair>::from_phrase(
-        &String::from_utf8(mnemonic).expect("Issue converting mnemonic to string"),
-        None,
-    )
-    .expect("Issue converting mnemonic to pair");
-    AccountId32::new(pair.0.public().into()).to_ss58check()
-}
-
 pub async fn has_mnemonic(kv: &KvManager) -> bool {
     let exists = kv.kv().exists(FORBIDDEN_KEY_MNEMONIC).await.expect("issue querying DB");
     if exists {
@@ -344,6 +334,16 @@ pub async fn setup_mnemonic(kv: &KvManager, mnemonic: bip39::Mnemonic) -> String
 
     tracing::debug!("Starting process with account ID: `{id}`");
     id.to_ss58check()
+}
+
+pub async fn threshold_account_id(kv: &KvManager) -> String {
+    let mnemonic = kv.kv().get(FORBIDDEN_KEY_MNEMONIC).await.expect("Issue getting mnemonic");
+    let pair = <sr25519::Pair as Pair>::from_phrase(
+        &String::from_utf8(mnemonic).expect("Issue converting mnemonic to string"),
+        None,
+    )
+    .expect("Issue converting mnemonic to pair");
+    AccountId32::new(pair.0.public().into()).to_ss58check()
 }
 
 pub async fn setup_latest_block_number(kv: &KvManager) -> Result<(), KvError> {

--- a/crates/threshold-signature-server/src/main.rs
+++ b/crates/threshold-signature-server/src/main.rs
@@ -112,14 +112,47 @@ async fn main() {
     if args.setup_only {
         setup_only(&kv_store).await;
     } else {
-        let api = get_api(&app_state.configuration.endpoint).await.expect("Error getting api");
-        let rpc = get_rpc(&app_state.configuration.endpoint).await.expect("Error getting rpc");
-        let has_fee_balance = check_balance_for_fees(&api, &rpc, account_id.clone(), MIN_BALANCE)
-            .await
-            .expect("Error in check balance");
-        if !has_fee_balance {
-            panic!("threshold account needs balance: {:?}", account_id);
+        let connect_to_substrate_node = || async {
+            tracing::info!(
+                "Attempting to establish connection to Substrate node at `{}`",
+                &app_state.configuration.endpoint
+            );
+
+            let api = get_api(&app_state.configuration.endpoint).await.map_err(|_| {
+                Err::<(), String>("Unable to connect to Substrate chain API".to_string())
+            })?;
+
+            let rpc = get_rpc(&app_state.configuration.endpoint)
+                .await
+                .map_err(|_| Err("Unable to connect to Substrate chain RPC".to_string()))?;
+
+            Ok((api, rpc))
+        };
+
+        let backoff = backoff::ExponentialBackoffBuilder::default()
+            .with_max_elapsed_time(Some(std::time::Duration::from_secs(60)))
+            .build();
+        match backoff::future::retry(backoff, connect_to_substrate_node).await {
+            Ok((api, rpc)) => {
+                tracing::info!("Sucessfully connected to Substrate node!");
+                tracing::info!("Checking balance of threshold server AccountId `{}`", &account_id);
+                let has_fee_balance =
+                    check_balance_for_fees(&api, &rpc, account_id.clone(), MIN_BALANCE)
+                        .await
+                        .expect("Error in check balance");
+                if !has_fee_balance {
+                    panic!("threshold account needs balance: {:?}", account_id);
+                }
+            },
+            Err(_err) => {
+                tracing::error!(
+                    "Unable to establish connection with Substrate node at `{}`",
+                    &app_state.configuration.endpoint
+                );
+                panic!("Unable to establish connection with Substrate node.");
+            },
         }
+
         let listener = tokio::net::TcpListener::bind(&addr)
             .await
             .expect("Unable to bind to given server address.");

--- a/crates/threshold-signature-server/src/main.rs
+++ b/crates/threshold-signature-server/src/main.rs
@@ -17,15 +17,12 @@ use std::{net::SocketAddr, str::FromStr};
 
 use clap::Parser;
 
-use entropy_shared::MIN_BALANCE;
 use entropy_tss::{
     app,
-    chain_api::{get_api, get_rpc},
     launch::{
         development_mnemonic, load_kv_store, setup_latest_block_number, setup_mnemonic, setup_only,
         Configuration, StartupArgs, ValidatorName,
     },
-    validator::api::check_balance_for_fees,
     AppState,
 };
 

--- a/crates/threshold-signature-server/src/main.rs
+++ b/crates/threshold-signature-server/src/main.rs
@@ -96,12 +96,13 @@ async fn main() {
     } else if cfg!(test) || validator_name.is_some() {
         setup_mnemonic(&kv_store, development_mnemonic(&validator_name)).await
     } else {
-        let (has_mnemonic, account_id) = entropy_tss::launch::has_mnemonic(&kv_store).await;
+        let has_mnemonic = entropy_tss::launch::has_mnemonic(&kv_store).await;
         assert!(
             has_mnemonic,
             "No mnemonic provided. Please provide one or use a development account."
         );
-        account_id
+
+        entropy_tss::launch::threshold_account_id(&kv_store).await
     };
 
     setup_latest_block_number(&kv_store).await.expect("Issue setting up Latest Block Number");

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -144,11 +144,16 @@ async fn test_get_signer_does_not_throw_err() {
     initialize_test_logger().await;
     clean_tests();
 
+    let pair = <sr25519::Pair as Pair>::from_phrase(crate::helpers::launch::DEFAULT_MNEMONIC, None)
+        .expect("Issue converting mnemonic to pair");
+    let expected_account_id = AccountId32::new(pair.0.public().into()).to_ss58check();
+
     let kv_store = load_kv_store(&None, None).await;
     setup_mnemonic(&kv_store, development_mnemonic(&None)).await;
+    development_mnemonic(&None).to_string();
     let account = threshold_account_id(&kv_store).await;
 
-    assert_eq!(account, "5DACCJgQV6sHoYUKfTGEimddFxe16NJXgkzHZ3RC9QCBShMH");
+    assert_eq!(account, expected_account_id);
     get_signer(&kv_store).await.unwrap();
     clean_tests();
 }

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -111,8 +111,9 @@ use crate::{
     get_signer,
     helpers::{
         launch::{
-            development_mnemonic, load_kv_store, setup_mnemonic, Configuration, ValidatorName,
-            DEFAULT_BOB_MNEMONIC, DEFAULT_CHARLIE_MNEMONIC, DEFAULT_ENDPOINT, DEFAULT_MNEMONIC,
+            development_mnemonic, load_kv_store, setup_mnemonic, threshold_account_id,
+            Configuration, ValidatorName, DEFAULT_BOB_MNEMONIC, DEFAULT_CHARLIE_MNEMONIC,
+            DEFAULT_ENDPOINT, DEFAULT_MNEMONIC,
         },
         signing::Hasher,
         substrate::{query_chain, submit_transaction},
@@ -144,7 +145,9 @@ async fn test_get_signer_does_not_throw_err() {
     clean_tests();
 
     let kv_store = load_kv_store(&None, None).await;
-    let account = setup_mnemonic(&kv_store, development_mnemonic(&None)).await;
+    setup_mnemonic(&kv_store, development_mnemonic(&None)).await;
+    let account = threshold_account_id(&kv_store).await;
+
     assert_eq!(account, "5DACCJgQV6sHoYUKfTGEimddFxe16NJXgkzHZ3RC9QCBShMH");
     get_signer(&kv_store).await.unwrap();
     clean_tests();


### PR DESCRIPTION
Right now the TSS panics and crashes if it's not able to establish a connection with a
Substrate node or if the TSS account doesn't meet a minimum balance.

This PR makes it so that the TSS server retries establishing a connection for ~15 mins
before calling it quits. It also doesn't crash if the TSS account doesn't have a minimum
balance, instead it prints a warning and continues.