### PR TITLE
Add test showing register and sign with test client

### DIFF
--- a/crates/testing-utils/src/lib.rs
+++ b/crates/testing-utils/src/lib.rs
@@ -21,6 +21,8 @@ pub mod constants;
 pub mod create_test_keyshares;
 mod node_proc;
 pub mod substrate_context;
-pub use entropy_tss::helpers::tests::spawn_testing_validators;
+pub use entropy_tss::helpers::tests::{
+    jump_start_network_with_signer as jump_start_network, spawn_testing_validators,
+};
 pub use node_proc::TestNodeProcess;
 pub use substrate_context::*;

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -19,7 +19,7 @@ use bip39::{Language, Mnemonic};
 use blake3::hash;
 use entropy_client::substrate::get_registered_details;
 use entropy_client::{
-    client::{register, sign, store_program, update_programs},
+    client::{sign, store_program, update_programs},
     user::get_signers_from_chain,
 };
 use entropy_kvdb::{

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -19,7 +19,7 @@ use bip39::{Language, Mnemonic};
 use blake3::hash;
 use entropy_client::substrate::get_registered_details;
 use entropy_client::{
-    client::{sign, store_program, update_programs},
+    client::{register, sign, store_program, update_programs},
     user::get_signers_from_chain,
 };
 use entropy_kvdb::{
@@ -1554,6 +1554,81 @@ async fn test_new_registration_flow() {
 
     clean_tests();
 }
+
+#[tokio::test]
+#[serial]
+async fn test_client_register_and_sign() {
+    clean_tests();
+    let account_owner = AccountKeyring::Ferdie.pair();
+    let signature_request_author = AccountKeyring::One;
+
+    let add_parent_key = true;
+    let (_validator_ips, _validator_ids) = spawn_testing_validators(add_parent_key).await;
+
+    let force_authoring = true;
+    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let api = get_api(&substrate_context.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+
+    // Jumpstart the network
+    jump_start_network(&api, &rpc).await;
+
+    // Store a program
+    let program_pointer = store_program(
+        &api,
+        &rpc,
+        &account_owner,
+        TEST_PROGRAM_WASM_BYTECODE.to_owned(),
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    // Register, using that program
+    let (verifying_key, _registered_info) = {
+        let register_on_chain = true;
+        let mut registrations = register(
+            &api,
+            &rpc,
+            account_owner.clone(),
+            subxtAccountId32(account_owner.public().0),
+            BoundedVec(vec![ProgramInstance { program_pointer, program_config: vec![] }]),
+            register_on_chain,
+        )
+        .await
+        .unwrap();
+
+        registrations.pop().unwrap()
+    };
+
+    // Sign a message
+    let recoverable_signature = sign(
+        &api,
+        &rpc,
+        signature_request_author.pair(),
+        verifying_key,
+        PREIMAGE_SHOULD_SUCCEED.to_vec(),
+        Some(AUXILARY_DATA_SHOULD_SUCCEED.to_vec()),
+    )
+    .await
+    .unwrap();
+
+    // Check the signature
+    let message_should_succeed_hash = Hasher::keccak(PREIMAGE_SHOULD_SUCCEED);
+    let recovery_key_from_sig = VerifyingKey::recover_from_prehash(
+        &message_should_succeed_hash,
+        &recoverable_signature.signature,
+        recoverable_signature.recovery_id,
+    )
+    .unwrap();
+    assert_eq!(
+        verifying_key.to_vec(),
+        recovery_key_from_sig.to_encoded_point(true).to_bytes().to_vec()
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn test_mutiple_confirm_done() {

--- a/crates/threshold-signature-server/tests/register_and_sign.rs
+++ b/crates/threshold-signature-server/tests/register_and_sign.rs
@@ -1,0 +1,107 @@
+// Copyright (C) 2023 Entropy Cryptography Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use entropy_client::{
+    chain_api::{
+        entropy::runtime_types::bounded_collections::bounded_vec::BoundedVec,
+        entropy::runtime_types::pallet_registry::pallet::ProgramInstance, get_api, get_rpc,
+        EntropyConfig,
+    },
+    client as test_client, Hasher,
+};
+use entropy_kvdb::clean_tests;
+use entropy_testing_utils::{
+    constants::{
+        AUXILARY_DATA_SHOULD_SUCCEED, PREIMAGE_SHOULD_SUCCEED, TEST_PROGRAM_WASM_BYTECODE,
+    },
+    jump_start_network, spawn_testing_validators, test_node_process_testing_state,
+};
+use serial_test::serial;
+use sp_core::{sr25519, Pair};
+use sp_keyring::AccountKeyring;
+use subxt::{tx::PairSigner, utils::AccountId32};
+use synedrion::k256::ecdsa::VerifyingKey;
+
+#[tokio::test]
+#[serial]
+async fn integration_test_register_and_sign() {
+    clean_tests();
+    let account_owner = AccountKeyring::Ferdie.pair();
+    let signature_request_author = AccountKeyring::One;
+
+    let add_parent_key = true;
+    let (_validator_ips, _validator_ids) = spawn_testing_validators(add_parent_key).await;
+
+    let force_authoring = true;
+    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let api = get_api(&substrate_context.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+
+    // Jumpstart the network
+    let alice = AccountKeyring::Alice;
+    let signer = PairSigner::<EntropyConfig, sr25519::Pair>::new(alice.clone().into());
+    jump_start_network(&api, &rpc, &signer).await;
+
+    // Store a program
+    let program_pointer = test_client::store_program(
+        &api,
+        &rpc,
+        &account_owner,
+        TEST_PROGRAM_WASM_BYTECODE.to_owned(),
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    // Register, using that program
+    let register_on_chain = true;
+    let (verifying_key, _registered_info) = test_client::register(
+        &api,
+        &rpc,
+        account_owner.clone(),
+        AccountId32(account_owner.public().0),
+        BoundedVec(vec![ProgramInstance { program_pointer, program_config: vec![] }]),
+        register_on_chain,
+    )
+    .await
+    .unwrap();
+
+    // Sign a message
+    let recoverable_signature = test_client::sign(
+        &api,
+        &rpc,
+        signature_request_author.pair(),
+        verifying_key,
+        PREIMAGE_SHOULD_SUCCEED.to_vec(),
+        Some(AUXILARY_DATA_SHOULD_SUCCEED.to_vec()),
+    )
+    .await
+    .unwrap();
+
+    // Check the signature
+    let message_should_succeed_hash = Hasher::keccak(PREIMAGE_SHOULD_SUCCEED);
+    let recovery_key_from_sig = VerifyingKey::recover_from_prehash(
+        &message_should_succeed_hash,
+        &recoverable_signature.signature,
+        recoverable_signature.recovery_id,
+    )
+    .unwrap();
+    assert_eq!(
+        verifying_key.to_vec(),
+        recovery_key_from_sig.to_encoded_point(true).to_bytes().to_vec()
+    );
+}


### PR DESCRIPTION
@HCastano you don't need to merge this, i just wanted to see it passing.

I really wanted to make this an integration test, but it didn't work out.  The cool thing about the new registration flow is that we can test it in integration because it doesn't rely on there being multiple chain nodes.

But not quite. We have the pre-existing parent keyshares - but we don't have a way to get the chain to a state where jumpstart is completed. The staking extension pallet's genesis config would need to let us put the chain into a jump start completed state.  Something for another PR.