### PR TITLE
Add instructions for adding Charlie Docker address to `/etc/hosts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository provides a [Docker Compose](https://docs.docker.com/compose/) co
     ```
 1. If you need to communicate directly with the threshold signature scheme server from your Docker host machine, you may also need to include its address in your local `/etc/hosts` file:
     ```sh
-    echo "127.0.0.1	alice-tss-server bob-tss-server" | sudo tee -a /etc/hosts
+    echo "127.0.0.1	alice-tss-server bob-tss-server charlie-tss-server" | sudo tee -a /etc/hosts
     ```
 1. Confirm your local development network is up and running. You can:
     * look at server logs:
@@ -40,7 +40,7 @@ This repository provides a [Docker Compose](https://docs.docker.com/compose/) co
         ```
     * [use the Entropy Test CLI](https://docs.entropy.xyz/reference/rust-testing-interface) to interact with the locally running network:
         ```sh
-        cargo run -p entropy-test-cli -- --chain-endpoint="ws://127.0.0.1:9944" status 
+        cargo run -p entropy-test-cli -- --chain-endpoint="ws://127.0.0.1:9944" status
         ```
 
 ### Building from source

--- a/crates/test-cli/README.md
+++ b/crates/test-cli/README.md
@@ -26,6 +26,7 @@ When using the local docker compose setup, be aware you need to set the TSS host
 ```
 127.0.0.1 alice-tss-server
 127.0.0.1 bob-tss-server
+127.0.0.1 charlie-tss-server
 ```
 
 You'll also need the following packages:
@@ -39,9 +40,9 @@ You'll also need the following packages:
 
     ```shell
     # MacOS
-    brew install openssl 
+    brew install openssl
     ```
-    
+
 2. `pkg-config`:
 
     ```shell


### PR DESCRIPTION
I forgot to do this in #940.
