### PR TITLE
Bump tdx-quote - and specify a version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14130,10 +14130,11 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 [[package]]
 name = "tdx-quote"
 version = "0.1.0"
-source = "git+https://github.com/entropyxyz/tdx-quote#785cd6680e857cc527037befba185fb5f84ab806"
+source = "git+https://github.com/entropyxyz/tdx-quote?rev=f7968ff#f7968ff35ff744ff8c007cffe6ec8d709d7f18d9"
 dependencies = [
  "nom",
  "p256",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -57,21 +57,23 @@ uuid                    ={ version="1.10.0", features=["v4"] }
 
 # Misc
 tokio-tungstenite="0.23.1"
-bincode          ="1.3.3"
-bip32            ={ version="0.5.2" }
-bip39            ={ version="2.0.0", features=["zeroize"] }
-bytes            ={ version="1.7", default-features=false, features=["serde"] }
-base64           ="0.22.1"
-clap             ={ version="4.5.17", features=["derive"] }
-num              ="0.4.3"
-snow             ="0.9.6"
-sha3             ="0.10.8"
-hostname         ="0.4"
-sha1             ="0.10.6"
-sha2             ="0.10.8"
-hkdf             ="0.12.4"
-project-root     ={ version="0.2.2", optional=true }
-tdx-quote        ={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff", optional=true, features=["mock"] }
+bincode="1.3.3"
+bip32={ version="0.5.2" }
+bip39={ version="2.0.0", features=["zeroize"] }
+bytes={ version="1.7", default-features=false, features=["serde"] }
+base64="0.22.1"
+clap={ version="4.5.17", features=["derive"] }
+num="0.4.3"
+snow="0.9.6"
+sha3="0.10.8"
+hostname="0.4"
+sha1="0.10.6"
+sha2="0.10.8"
+hkdf="0.12.4"
+project-root={ version="0.2.2", optional=true }
+tdx-quote={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff", optional=true, features=[
+  "mock",
+] }
 
 [dev-dependencies]
 serial_test ="3.1.1"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -71,7 +71,7 @@ sha1             ="0.10.6"
 sha2             ="0.10.8"
 hkdf             ="0.12.4"
 project-root     ={ version="0.2.2", optional=true }
-tdx-quote        ={ git="https://github.com/entropyxyz/tdx-quote", optional=true, features=["mock"] }
+tdx-quote        ={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff", optional=true, features=["mock"] }
 
 [dev-dependencies]
 serial_test ="3.1.1"
@@ -85,7 +85,7 @@ ethers-core ="2.0.14"
 schnorrkel  ={ version="0.11.4", default-features=false, features=["std"] }
 schemars    ={ version="0.8.21" }
 subxt-signer="0.35.3"
-tdx-quote   ={ git="https://github.com/entropyxyz/tdx-quote", features=["mock"] }
+tdx-quote   ={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff", features=["mock"] }
 
 # Note: We don't specify versions here because otherwise we run into a cyclical dependency between
 # `entropy-tss` and `entropy-testing-utils` when we try and publish the `entropy-tss` crate.

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -27,7 +27,7 @@ entropy-shared={ version="0.2.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 pallet-staking-extension={ version="0.2.0", path="../staking", default-features=false }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote" }
+tdx-quote={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff" }
 
 [dev-dependencies]
 pallet-session                 ={ version="29.0.0", default-features=false }
@@ -38,7 +38,7 @@ pallet-timestamp               ={ version="28.0.0", default-features=false }
 sp-npos-elections              ={ version="27.0.0", default-features=false }
 frame-election-provider-support={ version="29.0.0", default-features=false }
 pallet-staking-reward-curve    ={ version="11.0.0" }
-tdx-quote                      ={ git="https://github.com/entropyxyz/tdx-quote", features=["mock"] }
+tdx-quote                      ={ git="https://github.com/entropyxyz/tdx-quote", rev="f7968ff", features=["mock"] }
 rand_core                      ="0.6.4"
 
 [features]


### PR DESCRIPTION
This explicitly specifies which commit of TDX quote is used, and uses the latest commit which has changes for parsing the certification data.  Once the TDX attestation feature is done (and before the next release), this crate will be published and we can use a release version number.

I closed https://github.com/entropyxyz/entropy-core/pull/1044 in favor of this.