### PR TITLE
Delete old keyshare if not in next_signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ At the moment this project **does not** adhere to
 - Reshare confirmation ([#965](https://github.com/entropyxyz/entropy-core/pull/965))
 - Set inital signers ([#971](https://github.com/entropyxyz/entropy-core/pull/971))
 - Add parent key threshold dynamically ([#974](https://github.com/entropyxyz/entropy-core/pull/974))
-- Delete old keyshare if not in next_signers ([#999](https://github.com/entropyxyz/entropy-core/pull/999))
 - TSS attestation endpoint ([#1001](https://github.com/entropyxyz/entropy-core/pull/1001))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ At the moment this project **does not** adhere to
 - Reshare confirmation ([#965](https://github.com/entropyxyz/entropy-core/pull/965))
 - Set inital signers ([#971](https://github.com/entropyxyz/entropy-core/pull/971))
 - Add parent key threshold dynamically ([#974](https://github.com/entropyxyz/entropy-core/pull/974))
+- Delete old keyshare if not in next_signers ([#999](https://github.com/entropyxyz/entropy-core/pull/999))
 
 ### Changed
 - Fix TSS `AccountId` keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -99,8 +99,12 @@ pub async fn new_reshare(
     )
     .map_err(|e| ValidatorErr::VerifyingKeyError(e.to_string()))?;
 
-    let is_proper_signer =
-        is_proper_signer(signer.account_id(), validators_info.clone(), &app_state.kv_store).await?;
+    let is_proper_signer = is_signer_or_delete_parent_key(
+        signer.account_id(),
+        validators_info.clone(),
+        &app_state.kv_store,
+    )
+    .await?;
 
     if !is_proper_signer {
         return Ok(StatusCode::MISDIRECTED_REQUEST);
@@ -361,7 +365,7 @@ pub async fn prune_old_holders(
 }
 
 /// Checks if TSS is a proper signer and if isn't deletes their parent key if they have one
-pub async fn is_proper_signer(
+pub async fn is_signer_or_delete_parent_key(
     account_id: &AccountId32,
     validators_info: Vec<ValidatorInfo>,
     kv_manager: &KvManager,

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -371,13 +371,14 @@ pub async fn is_signer_or_delete_parent_key(
     kv_manager: &KvManager,
 ) -> Result<bool, ValidatorErr> {
     let is_proper_signer =
-        &validators_info.iter().any(|validator_info| validator_info.tss_account == *account_id);
-    if *is_proper_signer {
+        validators_info.iter().any(|validator_info| validator_info.tss_account == *account_id);
+    if is_proper_signer {
         Ok(true)
     } else {
         // delete old keyshare if has it and not next_signer
-        if kv_manager.kv().exists(&hex::encode(NETWORK_PARENT_KEY)).await? {
-            kv_manager.kv().delete(&hex::encode(NETWORK_PARENT_KEY)).await?
+        let network_key = hex::encode(NETWORK_PARENT_KEY);
+        if kv_manager.kv().exists(&network_key).await? {
+            kv_manager.kv().delete(&network_key).await?
         }
         Ok(false)
     }

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -104,6 +104,10 @@ pub async fn new_reshare(
         .any(|validator_info| validator_info.tss_account == *signer.account_id());
 
     if !is_proper_signer {
+        // delete old keyshare if has it and not next_signer
+        if app_state.kv_store.kv().exists(&hex::encode(NETWORK_PARENT_KEY)).await? {
+            app_state.kv_store.kv().delete(&hex::encode(NETWORK_PARENT_KEY)).await?
+        }
         return Ok(StatusCode::MISDIRECTED_REQUEST);
     }
 

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -30,7 +30,7 @@ use crate::{
         validator::get_signer_and_x25519_secret_from_mnemonic,
     },
     validator::{
-        api::{prune_old_holders, validate_new_reshare},
+        api::{is_proper_signer, prune_old_holders, validate_new_reshare},
         errors::ValidatorErr,
     },
 };
@@ -254,4 +254,24 @@ async fn test_forbidden_keys() {
 
     let should_pass = check_forbidden_key("test");
     assert_eq!(should_pass.unwrap(), ());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_deletes_key() {
+    initialize_test_logger().await;
+    clean_tests();
+
+    let dave = AccountKeyring::Dave;
+    let kv = setup_client().await;
+    let reservation = kv.kv().reserve_key(hex::encode(NETWORK_PARENT_KEY)).await.unwrap();
+    kv.kv().put(reservation, vec![10]).await.unwrap();
+
+    let is_proper_signer_result =
+        is_proper_signer(&dave.to_account_id().into(), vec![], &kv).await.unwrap();
+    assert!(!is_proper_signer_result);
+
+    let has_key = kv.kv().exists(&hex::encode(NETWORK_PARENT_KEY)).await.unwrap();
+    assert!(!has_key);
+    clean_tests();
 }

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -30,7 +30,7 @@ use crate::{
         validator::get_signer_and_x25519_secret_from_mnemonic,
     },
     validator::{
-        api::{is_proper_signer, prune_old_holders, validate_new_reshare},
+        api::{is_signer_or_delete_parent_key, prune_old_holders, validate_new_reshare},
         errors::ValidatorErr,
     },
 };

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -268,7 +268,7 @@ async fn test_deletes_key() {
     kv.kv().put(reservation, vec![10]).await.unwrap();
 
     let is_proper_signer_result =
-        is_proper_signer(&dave.to_account_id().into(), vec![], &kv).await.unwrap();
+        is_signer_or_delete_parent_key(&dave.to_account_id().into(), vec![], &kv).await.unwrap();
     assert!(!is_proper_signer_result);
 
     let has_key = kv.kv().exists(&hex::encode(NETWORK_PARENT_KEY)).await.unwrap();


### PR DESCRIPTION
Related #941 

- [x] Delete old key if not a new signer (includes making the test for reshare in TSS actually rotate the signers not just do a reshare)