### PR TITLE
Add `network-jumpstart` command to `entropy-test-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ At the moment this project **does not** adhere to
 - Set inital signers ([#971](https://github.com/entropyxyz/entropy-core/pull/971))
 - Add parent key threshold dynamically ([#974](https://github.com/entropyxyz/entropy-core/pull/974))
 - TSS attestation endpoint ([#1001](https://github.com/entropyxyz/entropy-core/pull/1001))
+- Add `network-jumpstart` command to `entropy-test-cli` ([#1004](https://github.com/entropyxyz/entropy-core/pull/1004))
 
 ### Changed
 - Fix TSS `AccountId` keys in chainspec ([#993](https://github.com/entropyxyz/entropy-core/pull/993))

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -33,7 +33,7 @@ anyhow          ="1.0.86"
 
 # Only for the browser
 js-sys={ version="0.3.70", optional=true }
-tokio ="1.39"
+tokio ={ version="1.39", features=["time"] }
 
 [dev-dependencies]
 serial_test          ="3.1.1"

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -369,6 +369,18 @@ pub async fn jumpstart_network(
     rpc: &LegacyRpcMethods<EntropyConfig>,
     signer: sr25519::Pair,
 ) -> Result<(), ClientError> {
+    // We split the implementation out into an inner function so that we can more easily pass a
+    // single future to the `timeout`
+    tokio::time::timeout(std::time::Duration::from_secs(45), jumpstart_inner(api, rpc, signer))
+        .await
+        .map_err(|_| ClientError::JumpstartTimeout)?
+}
+
+async fn jumpstart_inner(
+    api: &OnlineClient<EntropyConfig>,
+    rpc: &LegacyRpcMethods<EntropyConfig>,
+    signer: sr25519::Pair,
+) -> Result<(), ClientError> {
     // In this case we don't care too much about the result because we're more interested in the
     // `FinishedNetworkJumpStart` event, which happens later on.
     let jump_start_request = entropy::tx().registry().jump_start_network();

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -360,3 +360,31 @@ pub async fn change_threshold_accounts(
         .ok_or(anyhow!("Error with transaction"))?;
     Ok(result_event)
 }
+
+/// Trigger a network wide distributed key generation (DKG) event.
+///
+/// Fails if the network has already been jumpstarted.
+pub async fn jumpstart_network(
+    api: &OnlineClient<EntropyConfig>,
+    rpc: &LegacyRpcMethods<EntropyConfig>,
+    signer: sr25519::Pair,
+) -> Result<(), ClientError> {
+    // In this case we don't care too much about the result because we're more interested in the
+    // `FinishedNetworkJumpStart` event, which happens later on.
+    let jump_start_request = entropy::tx().registry().jump_start_network();
+    let _result =
+        submit_transaction_with_pair(api, rpc, &signer, &jump_start_request, None).await?;
+
+    let mut blocks_sub = api.blocks().subscribe_finalized().await?;
+
+    while let Some(block) = blocks_sub.next().await {
+        let block = block?;
+        let events = block.events().await?;
+
+        if events.has::<entropy::registry::events::FinishedNetworkJumpStart>()? {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -66,6 +66,8 @@ pub enum ClientError {
     Subxt(#[from] subxt::Error),
     #[error("Timed out waiting for register confirmation")]
     RegistrationTimeout,
+    #[error("Timed out waiting for jumpstart confirmation")]
+    JumpstartTimeout,
     #[error("Cannot get subgroup: {0}")]
     SubgroupGet(#[from] SubgroupGetError),
     #[error("JSON: {0}")]


### PR DESCRIPTION
This PR adds a way to trigger a network jumpstart from the test CLI. This is useful for ensuring the
network is in the correct state before registering using the new registration flow.
