### PR TITLE
Add three-node `devnet-local` configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,7 +43,11 @@ target
 .cargo-remote.toml
 .entropy
 chains
+
+# We specifically want to include the `create-test-keyshares` crate as part of our builds.
 scripts
+!scripts/create-test-keyshares/
+
 service
 shell.nix
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,3 +88,41 @@ services:
       - "/dns4/alice-chain-node/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
       - "--tss-server-endpoint"
       - "http://bob-tss-server:3002"
+
+  # "Charlie's TSS server."
+  charlie-tss-server:
+    extends:
+      file: docker-compose-common.yaml
+      service: tss-server
+    ports:
+      - "127.0.0.1:3003:3003/tcp"
+    command:
+      - "--charlie"
+      - "--threshold-url"
+      - "0.0.0.0:3003"
+      - "--chain-endpoint"
+      - "ws://charlie-chain-node:9944"
+      - "--no-sync"
+
+  # "Charlie's chain node."
+  charlie-chain-node:
+    extends:
+      file: docker-compose-common.yaml
+      service: chain-node
+    ports:
+      - "127.0.0.1:9946:9944/tcp"
+    command:
+      - "--chain"
+      - "devnet-local"
+      - "--charlie"                 # Shortcut for `--name Charlie --validator`
+      - "--base-path"
+      - ".entropy/charlie"
+      - "--rpc-port"
+      - "9944"
+      - "--rpc-cors"
+      - "all"
+      - "--unsafe-rpc-external" # Intentional, for TSS's access.
+      - "--bootnodes"
+      - "/dns4/alice-chain-node/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
+      - "--tss-server-endpoint"
+      - "http://charlie-tss-server:3003"

--- a/node/cli/src/chain_spec/dev.rs
+++ b/node/cli/src/chain_spec/dev.rs
@@ -37,7 +37,7 @@ use sp_consensus_babe::AuthorityId as BabeId;
 use sp_core::sr25519;
 use sp_runtime::{BoundedVec, Perbill};
 
