### PR TITLE
Remove session hash from protocol message 

### DIFF
--- a/crates/protocol/src/protocol_message.rs
+++ b/crates/protocol/src/protocol_message.rs
@@ -33,8 +33,6 @@ pub struct ProtocolMessage {
     /// We need to send verifying keys during DKG to parties who were not present for the key init
     /// session.
     pub payload: ProtocolMessagePayload,
-    /// Identifier for this protocol session
-    pub session_id_hash: [u8; 32],
 }
 
 /// The payload of a message sent during one of the synedrion protocols
@@ -60,13 +58,11 @@ impl ProtocolMessage {
         from: &PartyId,
         to: &PartyId,
         payload: MessageBundle<sr25519::Signature>,
-        session_id_hash: [u8; 32],
     ) -> Self {
         Self {
             from: from.clone(),
             to: to.clone(),
             payload: ProtocolMessagePayload::MessageBundle(Box::new(payload)),
-            session_id_hash,
         }
     }
 }


### PR DESCRIPTION
Merging https://github.com/entropyxyz/entropy-core/pull/946 means we can now get the session Id from synedrion protocol messages and don't need to store it a second time in `ProtocolMessage`.
