### PR TITLE
Bump Synedrion to latest `master`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,6 +4051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashing-serializer"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c9b1a5e47c3bf40ae0f5705e84daa4cd6d8a74b2bdba43c06eb01dbc236f6e"
+dependencies = [
+ "digest 0.10.7",
+ "serde",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11276,6 +11286,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -13906,22 +13917,24 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 [[package]]
 name = "synedrion"
 version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?rev=25373111cbb01e1a25d8a5c5bb8f4652c725b3f1#25373111cbb01e1a25d8a5c5bb8f4652c725b3f1"
+source = "git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956#3bd9680dafc692b103fcb9c4b750fb1c6932b956"
 dependencies = [
  "base64 0.21.7",
  "bincode",
- "cfg-if",
  "crypto-bigint",
  "crypto-primes",
  "digest 0.10.7",
  "displaydoc",
+ "hashing-serializer",
  "hex",
  "k256",
  "rand_core 0.6.4",
+ "secrecy",
  "serde",
  "sha2 0.10.8",
  "sha3",
  "signature",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,7 +2469,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2484,7 +2484,7 @@ dependencies = [
  "entropy-shared",
  "entropy-testing-utils",
  "entropy-tss",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
+ "synedrion",
  "tokio",
 ]
 
@@ -2503,7 +2503,7 @@ dependencies = [
  "serial_test",
  "sled",
  "sp-core 31.0.0",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2563,7 +2563,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -2712,7 +2712,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
+ "synedrion",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2767,7 +2767,7 @@ dependencies = [
  "strum 0.26.3",
  "subxt",
  "subxt-signer",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -13917,30 +13917,7 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 [[package]]
 name = "synedrion"
 version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params#b7d8af48bc0679025477c4d9d0df60f8cb230de3"
-dependencies = [
- "base64 0.21.7",
- "bincode",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.10.7",
- "displaydoc",
- "hashing-serializer",
- "hex",
- "k256",
- "rand_core 0.6.4",
- "secrecy",
- "serde",
- "sha2 0.10.8",
- "sha3",
- "signature",
- "zeroize",
-]
-
-[[package]]
-name = "synedrion"
-version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956#3bd9680dafc692b103fcb9c4b750fb1c6932b956"
+source = "git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63#3be1339c21384a8e60a1534f1d3bfdd022662e63"
 dependencies = [
  "base64 0.21.7",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,7 +2469,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956)",
  "thiserror",
  "tokio",
  "tracing",
@@ -2484,7 +2484,7 @@ dependencies = [
  "entropy-shared",
  "entropy-testing-utils",
  "entropy-tss",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
  "tokio",
 ]
 
@@ -2503,7 +2503,7 @@ dependencies = [
  "serial_test",
  "sled",
  "sp-core 31.0.0",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3bd9680dafc692b103fcb9c4b750fb1c6932b956)",
  "thiserror",
  "tokio",
  "tracing",
@@ -2563,7 +2563,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -2712,7 +2712,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2767,7 +2767,7 @@ dependencies = [
  "strum 0.26.3",
  "subxt",
  "subxt-signer",
- "synedrion",
+ "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params)",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -13913,6 +13913,29 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synedrion"
+version = "0.1.0"
+source = "git+https://github.com/entropyxyz/synedrion?branch=hc/impl-serde-for-cggmp21-params#b7d8af48bc0679025477c4d9d0df60f8cb230de3"
+dependencies = [
+ "base64 0.21.7",
+ "bincode",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.10.7",
+ "displaydoc",
+ "hashing-serializer",
+ "hex",
+ "k256",
+ "rand_core 0.6.4",
+ "secrecy",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "signature",
+ "zeroize",
+]
 
 [[package]]
 name = "synedrion"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.2.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.5", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1", optional=true }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956", optional=true }
 hex             ={ version="0.4.3", optional=true }
 anyhow          ="1.0.86"
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.2.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.5", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956", optional=true }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63", optional=true }
 hex             ={ version="0.4.3", optional=true }
 anyhow          ="1.0.86"
 

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.8", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
 
 # Async
 tokio  ={ version="1.38", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.8", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
 
 # Async
 tokio  ={ version="1.38", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.81"
 entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.81"
 entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.81"
 entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -51,8 +51,10 @@ impl<Res: ProtocolResult> From<sessions::Error<Res, PartyId>> for GenericProtoco
     }
 }
 
-impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<InteractiveSigningResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<InteractiveSigningResult<KeyParams, PartyId>>>
+    for ProtocolExecutionErr
+{
+    fn from(err: GenericProtocolError<InteractiveSigningResult<KeyParams, PartyId>>) -> Self {
         tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::SigningProtocolError(err),
@@ -63,8 +65,8 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams>>> for Protoco
     }
 }
 
-impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<KeyInitResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<KeyInitResult<KeyParams, PartyId>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<KeyInitResult<KeyParams, PartyId>>) -> Self {
         tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyInitProtocolError(err),
@@ -75,8 +77,8 @@ impl From<GenericProtocolError<KeyInitResult<KeyParams>>> for ProtocolExecutionE
     }
 }
 
-impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<KeyResharingResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<KeyResharingResult<KeyParams, PartyId>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<KeyResharingResult<KeyParams, PartyId>>) -> Self {
         tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::KeyReshareProtocolError(err),
@@ -87,8 +89,8 @@ impl From<GenericProtocolError<KeyResharingResult<KeyParams>>> for ProtocolExecu
     }
 }
 