-pub fn devnet_two_node_initial_tss_servers(
+pub fn devnet_three_node_initial_tss_servers(
 ) -> Vec<(sp_runtime::AccountId32, TssX25519PublicKey, String)> {
     let alice = (
         crate::chain_spec::tss_account_id::ALICE.clone(),
@@ -60,7 +60,7 @@ pub fn devnet_two_node_initial_tss_servers(
     vec![alice, bob, charlie]
 }
 
-pub fn devnet_local_docker_two_node_initial_tss_servers(
+pub fn devnet_local_docker_three_node_initial_tss_servers(
 ) -> Vec<(sp_runtime::AccountId32, TssX25519PublicKey, String)> {
     let alice = (
         crate::chain_spec::tss_account_id::ALICE.clone(),
@@ -74,7 +74,13 @@ pub fn devnet_local_docker_two_node_initial_tss_servers(
         "bob-tss-server:3002".to_string(),
     );
 
-    vec![alice, bob]
+    let charlie = (
+        crate::chain_spec::tss_account_id::CHARLIE.clone(),
+        crate::chain_spec::tss_x25519_public_key::CHARLIE,
+        "charlie-tss-server:3002".to_string(),
+    );
+
+    vec![alice, bob, charlie]
 }
 
 pub fn devnet_local_docker_four_node_initial_tss_servers(
@@ -108,8 +114,8 @@ pub fn devnet_local_docker_four_node_initial_tss_servers(
 
 /// The configuration used for development.
 ///
-/// Since Entropy requires at least two signing groups to work properly we spin up this network with
-/// two validators, Alice and Bob.
+/// Since Entropy requires at two-of-three threshold setup, we spin up three validators: Alice, Bob,
+/// and Charlie.
 pub fn development_config() -> ChainSpec {
     ChainSpec::builder(wasm_binary_unwrap(), Default::default())
         .with_name("Development")
@@ -124,7 +130,7 @@ pub fn development_config() -> ChainSpec {
             ],
             vec![],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
-            devnet_two_node_initial_tss_servers(),
+            devnet_three_node_initial_tss_servers(),
         ))
         .build()
 }
@@ -132,9 +138,9 @@ pub fn development_config() -> ChainSpec {
 /// The configuration used for a local development network spun up with the `docker-compose` setup
 /// provided in this repository.
 ///
-/// Since Entropy requires at least two signing groups to work properly we spin up this network with
-/// two validators, Alice and Bob.
-pub fn devnet_local_two_node_config() -> crate::chain_spec::ChainSpec {
+/// Since Entropy requires at two-of-three threshold setup, we spin up three validators: Alice, Bob,
+/// and Charlie.
+pub fn devnet_local_three_node_config() -> crate::chain_spec::ChainSpec {
     ChainSpec::builder(wasm_binary_unwrap(), Default::default())
         .with_name("Devnet Local")
         .with_id("devnet_local")
@@ -144,17 +150,18 @@ pub fn devnet_local_two_node_config() -> crate::chain_spec::ChainSpec {
             vec![
                 crate::chain_spec::authority_keys_from_seed("Alice"),
                 crate::chain_spec::authority_keys_from_seed("Bob"),
+                crate::chain_spec::authority_keys_from_seed("Charlie"),
             ],
             vec![],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
-            devnet_local_docker_two_node_initial_tss_servers(),
+            devnet_local_docker_three_node_initial_tss_servers(),
         ))
         .build()
 }
 
 /// The configuration used for a local four-node development network spun up using `docker-compose`.
 ///
-/// Note that this repository does not provide an example of that, but the provided two-node
+/// Note that this repository does not provide an example of that, but the provided three-node
 /// `docker-compose` setup can be used as a reference.
 pub fn devnet_local_four_node_config() -> crate::chain_spec::ChainSpec {
     ChainSpec::builder(wasm_binary_unwrap(), Default::default())

--- a/node/cli/src/chain_spec/dev.rs
+++ b/node/cli/src/chain_spec/dev.rs
@@ -77,7 +77,7 @@ pub fn devnet_local_docker_three_node_initial_tss_servers(
     let charlie = (
         crate::chain_spec::tss_account_id::CHARLIE.clone(),
         crate::chain_spec::tss_x25519_public_key::CHARLIE,
-        "charlie-tss-server:3002".to_string(),
+        "charlie-tss-server:3003".to_string(),
     );
 
     vec![alice, bob, charlie]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -69,8 +69,8 @@ impl SubstrateCli for Cli {
 
     // | --chain           | Description |
     // |-----------------  |----------- |
-    // | dev               | Two nodes, Two threshold servers, Alice and Bob, Development Configuration |
-    // | devnet-local      | Two nodes, Two threshold servers, Alice and Bob, Development Configuration, Docker Compatible |
+    // | dev               | Three nodes, Three threshold servers, Alice Bob and Charlie, Development Configuration |
+    // | devnet-local      | Three nodes, Three threshold servers, Alice Bob and Charlie, Development Configuration, Docker Compatible |
     // | devnet-local-four-nodes     | Four Nodes, Four threshold servers, Alice, Bob, Dave, Eve, Testnet Configuration, Docker Compatible |
     // | integration-tests | Two nodes, Four threshold servers, Alice and Bob, Development Configuration |
     // | testnet-local     | Two Nodes, Two threshold servers, Alice and Bob, Testnet Configuration, Docker Compatible |
@@ -78,7 +78,7 @@ impl SubstrateCli for Cli {
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
             "" | "dev" => Box::new(chain_spec::dev::development_config()),
-            "devnet-local" => Box::new(chain_spec::dev::devnet_local_two_node_config()),
+            "devnet-local" => Box::new(chain_spec::dev::devnet_local_three_node_config()),
             "devnet-local-four-nodes" => Box::new(chain_spec::dev::devnet_local_four_node_config()),
             "integration-tests" => {
                 Box::new(chain_spec::integration_tests::integration_tests_config())


### PR DESCRIPTION
This adds a third node to our `devnet-local` chainspec and adds that to our Docker
Compose setup.

While the containers spin up correctly, I've ran into some issues around TSS accounts not
being funded properly and with signing not working on the test CLI. Since these issues
aren't exactly related to the Docker stuff I'm gonna dig into those in some different
PRs.

Closes #892.
