### PR TITLE
Add new registration flow test to TSS side

### DIFF
--- a/crates/threshold-signature-server/src/helpers/substrate.rs
+++ b/crates/threshold-signature-server/src/helpers/substrate.rs
@@ -82,11 +82,10 @@ pub async fn get_registered_details(
 
         let registered_info_query =
             entropy::storage().registry().registered_on_chain(BoundedVec(verifying_key));
-        let new_registration_info = query_chain(api, rpc, registered_info_query, None)
-            .await?
-            .ok_or_else(|| UserErr::ChainFetch("Not Registering error: Register Onchain first"))?;
 
-        new_registration_info
+        query_chain(api, rpc, registered_info_query, None)
+            .await?
+            .ok_or_else(|| UserErr::ChainFetch("Not Registering error: Register Onchain first"))?
     };
 
     Ok(registration_info)

--- a/crates/threshold-signature-server/src/helpers/substrate.rs
+++ b/crates/threshold-signature-server/src/helpers/substrate.rs
@@ -62,16 +62,34 @@ pub async fn get_program(
 }
 
 /// Returns a registered user's key visibility
+#[tracing::instrument(skip_all, fields(verifying_key))]
 pub async fn get_registered_details(
     api: &OnlineClient<EntropyConfig>,
     rpc: &LegacyRpcMethods<EntropyConfig>,
     verifying_key: Vec<u8>,
 ) -> Result<RegisteredInfo, UserErr> {
-    let registered_info_query = entropy::storage().registry().registered(BoundedVec(verifying_key));
-    let result = query_chain(api, rpc, registered_info_query, None)
-        .await?
-        .ok_or_else(|| UserErr::ChainFetch("Not Registering error: Register Onchain first"))?;
-    Ok(result)
+    tracing::info!("Querying chain for registration info.");
+
+    let registered_info_query =
+        entropy::storage().registry().registered(BoundedVec(verifying_key.clone()));
+    let registered_result = query_chain(api, rpc, registered_info_query, None).await?;
+
+    let registration_info = if let Some(old_registration_info) = registered_result {
+        old_registration_info
+    } else {
+        // We failed with the old registration path, let's try the new one
+        tracing::warn!("Didn't find user in old `Registered` struct, trying new one");
+
+        let registered_info_query =
+            entropy::storage().registry().registered_on_chain(BoundedVec(verifying_key));
+        let new_registration_info = query_chain(api, rpc, registered_info_query, None)
+            .await?
+            .ok_or_else(|| UserErr::ChainFetch("Not Registering error: Register Onchain first"))?;
+
+        new_registration_info
+    };
+
+    Ok(registration_info)
 }
 
 /// Takes Stash keys and returns validator info from chain

--- a/crates/threshold-signature-server/src/user/mod.rs
+++ b/crates/threshold-signature-server/src/user/mod.rs
@@ -31,7 +31,7 @@ use subxt::ext::sp_runtime::AccountId32;
 pub use self::errors::*;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 /// User input, contains key (substrate key) and value (entropy shard)
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -88,6 +88,7 @@ use subxt::{
     Config, OnlineClient,
 };
 use subxt_signer::ecdsa::PublicKey as EcdsaPublicKey;
+use synedrion::{ecdsa::VerifyingKey as SynedrionVerifyingKey, DeriveChildKey};
 use synedrion::{
     k256::ecdsa::{RecoveryId, Signature as k256Signature, VerifyingKey},
     AuxInfo, ThresholdKeyShare,
@@ -1323,6 +1324,107 @@ async fn test_faucet() {
     clean_tests();
 }
 
+#[tokio::test]
+#[serial]
+async fn test_new_registration_flow() {
+    initialize_test_logger().await;
+    clean_tests();
+
+    let alice = AccountKeyring::Alice;
+    let bob = AccountKeyring::Bob;
+    let charlie = AccountKeyring::Charlie;
+
+    let add_parent_key_to_kvdb = true;
+    let (_validator_ips, _validator_ids) = spawn_testing_validators(add_parent_key_to_kvdb).await;
+
+    // Here we need to use `--chain=integration-tests` force authoring otherwise we won't be able
+    // to get our chain in the right state to be jump started.
+    let force_authoring = true;
+    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+
+    // We first need to jump start the network and grab the resulting network wide verifying key
+    // for later
+    jump_start_network(&entropy_api, &rpc).await;
+
+    let jump_start_progress_query = entropy::storage().staking_extension().jump_start_progress();
+    let jump_start_progress =
+        query_chain(&entropy_api, &rpc, jump_start_progress_query, None).await.unwrap().unwrap();
+
+    let network_verifying_key = jump_start_progress.verifying_key.unwrap().0;
+
+    // We need to store a program in order to be able to register succesfully
+    let program_hash = store_program(
+        &entropy_api,
+        &rpc,
+        &bob.pair(), // This is our program deployer
+        TEST_PROGRAM_WASM_BYTECODE.to_owned(),
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    let registration_request = put_new_register_request_on_chain(
+        &entropy_api,
+        &rpc,
+        &alice,                         // This is our signature request account
+        charlie.to_account_id().into(), // This is our program modification account
+        BoundedVec(vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }]),
+    )
+    .await;
+
+    assert!(
+        matches!(registration_request, Ok(_)),
+        "We expect our registration request to succeed."
+    );
+
+    let entropy::registry::events::AccountRegistered(
+        _actual_signature_request_account,
+        actual_verifying_key,
+    ) = registration_request.unwrap();
+
+    // This is slightly more convenient to work with later one
+    let actual_verifying_key = actual_verifying_key.0;
+
+    // Next we want to check that the info that's on-chain is what we actually expect
+    let registered_info = crate::helpers::substrate::get_registered_details(
+        &entropy_api,
+        &rpc,
+        actual_verifying_key.to_vec(),
+    )
+    .await;
+
+    assert!(
+        matches!(registered_info, Ok(_)),
+        "We expect that the verifying key we got back matches registration entry in storage."
+    );
+
+    assert_eq!(
+        registered_info.unwrap().program_modification_account,
+        charlie.to_account_id().into()
+    );
+
+    // Next, let's check that the child verifying key matches
+    let network_verifying_key =
+        SynedrionVerifyingKey::try_from(network_verifying_key.as_slice()).unwrap();
+
+    // We hardcode the derivation path here since we know that there's only been one registration
+    // request (ours).
+    let derivation_path = "m/0/0".parse().unwrap();
+    let expected_verifying_key =
+        network_verifying_key.derive_verifying_key_bip32(&derivation_path).unwrap();
+    let expected_verifying_key = expected_verifying_key.to_encoded_point(true).as_bytes().to_vec();
+
+    assert_eq!(
+        expected_verifying_key, actual_verifying_key,
+        "The derived child key doesn't match our registered verifying key."
+    );
+
+    clean_tests();
+}
 #[tokio::test]
 #[serial]
 async fn test_mutiple_confirm_done() {

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -143,15 +143,6 @@ pub mod pallet {
                         version_number: T::KeyVersionNumber::get(),
                     },
                 );
-
-                RegisteredOnChain::<T>::insert(
-                    verifying_key.clone(),
-                    RegisteredInfo {
-                        programs_data: BoundedVec::default(),
-                        program_modification_account: account_id.clone(),
-                        version_number: T::KeyVersionNumber::get(),
-                    },
-                );
             }
         }
     }


### PR DESCRIPTION
While working on the signing flow I realized that there wasn't a test checking the new
registration flow on the TSS side (which is a pre-requisite to doing signing).

I've added a mostly happy-path test for registration. I don't really want to get bogged
down in checking all the failure scenarios until after the signing flow is done.
