### PR TITLE
Bump Synedrion to latest `master` in TSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2510,7 +2510,7 @@ dependencies = [
  "entropy-shared",
  "entropy-testing-utils",
  "entropy-tss",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "tokio",
 ]
 
@@ -2529,7 +2529,7 @@ dependencies = [
  "serial_test",
  "sled",
  "sp-core 31.0.0",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tracing",
@@ -2589,7 +2589,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -2738,7 +2738,7 @@ dependencies = [
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
  "subxt",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2793,7 +2793,7 @@ dependencies = [
  "strum 0.26.3",
  "subxt",
  "subxt-signer",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63)",
+ "synedrion",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.23.1",
@@ -7223,7 +7223,7 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-staking 27.0.0",
  "sp-std 14.0.0",
- "synedrion 0.1.0 (git+https://github.com/entropyxyz/synedrion/?rev=1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa)",
+ "synedrion",
 ]
 
 [[package]]
@@ -11340,7 +11340,6 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -13982,7 +13981,7 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 [[package]]
 name = "synedrion"
 version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion/?rev=1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa#1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa"
+source = "git+https://github.com/entropyxyz/synedrion?rev=1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa#1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",
@@ -13996,29 +13995,6 @@ dependencies = [
  "k256",
  "rand_core 0.6.4",
  "secrecy 0.9.0-pre.0",
- "serde",
- "sha2 0.10.8",
- "sha3",
- "signature",
- "zeroize",
-]
-
-[[package]]
-name = "synedrion"
-version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?rev=3be1339c21384a8e60a1534f1d3bfdd022662e63#3be1339c21384a8e60a1534f1d3bfdd022662e63"
-dependencies = [
- "base64 0.21.7",
- "bincode 1.3.3",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.10.7",
- "displaydoc",
- "hashing-serializer",
- "hex",
- "k256",
- "rand_core 0.6.4",
- "secrecy 0.8.0",
  "serde",
  "sha2 0.10.8",
  "sha3",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.2.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.5", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63", optional=true }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa", optional=true }
 hex             ={ version="0.4.3", optional=true }
 anyhow          ="1.0.86"
 

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.8", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
+synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
 
 # Async
 tokio  ={ version="1.39", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.81"
 entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -99,7 +99,7 @@ pub async fn execute_protocol_generic<Res: synedrion::ProtocolResult>(
 
         for preprocessed in cached_messages {
             // TODO (#641): this may happen in a spawned task.
-            let processed = session.process_message(preprocessed)?;
+            let processed = session.process_message(&mut OsRng, preprocessed)?;
 
             // This will happen in a host task.
             accum.add_processed_message(processed)??;
@@ -135,7 +135,7 @@ pub async fn execute_protocol_generic<Res: synedrion::ProtocolResult>(
 
             if let Some(preprocessed) = preprocessed {
                 // TODO (#641): this may happen in a spawned task.
-                let result = session.process_message(preprocessed)?;
+                let result = session.process_message(&mut OsRng, preprocessed)?;
 
                 // This will happen in a host task.
                 accum.add_processed_message(result)??;

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server", features=["test_helpers"] }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
+synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/testing-utils/src/create_test_keyshares.rs
+++ b/crates/testing-utils/src/create_test_keyshares.rs
@@ -171,7 +171,7 @@ mod synedrion_test_environment {
             for preprocessed in cached_messages {
                 // In production usage, this will happen in a spawned task.
                 println!("{key_str}: applying a cached message");
-                let result = session.process_message(preprocessed).unwrap();
+                let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
                 // This will happen in a host task.
                 accum.add_processed_message(result).unwrap().unwrap();
@@ -191,7 +191,7 @@ mod synedrion_test_environment {
                 if let Some(preprocessed) = preprocessed {
                     // In production usage, this will happen in a spawned task.
                     println!("{key_str}: applying a message from {}", key_to_str(&from));
-                    let result = session.process_message(preprocessed).unwrap();
+                    let result = session.process_message(&mut OsRng, preprocessed).unwrap();
 
                     // This will happen in a host task.
                     accum.add_processed_message(result).unwrap().unwrap();

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -21,7 +21,7 @@ zeroize            ="1.8.1"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
+synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
 strum              ="0.26.2"
 backoff            ={ version="0.4.0", features=["tokio"] }
 

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -15,7 +15,7 @@ entropy-shared       ={ version="0.2.0-rc.1", path="../../crates/shared" }
 entropy-kvdb         ={ version="0.2.0-rc.1", path="../../crates/kvdb", default-features=false }
 
 # Unreleased version of Synedrion with support for child key derivations.
-synedrion={ git="https://github.com/entropyxyz/synedrion", rev="3be1339c21384a8e60a1534f1d3bfdd022662e63" }
+synedrion={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
 entropy-tss={ version="0.2.0-rc.1", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }


### PR DESCRIPTION
I didn't want to bump it in #955 since it could've introduced a lot of noise. Now that I need some
of new child key derivation APIs in the TSS it makes sense to update it elsewhere.
