### PR TITLE
Don't lock pull request discussions after merge

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -50,3 +50,4 @@ jobs:
           exemptRepoOrgMembers: true
           remote-organization-name: entropyxyz
           remote-repository-name: .github
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
In #963 we introduced a CLA bot. By default, the package we used for that locks discussions on PRs
after they are merged, limiting them to collaborators.

The intent here is so that external contributors cannot revoke their CLA after the fact.

I've been finding it pretty annoying to have the discussions locked even as a collaborator (e.g I
can't react to messages). This also limits the potential for external contributors to point out bugs
or issues in PRs down the line, which isn't ideal.

I've changed the setting so that PRs aren't locked. I don't think the issue around contributors
changing their comments after the fact should be a big deal given than we're storing that signature
somewhere external.
