### PR TITLE
Refactor reshare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ At the moment this project **does not** adhere to
 
 ### Changed
 - Fix TSS `AccountId` keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))
-- Refactor reshare ([#994](https://github.com/entropyxyz/entropy-core/pull/994))
 
 ## [0.2.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0) - 2024-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ At the moment this project **does not** adhere to
 
 ### Changed
 - Fix TSS `AccountId` keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))
+- Refactor reshare ([#994](https://github.com/entropyxyz/entropy-core/pull/994))
 
 ## [0.2.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.1.0...release/v0.2.0) - 2024-07-11
 

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -329,6 +329,7 @@ pub async fn execute_dkg(
 }
 
 /// Execute proactive refresh.
+#[allow(clippy::type_complexity)]
 #[tracing::instrument(
     skip_all,
     fields(threshold_accounts, my_idx),
@@ -339,8 +340,6 @@ pub async fn execute_proactive_refresh(
     chans: Channels,
     threshold_pair: &sr25519::Pair,
     threshold_accounts: Vec<AccountId32>,
-    verifying_key: VerifyingKey,
-    threshold: usize,
     inputs: KeyResharingInputs<KeyParams, PartyId>,
 ) -> Result<
     (ThresholdKeyShare<KeyParams, PartyId>, Broadcaster, mpsc::Receiver<ProtocolMessage>),

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -16,9 +16,7 @@
 //! A simple protocol server, like a mini version of entropy-tss, for benchmarking
 use anyhow::{anyhow, ensure};
 use entropy_protocol::{
-    execute_protocol::{
-        execute_dkg, execute_proactive_refresh, execute_signing_protocol, Channels,
-    },
+    execute_protocol::{execute_dkg, execute_reshare, execute_signing_protocol, Channels},
     protocol_transport::{
         errors::WsError,
         noise::{noise_handshake_initiator, noise_handshake_responder},
@@ -147,8 +145,7 @@ pub async fn server(
             };
 
             let new_keyshare =
-                execute_proactive_refresh(session_id, channels, &pair, tss_accounts, inputs)
-                    .await?;
+                execute_reshare(session_id, channels, &pair, tss_accounts, inputs, None).await?;
             Ok(ProtocolOutput::Reshare(new_keyshare.0))
         },
         SessionId::Dkg { .. } => {

--- a/crates/protocol/tests/helpers/mod.rs
+++ b/crates/protocol/tests/helpers/mod.rs
@@ -144,8 +144,7 @@ pub async fn server(
                 new_threshold: old_key.threshold(),
             };
 
-            let new_keyshare =
-                execute_reshare(session_id, channels, &pair, tss_accounts, inputs, None).await?;
+            let new_keyshare = execute_reshare(session_id, channels, &pair, inputs, None).await?;
             Ok(ProtocolOutput::Reshare(new_keyshare.0))
         },
         SessionId::Dkg { .. } => {

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -153,6 +153,7 @@ async fn handle_socket_result(socket: WebSocket, app_state: AppState) {
     };
 }
 
+#[allow(clippy::type_complexity)]
 #[tracing::instrument(
     skip_all,
     fields(validators_info, verifying_key, my_subgroup),
@@ -216,16 +217,9 @@ pub async fn do_proactive_refresh(
     )
     .await?;
 
-    let result = execute_proactive_refresh(
-        session_id,
-        channels,
-        signer.signer(),
-        tss_accounts,
-        old_key.verifying_key(),
-        old_key.threshold(),
-        inputs,
-    )
-    .await?;
+    let result =
+        execute_proactive_refresh(session_id, channels, signer.signer(), tss_accounts, inputs)
+            .await?;
     Ok(result)
 }
 

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -204,15 +204,8 @@ pub async fn do_proactive_refresh(
     )
     .await?;
 
-    let result = execute_reshare(
-        session_id,
-        channels,
-        signer.signer(),
-        tss_accounts,
-        inputs,
-        Some(aux_info),
-    )
-    .await?;
+    let result =
+        execute_reshare(session_id, channels, signer.signer(), inputs, Some(aux_info)).await?;
     Ok(result)
 }
 

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -13,8 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::Duration;
-
 use axum::{
     body::Bytes,
     extract::{
@@ -27,9 +25,12 @@ use axum::{
 use blake2::{Blake2s256, Digest};
 use entropy_protocol::{
     execute_protocol::{execute_proactive_refresh, Channels},
-    KeyParams, KeyShareWithAuxInfo, Listener, PartyId, SessionId, ValidatorInfo,
+    protocol_transport::Broadcaster,
+    KeyParams, KeyShareWithAuxInfo, Listener, PartyId, ProtocolMessage, SessionId, ValidatorInfo,
 };
 use parity_scale_codec::Encode;
+use std::{collections::BTreeSet, time::Duration};
+use tokio::sync::mpsc;
 
 use entropy_kvdb::kv_manager::{
     helpers::{deserialize, serialize as key_serialize},
@@ -45,7 +46,7 @@ use subxt::{
     utils::{AccountId32 as SubxtAccountId32, Static},
     OnlineClient,
 };
-use synedrion::{AuxInfo, ThresholdKeyShare};
+use synedrion::{AuxInfo, KeyResharingInputs, NewHolder, OldHolder, ThresholdKeyShare};
 use tokio::time::timeout;
 use x25519_dalek::StaticSecret;
 
@@ -102,7 +103,7 @@ pub async fn proactive_refresh(
             ) = deserialize(&old_key_share)
                 .ok_or_else(|| ProtocolErr::Deserialization("Failed to load KeyShare".into()))?;
 
-            let new_key_share = do_proactive_refresh(
+            let (new_key_share, _broadcaster, _rx) = do_proactive_refresh(
                 &ocw_data.validators_info,
                 &signer,
                 &x25519_secret_key,
@@ -165,7 +166,10 @@ pub async fn do_proactive_refresh(
     verifying_key: Vec<u8>,
     old_key: ThresholdKeyShare<KeyParams, PartyId>,
     block_number: u32,
-) -> Result<ThresholdKeyShare<KeyParams, PartyId>, ProtocolErr> {
+) -> Result<
+    (ThresholdKeyShare<KeyParams, PartyId>, Broadcaster, mpsc::Receiver<ProtocolMessage>),
+    ProtocolErr,
+> {
     tracing::debug!("Preparing to perform proactive refresh");
     tracing::debug!("Signing with {:?}", &signer.signer().public());
 
@@ -189,31 +193,39 @@ pub async fn do_proactive_refresh(
         tss_accounts.push(tss_account);
     }
 
-    // subscribe to all other participating parties. Listener waits for other subscribers.
-    let (rx_ready, rx_from_others, listener) =
-        Listener::new(converted_validator_info.clone(), &account_id);
-    state
-        .listeners
-        .lock()
-        .map_err(|_| ProtocolErr::SessionError("Error getting lock".to_string()))?
-        .insert(session_id.clone(), listener);
+    let party_ids: BTreeSet<PartyId> = tss_accounts.iter().cloned().map(PartyId::new).collect();
 
-    open_protocol_connections(
-        &converted_validator_info,
-        &session_id,
-        signer.signer(),
+    let inputs = KeyResharingInputs {
+        old_holder: Some(OldHolder { key_share: old_key.clone() }),
+        new_holder: Some(NewHolder {
+            verifying_key: old_key.verifying_key(),
+            old_threshold: party_ids.len(),
+            old_holders: party_ids.clone(),
+        }),
+        new_holders: party_ids.clone(),
+        new_threshold: old_key.threshold(),
+    };
+
+    let channels = get_channels(
         state,
+        converted_validator_info,
+        account_id,
+        &session_id,
+        signer,
         x25519_secret_key,
     )
     .await?;
-    let channels = {
-        let ready = timeout(Duration::from_secs(SETUP_TIMEOUT_SECONDS), rx_ready).await?;
-        let broadcast_out = ready??;
-        Channels(broadcast_out, rx_from_others)
-    };
-    let result =
-        execute_proactive_refresh(session_id, channels, signer.signer(), tss_accounts, old_key)
-            .await?;
+
+    let result = execute_proactive_refresh(
+        session_id,
+        channels,
+        signer.signer(),
+        tss_accounts,
+        old_key.verifying_key(),
+        old_key.threshold(),
+        inputs,
+    )
+    .await?;
     Ok(result)
 }
 
@@ -272,4 +284,35 @@ pub async fn validate_proactive_refresh(
         kv_manager.kv().reserve_key(LATEST_BLOCK_NUMBER_PROACTIVE_REFRESH.to_string()).await?;
     kv_manager.kv().put(reservation, latest_block_number.to_be_bytes().to_vec()).await?;
     Ok(())
+}
+
+pub async fn get_channels(
+    state: &ListenerState,
+    converted_validator_info: Vec<ValidatorInfo>,
+    account_id: SubxtAccountId32,
+    session_id: &SessionId,
+    signer: &PairSigner<EntropyConfig, sr25519::Pair>,
+    x25519_secret_key: &StaticSecret,
+) -> Result<Channels, ProtocolErr> {
+    // subscribe to all other participating parties. Listener waits for other subscribers.
+    let (rx_ready, rx_from_others, listener) =
+        Listener::new(converted_validator_info.clone(), &account_id);
+    state
+        .listeners
+        .lock()
+        .map_err(|_| ProtocolErr::SessionError("Error getting lock".to_string()))?
+        .insert(session_id.clone(), listener);
+
+    open_protocol_connections(
+        &converted_validator_info,
+        session_id,
+        signer.signer(),
+        state,
+        x25519_secret_key,
+    )
+    .await?;
+
+    let ready = timeout(Duration::from_secs(SETUP_TIMEOUT_SECONDS), rx_ready).await?;
+    let broadcast_out = ready??;
+    Ok(Channels(broadcast_out, rx_from_others))
 }

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -632,7 +632,7 @@ async fn test_store_share() {
 
     let mut new_verifying_key = vec![];
     // wait for registered event check that key exists in kvdb
-    for _ in 0..45 {
+    for _ in 0..65 {
         std::thread::sleep(std::time::Duration::from_millis(1000));
         let block_hash = rpc.chain_get_block_hash(None).await.unwrap();
         let events = EventsClient::new(api.clone()).at(block_hash.unwrap()).await.unwrap();

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -169,8 +169,7 @@ pub async fn new_reshare(
     .await?;
 
     let (new_key_share, aux_info) =
-        execute_reshare(session_id.clone(), channels, signer.signer(), tss_accounts, inputs, None)
-            .await?;
+        execute_reshare(session_id.clone(), channels, signer.signer(), inputs, None).await?;
 
     let serialized_key_share = key_serialize(&(new_key_share, aux_info))
         .map_err(|_| ProtocolErr::KvSerialize("Kv Serialize Error".to_string()))?;

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -23,9 +23,7 @@ use crate::{
         launch::{FORBIDDEN_KEYS, LATEST_BLOCK_NUMBER_RESHARE},
         substrate::{get_stash_address, get_validators_info, query_chain, submit_transaction},
     },
-    signing_client::{
-        api::get_channels, protocol_transport::open_protocol_connections, ProtocolErr,
-    },
+    signing_client::{api::get_channels, ProtocolErr},
     validator::errors::ValidatorErr,
     AppState,
 };
@@ -40,20 +38,19 @@ pub use entropy_protocol::{
     },
     KeyParams, KeyShareWithAuxInfo, Listener, PartyId, SessionId, ValidatorInfo,
 };
-use entropy_shared::{OcwMessageReshare, NETWORK_PARENT_KEY, SETUP_TIMEOUT_SECONDS};
+use entropy_shared::{OcwMessageReshare, NETWORK_PARENT_KEY};
 use parity_scale_codec::{Decode, Encode};
 use rand_core::OsRng;
 use sp_core::Pair;
-use std::{collections::BTreeSet, str::FromStr, time::Duration};
+use std::{collections::BTreeSet, str::FromStr};
 use subxt::{
     backend::legacy::LegacyRpcMethods, ext::sp_core::sr25519, tx::PairSigner, utils::AccountId32,
     OnlineClient,
 };
 use synedrion::{
-    make_aux_gen_session, make_key_resharing_session, sessions::SessionId as SynedrionSessionId,
-    AuxInfo, KeyResharingInputs, NewHolder, OldHolder,
+    make_aux_gen_session, sessions::SessionId as SynedrionSessionId, AuxInfo, KeyResharingInputs,
+    NewHolder, OldHolder,
 };
-use tokio::time::timeout;
 
 /// HTTP POST endpoint called by the off-chain worker (propagation pallet) during network reshare.
 ///
@@ -183,8 +180,6 @@ pub async fn new_reshare(
         channels,
         signer.signer(),
         tss_accounts,
-        decoded_verifying_key,
-        threshold as usize,
         inputs,
     )
     .await?;

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -184,10 +184,10 @@ pub async fn new_reshare(
     )
     .await?;
 
-    // // Setup channels for the next session
+    // Setup channels for the next session
     let channels = Channels(brodcaster, rx);
 
-    // // Now run an aux gen session
+    // Now run an aux gen session
     let session_id_hash = session_id.blake2(Some(Subsession::AuxGen))?;
     let session = make_aux_gen_session(
         &mut OsRng,


### PR DESCRIPTION
Related #941 

Refactors reshare to share code between proactive refresh and reshare, mainly by pulling key reshare inputs out to a hire level and passed through 