### PR TITLE
Fix TSS `AccountId` keys in chainspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ At the moment this project **does not** adhere to
 - Add parent key threshold dynamically ([#974](https://github.com/entropyxyz/entropy-core/pull/974))
 
 ### Changed
-- Fix tss keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))
+- Fix TSS `AccountId` keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))
 
 ## [0.2.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0) - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ At the moment this project **does not** adhere to
 - Set inital signers ([#971](https://github.com/entropyxyz/entropy-core/pull/971))
 - Add parent key threshold dynamically ([#974](https://github.com/entropyxyz/entropy-core/pull/974))
 
+### Changed
+- Fix tss keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))
+
 ## [0.2.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0) - 2024-07-11
 
 ### Breaking Changes

--- a/node/cli/src/chain_spec/mod.rs
+++ b/node/cli/src/chain_spec/mod.rs
@@ -75,15 +75,15 @@ pub mod tss_account_id {
     pub static ref CHARLIE: sp_runtime::AccountId32  =
             super::hex!["946140d3d5ddb980c74ffa1bb64353b5523d2d77cdf3dc617fd63de9d3b66338"].into();
 
-    /// Not sure what mnemonic is used to derive the following `AccountId`.
+     /// The `DEFAULT_DAVE_MNEMONIC` is used to derive the following `AccountId`.
     /// Mnemonic: "beef dutch panic monkey black glad audit twice humor gossip wealth drive"
     pub static ref DAVE: sp_runtime::AccountId32  =
-            super::hex!["12bf1c8e365c20cc2af606e3814b98b192857d85d182dac5e33fb90d0380ca75"].into();
+            super::hex!["0a9054ef6b6b8ad0dd2c89895b2515583f2fbf1edced68e7328ae456d86b9402"].into();
 
-    /// The `DEFAULT_CHARLIE_MNEMONIC` is used to derive the following `AccountId`.
+    /// The `DEFAULT_EVE_MNEMONIC` is used to derive the following `AccountId`.
     /// Mnemonic: "impact federal dish number fun crisp various wedding radio immense whisper glue"
     pub static ref EVE: sp_runtime::AccountId32  =
-            super::hex!["f2b4113735e988f662fe45e97b39770e804ebcd893ad0ab7cd8b7c5b5dcfff22"].into();
+            super::hex!["ac0d9030598f1722ff7c6a2a3043fa65903448dcc7a23011ec06c1c31cdad120"].into();
 
     }
 }

--- a/node/cli/src/chain_spec/mod.rs
+++ b/node/cli/src/chain_spec/mod.rs
@@ -75,7 +75,7 @@ pub mod tss_account_id {
     pub static ref CHARLIE: sp_runtime::AccountId32  =
             super::hex!["946140d3d5ddb980c74ffa1bb64353b5523d2d77cdf3dc617fd63de9d3b66338"].into();
 
-     /// The `DEFAULT_DAVE_MNEMONIC` is used to derive the following `AccountId`.
+    /// The `DEFAULT_DAVE_MNEMONIC` is used to derive the following `AccountId`.
     /// Mnemonic: "beef dutch panic monkey black glad audit twice humor gossip wealth drive"
     pub static ref DAVE: sp_runtime::AccountId32  =
             super::hex!["0a9054ef6b6b8ad0dd2c89895b2515583f2fbf1edced68e7328ae456d86b9402"].into();


### PR DESCRIPTION
Keys were generated incorrectly with subkey when we needed to use hpke 