### PR TITLE
Fix test for rejecting a TSS node who is not part of the signing committe

### DIFF
--- a/crates/threshold-signature-server/src/signing_client/protocol_transport.rs
+++ b/crates/threshold-signature-server/src/signing_client/protocol_transport.rs
@@ -170,8 +170,7 @@ async fn handle_initial_incoming_ws_message(
     };
 
     {
-        // Check that the given public key matches the public key we got in the
-        // UserTransactionRequest or register transaction
+        // Check that the given public key is of the ones we are expecting for this protocol session
         let mut listeners = app_state
             .listener_state
             .listeners
@@ -186,8 +185,7 @@ async fn handle_initial_incoming_ws_message(
             // Make the signing process fail, since one of the commitee has misbehaved
             listeners.remove(&msg.session_id);
             return Err(SubscribeErr::Decryption(
-                "Public key does not match that given in UserTransactionRequest or register \
-                 transaction"
+                "Public key does not match any of those expected for this protocol session"
                     .to_string(),
             ));
         }


### PR DESCRIPTION
This is based off https://github.com/entropyxyz/entropy-core/pull/1026 and fixes the test which checks that a TSS server who is not a member of the expected signing committee is unable to participate in the signing protocol.

This test was actually pretty broken before - and i am to blame.  It was sending the signature request to one validator, and then attempting a bogus connection to another validator.  Which correctly failed because they were not expecting a signing session at all.  But what we want to test here is that when they are expecting a signing session, they will only allow members of the signing committee to connect.  