### PR TITLE
Fix warnings when running Staking tests

### DIFF
--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -360,9 +360,7 @@ impl pallet_session::historical::Config for Test {
 thread_local! {
     pub static LAST_RANDOM: RefCell<Option<(H256, u64)>> = RefCell::new(None);
 }
-fn set_last_random(output: H256, known_since: u64) {
-    LAST_RANDOM.with(|p| *p.borrow_mut() = Some((output, known_since)))
-}
+
 pub struct TestPastRandomness;
 impl Randomness<H256, BlockNumber> for TestPastRandomness {
     fn random(_subject: &[u8]) -> (H256, u64) {

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -332,16 +332,16 @@ fn it_tests_new_session_handler() {
         // no next signers at start
         assert_eq!(Staking::next_signers().len(), 0);
 
-        Staking::new_session_handler(&vec![1u64, 2u64, 3u64]);
+        assert_ok!(Staking::new_session_handler(&[1, 2, 3]));
         // takes signers original (5,6) pops off first 5, adds (fake randomness in mock so adds 1)
-        assert_eq!(Staking::next_signers(), vec![6u64, 1u64]);
+        assert_eq!(Staking::next_signers(), vec![6, 1]);
 
-        Staking::new_session_handler(&vec![6u64, 5u64, 3u64]);
+        assert_ok!(Staking::new_session_handler(&[6, 5, 3]));
         // takes 3 and leaves 5 and 6 since already in signer group
-        assert_eq!(Staking::next_signers(), vec![6u64, 3u64]);
+        assert_eq!(Staking::next_signers(), vec![6, 3]);
 
-        Staking::new_session_handler(&vec![1u64]);
+        assert_ok!(Staking::new_session_handler(&[1]));
         // does nothing as not enough validators
-        assert_eq!(Staking::next_signers(), vec![6u64, 3u64]);
+        assert_eq!(Staking::next_signers(), vec![6, 3]);
     });
 }


### PR DESCRIPTION
There were some warnings around unused `Result`s and functions, so I've fixed those. I also did a
tiny cleanup with the types.