-impl From<GenericProtocolError<AuxGenResult<KeyParams>>> for ProtocolExecutionErr {
-    fn from(err: GenericProtocolError<AuxGenResult<KeyParams>>) -> Self {
+impl From<GenericProtocolError<AuxGenResult<KeyParams, PartyId>>> for ProtocolExecutionErr {
+    fn from(err: GenericProtocolError<AuxGenResult<KeyParams, PartyId>>) -> Self {
         tracing::error!("{:?}", err);
         match err {
             GenericProtocolError::Joined(err) => ProtocolExecutionErr::AuxGenProtocolError(err),
@@ -107,13 +109,15 @@ pub enum ProtocolExecutionErr {
     #[error("Synedrion session creation error: {0}")]
     SessionCreation(sessions::LocalError),
     #[error("Synedrion signing session error")]
-    SigningProtocolError(Box<sessions::Error<InteractiveSigningResult<KeyParams>, PartyId>>),
+    SigningProtocolError(
+        Box<sessions::Error<InteractiveSigningResult<KeyParams, PartyId>, PartyId>>,
+    ),
     #[error("Synedrion key init session error")]
-    KeyInitProtocolError(Box<sessions::Error<KeyInitResult<KeyParams>, PartyId>>),
+    KeyInitProtocolError(Box<sessions::Error<KeyInitResult<KeyParams, PartyId>, PartyId>>),
     #[error("Synedrion key reshare session error")]
-    KeyReshareProtocolError(Box<sessions::Error<KeyResharingResult<KeyParams>, PartyId>>),
+    KeyReshareProtocolError(Box<sessions::Error<KeyResharingResult<KeyParams, PartyId>, PartyId>>),
     #[error("Synedrion aux generation session error")]
-    AuxGenProtocolError(Box<sessions::Error<AuxGenResult<KeyParams>, PartyId>>),
+    AuxGenProtocolError(Box<sessions::Error<AuxGenResult<KeyParams, PartyId>, PartyId>>),
     #[error("Broadcast error: {0}")]
     Broadcast(#[from] Box<tokio::sync::broadcast::error::SendError<ProtocolMessage>>),
     #[error("Mpsc send error: {0}")]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -15,14 +15,14 @@
 
 use synedrion::{
     sessions, AuxGenResult, InteractiveSigningResult, KeyInitResult, KeyResharingResult,
-    MappedResult,
+    ProtocolResult,
 };
 use thiserror::Error;
 
 use crate::{protocol_message::ProtocolMessage, KeyParams, PartyId};
 
 #[derive(Debug, Error)]
-pub enum GenericProtocolError<Res: MappedResult<PartyId>> {
+pub enum GenericProtocolError<Res: ProtocolResult> {
     #[error("Synedrion session error {0}")]
     Joined(Box<sessions::Error<Res, PartyId>>),
     #[error("Incoming message stream error: {0}")]
@@ -33,21 +33,19 @@ pub enum GenericProtocolError<Res: MappedResult<PartyId>> {
     Mpsc(#[from] tokio::sync::mpsc::error::SendError<ProtocolMessage>),
 }
 
-impl<Res: MappedResult<PartyId>> From<sessions::LocalError> for GenericProtocolError<Res> {
+impl<Res: ProtocolResult> From<sessions::LocalError> for GenericProtocolError<Res> {
     fn from(err: sessions::LocalError) -> Self {
         Self::Joined(Box::new(sessions::Error::Local(err)))
     }
 }
 
-impl<Res: MappedResult<PartyId>> From<sessions::RemoteError<PartyId>>
-    for GenericProtocolError<Res>
-{
+impl<Res: ProtocolResult> From<sessions::RemoteError<PartyId>> for GenericProtocolError<Res> {
     fn from(err: sessions::RemoteError<PartyId>) -> Self {
         Self::Joined(Box::new(sessions::Error::Remote(err)))
     }
 }
 
-impl<Res: MappedResult<PartyId>> From<sessions::Error<Res, PartyId>> for GenericProtocolError<Res> {
+impl<Res: ProtocolResult> From<sessions::Error<Res, PartyId>> for GenericProtocolError<Res> {
     fn from(err: sessions::Error<Res, PartyId>) -> Self {
         Self::Joined(Box::new(err))
     }

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -67,11 +67,11 @@ impl RandomizedPrehashSigner<sr25519::Signature> for PairWrapper {
     }
 }
 
-async fn execute_protocol_generic<Res: synedrion::MappedResult<PartyId>>(
+async fn execute_protocol_generic<Res: synedrion::ProtocolResult>(
     mut chans: Channels,
     session: Session<Res, sr25519::Signature, PairWrapper, PartyId>,
     session_id_hash: [u8; 32],
-) -> Result<(Res::MappedSuccess, mpsc::Receiver<ProtocolMessage>), GenericProtocolError<Res>> {
+) -> Result<(Res::Success, mpsc::Receiver<ProtocolMessage>), GenericProtocolError<Res>> {
     let tx = &chans.0;
     let rx = &mut chans.1;
 

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -209,7 +209,7 @@ pub async fn execute_dkg(
     tracing::debug!("Executing DKG");
     let broadcaster = chans.0.clone();
 
-    let mut party_ids: BTreeSet<PartyId> =
+    let party_ids: BTreeSet<PartyId> =
         threshold_accounts.iter().cloned().map(PartyId::new).collect();
 
     let pair = PairWrapper(threshold_pair.clone());
@@ -217,7 +217,7 @@ pub async fn execute_dkg(
     let my_party_id = PartyId::new(AccountId32(threshold_pair.public().0));
 
     let session_id_hash = session_id.blake2(Some(DkgSubsession::KeyInit))?;
-    let (mut key_init_parties, includes_me) =
+    let (key_init_parties, includes_me) =
         get_key_init_parties(&my_party_id, threshold, &party_ids, &session_id_hash)?;
 
     let (verifying_key, old_holder, chans) = if includes_me {
@@ -253,7 +253,7 @@ pub async fn execute_dkg(
         }
         (
             verifying_key,
-            Some(OldHolder { key_share: init_keyshare.to_threshold_key_share() }),
+            Some(OldHolder { key_share: ThresholdKeyShare::from_key_share(&init_keyshare) }),
             chans,
         )
     } else {

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -112,7 +112,7 @@ async fn execute_protocol_generic<Res: synedrion::ProtocolResult>(
                     ))
                 })?;
 
-                if let ProtocolMessagePayload::CombinedMessage(payload) = message.payload.clone() {
+                if let ProtocolMessagePayload::MessageBundle(payload) = message.payload.clone() {
                     if message.session_id_hash == session_id_hash {
                         break (message.from, *payload);
                     } else {

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -299,7 +299,7 @@ pub async fn execute_dkg(
         SynedrionSessionId::from_seed(session_id_hash.as_slice()),
         pair.clone(),
         &party_ids,
-        &inputs,
+        inputs,
     )
     .map_err(ProtocolExecutionErr::SessionCreation)?;
     let (new_key_share_option, rx) =
@@ -365,7 +365,7 @@ pub async fn execute_proactive_refresh(
         SynedrionSessionId::from_seed(session_id_hash.as_slice()),
         pair,
         &party_ids,
-        &inputs,
+        inputs,
     )
     .map_err(ProtocolExecutionErr::SessionCreation)?;
 

--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -17,7 +17,7 @@ use std::str;
 
 use serde::{Deserialize, Serialize};
 use sp_core::sr25519;
-use synedrion::sessions::CombinedMessage;
+use synedrion::sessions::MessageBundle;
 
 use crate::{protocol_transport::errors::ProtocolMessageErr, PartyId};
 
@@ -41,7 +41,7 @@ pub struct ProtocolMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProtocolMessagePayload {
     /// The signed protocol message
-    CombinedMessage(Box<CombinedMessage<sr25519::Signature>>),
+    MessageBundle(Box<MessageBundle<sr25519::Signature>>),
     /// A verifying key for parties who were not present in the key init session
     VerifyingKey(Vec<u8>),
 }
@@ -59,13 +59,13 @@ impl ProtocolMessage {
     pub(crate) fn new(
         from: &PartyId,
         to: &PartyId,
-        payload: CombinedMessage<sr25519::Signature>,
+        payload: MessageBundle<sr25519::Signature>,
         session_id_hash: [u8; 32],
     ) -> Self {
         Self {
             from: from.clone(),
             to: to.clone(),
-            payload: ProtocolMessagePayload::CombinedMessage(Box::new(payload)),
+            payload: ProtocolMessagePayload::MessageBundle(Box::new(payload)),
             session_id_hash,
         }
     }

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -162,8 +162,6 @@ async fn test_dkg_and_sign_with_parties(num_parties: usize) {
     let session_id = SessionId::Dkg { user: AccountId32([0; 32]), block_number: 0 };
     let outputs = test_protocol_with_parties(dkg_parties, session_id, threshold).await;
 
-    // TODO (Nando): Double check to see if this is actually equivalent to previous code
-    // let signing_committee = &ids[..threshold];
     let signing_committee = (0..threshold)
         .into_iter()
         .map(|i| pairs[i].clone())

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server" }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server" }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server" }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/testing-utils/src/create_test_keyshares.rs
+++ b/crates/testing-utils/src/create_test_keyshares.rs
@@ -18,12 +18,13 @@
 use entropy_protocol::{execute_protocol::PairWrapper, PartyId};
 use rand_core::OsRng;
 use sp_core::{sr25519, Pair};
-use subxt::utils::AccountId32;
 use synedrion::{
-    ecdsa::SigningKey, make_key_resharing_session, AuxInfo, KeyResharingInputs, KeyShare,
-    NewHolder, OldHolder, SchemeParams, ThresholdKeyShare,
+    ecdsa::SigningKey, make_key_resharing_session, sessions::SessionId, AuxInfo,
+    KeyResharingInputs, KeyShare, NewHolder, OldHolder, SchemeParams, ThresholdKeyShare,
 };
 use synedrion_test_environment::run_nodes;
+
+use std::collections::BTreeSet;
 
 /// Given a secp256k1 secret key and 3 signing keypairs for the TSS parties, generate a set of
 /// threshold keyshares with auxiliary info
@@ -37,34 +38,44 @@ where
     Params: SchemeParams,
 {
     let signing_key = SigningKey::from_bytes(&(distributed_secret_key_bytes).into()).unwrap();
-    let signers = vec![alice, bob, charlie.clone()];
-    let shared_randomness = b"12345";
+    let signers = vec![alice.clone(), bob, charlie.clone()];
+    let session_id = SessionId::from_seed(b"12345".as_slice());
     let all_parties =
-        signers.iter().map(|pair| PartyId::new(AccountId32(pair.public().0))).collect::<Vec<_>>();
+        signers.iter().map(|pair| PartyId::from(pair.public())).collect::<BTreeSet<_>>();
 
-    let old_holders = all_parties.clone().into_iter().take(2).collect::<Vec<_>>();
+    let old_holders = all_parties.clone().into_iter().take(2).collect::<BTreeSet<_>>();
 
     let keyshares =
         KeyShare::<Params, PartyId>::new_centralized(&mut OsRng, &old_holders, Some(&signing_key));
     let aux_infos = AuxInfo::<Params, PartyId>::new_centralized(&mut OsRng, &all_parties);
 
-    let new_holder =
-        NewHolder { verifying_key: keyshares[0].verifying_key(), old_threshold: 2, old_holders };
+    let alice_id = PartyId::from(alice.public());
+    let new_holder = NewHolder {
+        verifying_key: keyshares[&alice_id].verifying_key(),
+        old_threshold: 2,
+        old_holders,
+    };
 
-    let mut sessions = (0..2)
-        .map(|idx| {
+    let mut sessions = signers
+        .iter()
+        .filter(|&pair| pair.public() == charlie.public())
+        .map(|pair| {
             let inputs = KeyResharingInputs {
-                old_holder: Some(OldHolder { key_share: keyshares[idx].to_threshold_key_share() }),
+                old_holder: Some(OldHolder {
+                    key_share: ThresholdKeyShare::from_key_share(
+                        &keyshares[&PartyId::from(pair.public())],
+                    ),
+                }),
                 new_holder: Some(new_holder.clone()),
                 new_holders: all_parties.clone(),
                 new_threshold: 2,
             };
             make_key_resharing_session(
                 &mut OsRng,
-                shared_randomness,
-                PairWrapper(signers[idx].clone()),
+                session_id,
+                PairWrapper(pair.clone()),
                 &all_parties,
-                &inputs,
+                inputs,
             )
             .unwrap()
         })
@@ -79,10 +90,10 @@ where
         };
         make_key_resharing_session(
             &mut OsRng,
-            shared_randomness,
+            session_id,
             PairWrapper(charlie),
             &all_parties,
-            &inputs,
+            inputs,
         )
         .unwrap()
     };
@@ -92,8 +103,8 @@ where
     let new_t_key_shares = run_nodes(sessions).await;
 
     let mut output = Vec::new();
-    for i in 0..3 {
-        output.push((new_t_key_shares[i].clone().unwrap(), aux_infos[i].clone()));
+    for (i, party_id) in signers.iter().map(|pair| PartyId::from(pair.public())).enumerate() {
+        output.push((new_t_key_shares[i].clone().unwrap(), aux_infos[&party_id].clone()));
     }
     output
 }
@@ -242,7 +253,7 @@ mod synedrion_test_environment {
     ) -> Vec<Res::Success>
     where
         Res: ProtocolResult + Send + 'static,
-        Res::MappeSuccess: Send + 'static,
+        Res::Success: Send + 'static,
     {
         let num_parties = sessions.len();
 

--- a/crates/testing-utils/src/create_test_keyshares.rs
+++ b/crates/testing-utils/src/create_test_keyshares.rs
@@ -106,7 +106,7 @@ mod synedrion_test_environment {
     use rand_core::OsRng;
     use sp_core::sr25519;
     use std::collections::BTreeMap;
-    use synedrion::{CombinedMessage, FinalizeOutcome, MappedResult, Session};
+    use synedrion::{CombinedMessage, FinalizeOutcome, ProtocolResult, Session};
     use tokio::{
         sync::mpsc,
         time::{sleep, Duration},
@@ -119,11 +119,11 @@ mod synedrion_test_environment {
     }
 
     /// Run a generic synedrion session
-    async fn run_session<Res: MappedResult<PartyId>>(
+    async fn run_session<Res: ProtocolResult>(
         tx: mpsc::Sender<MessageOut>,
         rx: mpsc::Receiver<MessageIn>,
         session: Session<Res, sr25519::Signature, PairWrapper, PartyId>,
-    ) -> Res::MappedSuccess {
+    ) -> Res::Success {
         let mut rx = rx;
 
         let mut session = session;
@@ -239,10 +239,10 @@ mod synedrion_test_environment {
 
     pub async fn run_nodes<Res>(
         sessions: Vec<Session<Res, sr25519::Signature, PairWrapper, PartyId>>,
-    ) -> Vec<Res::MappedSuccess>
+    ) -> Vec<Res::Success>
     where
-        Res: MappedResult<PartyId> + Send + 'static,
-        Res::MappedSuccess: Send + 'static,
+        Res: ProtocolResult + Send + 'static,
+        Res::MappeSuccess: Send + 'static,
     {
         let num_parties = sessions.len();
 
@@ -257,7 +257,7 @@ mod synedrion_test_environment {
         let dispatcher_task = message_dispatcher(tx_map, dispatcher_rx);
         let dispatcher = tokio::spawn(dispatcher_task);
 
-        let handles: Vec<tokio::task::JoinHandle<Res::MappedSuccess>> = rxs
+        let handles: Vec<tokio::task::JoinHandle<Res::Success>> = rxs
             .into_iter()
             .zip(sessions.into_iter())
             .map(|(rx, session)| {

--- a/crates/testing-utils/src/create_test_keyshares.rs
+++ b/crates/testing-utils/src/create_test_keyshares.rs
@@ -58,7 +58,7 @@ where
 
     let mut sessions = signers
         .iter()
-        .filter(|&pair| pair.public() == charlie.public())
+        .filter(|&pair| pair.public() != charlie.public())
         .map(|pair| {
             let inputs = KeyResharingInputs {
                 old_holder: Some(OldHolder {

--- a/crates/testing-utils/src/create_test_keyshares.rs
+++ b/crates/testing-utils/src/create_test_keyshares.rs
@@ -106,13 +106,13 @@ mod synedrion_test_environment {
     use rand_core::OsRng;
     use sp_core::sr25519;
     use std::collections::BTreeMap;
-    use synedrion::{CombinedMessage, FinalizeOutcome, ProtocolResult, Session};
+    use synedrion::{FinalizeOutcome, MessageBundle, ProtocolResult, Session};
     use tokio::{
         sync::mpsc,
         time::{sleep, Duration},
     };
-    type MessageOut = (PartyId, PartyId, CombinedMessage<sr25519::Signature>);
-    type MessageIn = (PartyId, CombinedMessage<sr25519::Signature>);
+    type MessageOut = (PartyId, PartyId, MessageBundle<sr25519::Signature>);
+    type MessageIn = (PartyId, MessageBundle<sr25519::Signature>);
 
     fn key_to_str(key: &PartyId) -> String {
         key.to_string()

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.8.1"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
 strum              ="0.26.2"
 backoff            ={ version="0.4.0", features=["tokio"] }
 

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.8.1"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
 strum              ="0.26.2"
 backoff            ={ version="0.4.0", features=["tokio"] }
 

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.8.1"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
 strum              ="0.26.2"
 backoff            ={ version="0.4.0", features=["tokio"] }
 

--- a/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_execution/mod.rs
@@ -33,6 +33,8 @@ use crate::{
     signing_client::{ListenerState, ProtocolErr},
 };
 
+use std::collections::BTreeSet;
+
 /// Thin wrapper around [ListenerState], manages execution of a signing party.
 #[derive(Clone)]
 pub struct ThresholdSigningService<'a> {
@@ -98,7 +100,7 @@ impl<'a> ThresholdSigningService<'a> {
             return Err(ProtocolErr::BadSessionId);
         };
 
-        let parties: Vec<PartyId> =
+        let parties: BTreeSet<PartyId> =
             threshold_accounts.iter().map(|t| PartyId::new(t.clone())).collect();
 
         let rsig = execute_signing_protocol(

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -13,8 +13,9 @@ entropy-testing-utils={ version="0.2.0-rc.1", path="../../crates/testing-utils" 
 tokio                ={ version="1.38", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
 entropy-shared       ={ version="0.2.0-rc.1", path="../../crates/shared" }
 entropy-kvdb         ={ version="0.2.0-rc.1", path="../../crates/kvdb", default-features=false }
-# Unreleased version of synedrion - this was head of master at the point of beginning to add t of n
-synedrion={ git="https://github.com/entropyxyz/synedrion", rev="25373111cbb01e1a25d8a5c5bb8f4652c725b3f1" }
+
+# Unreleased version of Synedrion with support for child key derivations.
+synedrion={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
 entropy-tss={ version="0.2.0-rc.1", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -15,7 +15,7 @@ entropy-shared       ={ version="0.2.0-rc.1", path="../../crates/shared" }
 entropy-kvdb         ={ version="0.2.0-rc.1", path="../../crates/kvdb", default-features=false }
 
 # Unreleased version of Synedrion with support for child key derivations.
-synedrion={ git="https://github.com/entropyxyz/synedrion", rev="3bd9680dafc692b103fcb9c4b750fb1c6932b956" }
+synedrion={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
 entropy-tss={ version="0.2.0-rc.1", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -15,7 +15,7 @@ entropy-shared       ={ version="0.2.0-rc.1", path="../../crates/shared" }
 entropy-kvdb         ={ version="0.2.0-rc.1", path="../../crates/kvdb", default-features=false }
 
 # Unreleased version of Synedrion with support for child key derivations.
-synedrion={ git="https://github.com/entropyxyz/synedrion", branch="hc/impl-serde-for-cggmp21-params" }
+synedrion={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
 entropy-tss={ version="0.2.0-rc.1", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }


### PR DESCRIPTION
The latest `HEAD` of Synedrion includes child key derivation functionality that I need
for the new registration flow, so I had to update the dependency.

Two things to note:
- I'm using my own branch of Synedrion until
  https://github.com/entropyxyz/synedrion/pull/133 gets merged since that adds some
  `serde` support that I need
- There are one or two `TODO`s in places where I want to double check that functionality
  remained the same, but I'll do that tomorrow. I'd still consider the PR as a whole
  ready for review
