### PR TITLE
Run TSS tests in parallel

### DIFF
--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run `cargo build && cargo test`
         run: |
           pushd node
-          cargo build -p entropy-tss --all-targets --release -j $(nproc)
-          cargo test -p entropy-tss --all-targets --release -j 4 -- user::tests validator::tests
+          cargo build --all-targets --release -j $(nproc)
+          cargo test -p entropy-tss --all-targets --release -- user::tests validator::tests --test-threads 4
           yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm -j 4

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -1,12 +1,13 @@
 ---
 name: "Build and test"
-on:
-  push:
-    paths:
-      - "node/**"
-      - "crates/**"
-      - "pallets/**"
-      - "runtime/**"
+on: ["push"]
+# on:
+  # push:
+      # paths:
+      #   - "node/**"
+      #   - "crates/**"
+      #   - "pallets/**"
+      #   - "runtime/**"
 
 jobs:
  node-test:
@@ -34,6 +35,6 @@ jobs:
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
-          cargo test -p entropy-tss --all-targets --release -- user::tests validator::tests --test-threads 4
+          cargo test -p entropy-tss --all-targets --release -- user::tests validator::tests --test-threads 1 --nocapture
           yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm -j 4

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -1,6 +1,7 @@
 ---
 name: "Build and test"
 on: ["push"]
+
 # on:
   # push:
       # paths:

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run `cargo build && cargo test`
         run: |
           pushd node
-          cargo build --all-targets --release -j $(nproc)
-          cargo test --all-targets --release -j 4 -- user::tests validator::tests
+          cargo build -p entropy-tss --all-targets --release -j $(nproc)
+          cargo test -p entropy-tss --all-targets --release -j 4 -- user::tests validator::tests
           yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm -j 4

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -37,4 +37,4 @@ jobs:
           cargo build --all-targets --release -j $(nproc)
           cargo test -p entropy-tss --all-targets --release -- user::tests validator::tests --test-threads 1 --nocapture
           yarn --cwd ../crates/protocol/nodejs-test test
-          cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm -j 4
+          cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -34,6 +34,6 @@ jobs:
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
-          cargo test --all-targets --release
+          cargo test --all-targets --release -j 4 -- user::tests validator::tests
           yarn --cwd ../crates/protocol/nodejs-test test
-          cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm
+          cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm -j 4

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -35,6 +35,6 @@ jobs:
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
-          cargo test -p entropy-tss --all-targets --release -- user::tests validator::tests --test-threads 1 --nocapture
+        cargo test -p entropy-tss --all-targets --release -- user::tests::signature_request_with_derived_account_works user::tests::test_signature_requests_fail_on_different_conditions --nocapture
           yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -36,6 +36,6 @@ jobs:
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
-        cargo test -p entropy-tss --all-targets --release -- user::tests::signature_request_with_derived_account_works user::tests::test_signature_requests_fail_on_different_conditions --nocapture
+          cargo test -p entropy-tss --all-targets --release -- user::tests::signature_request_with_derived_account_works user::tests::test_signature_requests_fail_on_different_conditions --nocapture
           yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,7 @@ dependencies = [
  "num",
  "parity-scale-codec",
  "project-root",
+ "rand",
  "rand_core 0.6.4",
  "reqwest",
  "reqwest-eventsource",

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -144,7 +144,7 @@ impl TestNodeProcessBuilder {
         // TODO (Nando): Maybe do this like we do in the TSS startup
         //
         // wait for rpc to be initialized
-        const MAX_ATTEMPTS: u32 = 6; // 10;
+        const MAX_ATTEMPTS: u32 = 10; // 6;
         let mut attempts = 1;
         let mut wait_secs = 1;
         let client = loop {

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -129,7 +129,7 @@ impl TestNodeProcessBuilder {
             cmd.arg(format!("--port={p2p_port}"));
             cmd.arg(format!("--rpc-port={ws_port}"));
             tracing::info!("ws port: {ws_port}");
-            ws_port
+            dbg!(ws_port)
         } else {
             // the default Websockets port
             9944
@@ -140,8 +140,11 @@ impl TestNodeProcessBuilder {
         let mut proc = cmd.spawn().map_err(|e| {
             format!("Error spawning substrate node '{}': {e}", self.node_path.to_string_lossy())
         })?;
+
+        // TODO (Nando): Maybe do this like we do in the TSS startup
+        //
         // wait for rpc to be initialized
-        const MAX_ATTEMPTS: u32 = 6;
+        const MAX_ATTEMPTS: u32 = 6; // 10;
         let mut attempts = 1;
         let mut wait_secs = 1;
         let client = loop {
@@ -157,7 +160,10 @@ impl TestNodeProcessBuilder {
                 Err(err) => {
                     if attempts < MAX_ATTEMPTS {
                         attempts += 1;
+
+                        // TODO (Nando): Try making constant
                         wait_secs *= 2; // backoff
+
                         continue;
                     }
                     break Err(err);

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -84,6 +84,7 @@ pub async fn test_node(
 
     let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
         .with_authority(key)
+        .scan_for_open_ports()
         .spawn::<EntropyConfig>()
         .await;
     proc.unwrap()

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -85,7 +85,6 @@ pub async fn test_node(
 
     let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
         .with_authority(key)
-        .scan_for_open_ports()
         .spawn::<EntropyConfig>()
         .await;
     proc.unwrap()

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -56,6 +56,7 @@ fn get_path() -> Box<std::path::Path> {
     }
 }
 
+// TODO (Nando): Remove this
 pub type NodeRuntimeSignedExtra = SubstrateExtrinsicParams<EntropyConfig>;
 
 pub async fn test_node_process_with(
@@ -130,6 +131,62 @@ pub async fn testing_context() -> SubstrateTestingContext {
 /// Construct a new testing context for when we only need one Substrate node.
 pub async fn test_context_stationary() -> SubstrateTestingContext {
     let node_proc: TestNodeProcess<EntropyConfig> = test_node_process_stationary().await;
+    let api = node_proc.client().clone();
+    SubstrateTestingContext { node_proc, api }
+}
+
+/// Construct a new testing context for when we only need one Substrate node.
+pub async fn development_node_with_default_config() -> SubstrateTestingContext {
+    let key = AccountKeyring::Alice;
+    let path = get_path();
+    let path = path.to_str().expect("Path should've been checked to be valid earlier.");
+    let chain_type = "--dev".to_string();
+    let force_authoring = false;
+
+    let node_proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
+        .with_authority(key)
+        .spawn::<EntropyConfig>()
+        .await
+        .unwrap();
+
+    let api = node_proc.client().clone();
+    SubstrateTestingContext { node_proc, api }
+}
+
+/// Construct a new testing context for when we only need one Substrate node.
+pub async fn integration_test_node_with_default_port() -> SubstrateTestingContext {
+    let key = AccountKeyring::Alice;
+    let path = get_path();
+    let path = path.to_str().expect("Path should've been checked to be valid earlier.");
+    let chain_type = "--chain=integration-tests".to_string();
+    let force_authoring = true;
+
+    let node_proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
+        .with_authority(key)
+        .spawn::<EntropyConfig>()
+        .await
+        .unwrap();
+
+    let api = node_proc.client().clone();
+    SubstrateTestingContext { node_proc, api }
+}
+
+
+/// Construct a new testing context for when we only need one Substrate node.
+pub async fn integration_test_node_with_unique_ports() -> SubstrateTestingContext {
+    let key = AccountKeyring::Alice;
+    let path = get_path();
+    let path = path.to_str().expect("Path should've been checked to be valid earlier.");
+    let chain_type = "--chain=integration-tests".to_string();
+    let force_authoring = true;
+
+    let node_proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
+        .with_authority(key)
+        .scan_for_open_ports()
+        .spawn::<EntropyConfig>()
+        .await
+        .unwrap();
+
     let api = node_proc.client().clone();
     SubstrateTestingContext { node_proc, api }
 }

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -171,7 +171,6 @@ pub async fn integration_test_node_with_default_port() -> SubstrateTestingContex
     SubstrateTestingContext { node_proc, api }
 }
 
-
 /// Construct a new testing context for when we only need one Substrate node.
 pub async fn integration_test_node_with_unique_ports() -> SubstrateTestingContext {
     let key = AccountKeyring::Alice;

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -74,7 +74,7 @@ project-root     ={ version="0.2.2", optional=true }
 tdx-quote        ={ git="https://github.com/entropyxyz/tdx-quote", optional=true, features=["mock"] }
 
 # Using this in the `helpers` right now
-rand              ="0.8.5"
+rand="0.8.5"
 
 [dev-dependencies]
 serial_test ="3.1.1"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -73,6 +73,9 @@ hkdf             ="0.12.4"
 project-root     ={ version="0.2.2", optional=true }
 tdx-quote        ={ git="https://github.com/entropyxyz/tdx-quote", optional=true, features=["mock"] }
 
+# Using this in the `helpers` right now
+rand              ="0.8.5"
+
 [dev-dependencies]
 serial_test ="3.1.1"
 hex-literal ="0.4.1"

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -352,6 +352,7 @@ pub async fn spawn_testing_validators_parallel(
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let ips = ports.iter().map(|port| format!("127.0.0.1:{port}")).collect();
+    dbg!(&ips);
     (ips, ids)
 }
 

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -52,7 +52,7 @@ use entropy_testing_utils::{
     },
     substrate_context::{
         test_context_stationary, test_node_process_testing_state, testing_context,
-        SubstrateTestingContext,
+        SubstrateTestingContext, development_node_with_default_config, integration_test_node_with_unique_ports
     },
 };
 use futures::{
@@ -122,7 +122,7 @@ use crate::{
         substrate::{get_oracle_data, query_chain, submit_transaction},
         tests::{
             create_clients, initialize_test_logger, jump_start_network_with_signer, remove_program,
-            run_to_block, setup_client, spawn_testing_validators, spawn_testing_validators_inner,
+            run_to_block, setup_client, spawn_testing_validators, spawn_testing_validators_parallel,
             unsafe_get, ChainSpecType,
         },
         user::compute_hash,
@@ -183,7 +183,7 @@ async fn test_signature_requests_fail_on_different_conditions() {
     dbg!(&substrate_context.ws_url);
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -360,7 +360,7 @@ async fn signature_request_with_derived_account_works() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -448,7 +448,7 @@ async fn test_signing_fails_if_wrong_participants_are_used() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -535,7 +535,7 @@ async fn test_request_limit_are_updated_during_signing() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -663,7 +663,7 @@ async fn test_request_limit_are_updated_during_signing() {
 // #[serial]
 async fn test_fails_to_sign_if_non_signing_group_participants_are_used() {
     initialize_test_logger().await;
-    clean_tests();
+    // clean_tests();
 
     // let one = AccountKeyring::One;
     // let two = AccountKeyring::Two;
@@ -679,7 +679,7 @@ async fn test_fails_to_sign_if_non_signing_group_participants_are_used() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -789,7 +789,7 @@ async fn test_fails_to_sign_if_non_signing_group_participants_are_used() {
 
     assert!(connection_attempt_handle.await.unwrap());
 
-    clean_tests();
+    // clean_tests();
 }
 
 #[tokio::test]
@@ -814,7 +814,7 @@ async fn test_program_with_config() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -912,11 +912,13 @@ async fn test_jumpstart_network() {
 
     let alice = AccountKeyring::Alice;
 
-    let cxt = test_context_stationary().await;
-    let (_validator_ips, _validator_ids) =
-        spawn_testing_validators(false, ChainSpecType::Development).await;
+    // let cxt = test_context_stationary().await;
+    let cxt = development_node_with_default_config().await;
+
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
+    let (_validator_ips, _validator_ids) =
+        spawn_testing_validators(false, ChainSpecType::Development).await;
 
     let client = reqwest::Client::new();
 
@@ -1138,7 +1140,7 @@ async fn test_fail_infinite_program() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -1245,7 +1247,7 @@ async fn test_device_key_proxy() {
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
-    let (validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -1575,7 +1577,7 @@ async fn test_new_registration_flow() {
     dbg!(&substrate_context.ws_url);
 
     let add_parent_key_to_kvdb = true;
-    let (_validator_ips, _validator_ids) = spawn_testing_validators_inner(
+    let (_validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
         substrate_context.ws_url.clone(),
@@ -1662,13 +1664,14 @@ async fn test_new_registration_flow() {
 
 // TODO (Nando): Failing alongside `test_get_oracle_data`
 #[tokio::test]
-#[ignore]
-// #[serial]
+#[serial]
 async fn test_increment_or_wipe_request_limit() {
     initialize_test_logger().await;
-    // clean_tests();
+    clean_tests();
 
-    let substrate_context = test_context_stationary().await;
+    // let substrate_context = test_context_stationary().await;
+    let substrate_context = development_node_with_default_config().await;
+
     let api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
     let kv_store = load_kv_store(&None, None).await;
@@ -1708,17 +1711,18 @@ async fn test_increment_or_wipe_request_limit() {
     .map_err(|e| e.to_string());
     assert_eq!(err_too_many_requests, Err("Too many requests - wait a block".to_string()));
 
-    // clean_tests();
+    clean_tests();
 }
 
 // TODO (Nando): Failing alongside `test_increment_or_wipe_request_limit`
 #[tokio::test]
-#[ignore]
-// #[serial_test::serial]
+#[serial]
 async fn test_get_oracle_data() {
     initialize_test_logger().await;
 
-    let cxt = testing_context().await;
+    // let cxt = testing_context().await;
+    let cxt = development_node_with_default_config().await;
+
     setup_client().await;
 
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
@@ -1798,43 +1802,4 @@ pub async fn jump_start_network(
     let alice = AccountKeyring::Alice;
     let signer = PairSigner::<EntropyConfig, sr25519::Pair>::new(alice.clone().into());
     jump_start_network_with_signer(api, rpc, &signer).await;
-}
-
-#[tokio::test]
-async fn can_set_up_in_parallel_1() {
-    initialize_test_logger().await;
-    // clean_tests();
-
-    let add_parent_key_to_kvdb = true;
-    let (_validator_ips, _validator_ids) =
-        spawn_testing_validators(add_parent_key_to_kvdb, ChainSpecType::Integration).await;
-
-    // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
-    // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let _entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let _rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
-
-    // clean_tests();
-}
-
-#[tokio::test]
-async fn can_set_up_in_parallel_2() {
-    initialize_test_logger().await;
-    // clean_tests();
-
-    let add_parent_key_to_kvdb = true;
-    let (_validator_ips, _validator_ids) =
-        spawn_testing_validators(add_parent_key_to_kvdb, ChainSpecType::Integration).await;
-
-    // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
-    // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let _entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let _rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
-
-    // TODO (Nando): We may still need to clean up the test folder somehow
-    // clean_tests();
 }

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -984,7 +984,7 @@ async fn test_jumpstart_network() {
 
     // wait for jump start event check that key exists in kvdb
     let mut got_jumpstart_event = false;
-    for _ in 0..75 {
+    for _ in 0..85 {
         std::thread::sleep(std::time::Duration::from_millis(1000));
         let block_hash = rpc.chain_get_block_hash(None).await.unwrap();
         let events = EventsClient::new(api.clone()).at(block_hash.unwrap()).await.unwrap();

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -51,8 +51,9 @@ use entropy_testing_utils::{
         TEST_PROGRAM_WASM_BYTECODE, TSS_ACCOUNTS, X25519_PUBLIC_KEYS,
     },
     substrate_context::{
+        development_node_with_default_config, integration_test_node_with_unique_ports,
         test_context_stationary, test_node_process_testing_state, testing_context,
-        SubstrateTestingContext, development_node_with_default_config, integration_test_node_with_unique_ports
+        SubstrateTestingContext,
     },
 };
 use futures::{
@@ -122,8 +123,8 @@ use crate::{
         substrate::{get_oracle_data, query_chain, submit_transaction},
         tests::{
             create_clients, initialize_test_logger, jump_start_network_with_signer, remove_program,
-            run_to_block, setup_client, spawn_testing_validators, spawn_testing_validators_parallel,
-            unsafe_get, ChainSpecType,
+            run_to_block, setup_client, spawn_testing_validators,
+            spawn_testing_validators_parallel, unsafe_get, ChainSpecType,
         },
         user::compute_hash,
         validator::get_signer_and_x25519_secret_from_mnemonic,

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -177,17 +177,19 @@ async fn test_signature_requests_fail_on_different_conditions() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
-    dbg!(&substrate_context.ws_url);
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
+    dbg!(&substrate_context.node_proc.ws_url);
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
     dbg!(&validator_ips);
@@ -355,16 +357,19 @@ async fn signature_request_with_derived_account_works() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -443,16 +448,19 @@ async fn test_signing_fails_if_wrong_participants_are_used() {
 
     let one = AccountKeyring::Dave;
 
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -530,16 +538,18 @@ async fn test_request_limit_are_updated_during_signing() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -674,16 +684,18 @@ async fn test_fails_to_sign_if_non_signing_group_participants_are_used() {
     let two = AccountKeyring::BobStash;
     let charlie = AccountKeyring::CharlieStash;
 
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -809,16 +821,18 @@ async fn test_program_with_config() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -913,8 +927,8 @@ async fn test_jumpstart_network() {
 
     let alice = AccountKeyring::Alice;
 
-    // let cxt = test_context_stationary().await;
-    let cxt = development_node_with_default_config().await;
+    let cxt = test_context_stationary().await;
+    // let cxt = development_node_with_default_config().await;
 
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
@@ -1073,6 +1087,8 @@ async fn test_compute_hash() {
     // custom hash program uses blake 3 to hash
     let expected_hash = blake3::hash(PREIMAGE_SHOULD_SUCCEED).as_bytes().to_vec();
     assert_eq!(message_hash.to_vec(), expected_hash);
+
+    clean_tests();
 }
 
 #[tokio::test]
@@ -1135,16 +1151,18 @@ async fn test_fail_infinite_program() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -1242,16 +1260,18 @@ async fn test_device_key_proxy() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
     let add_parent_key_to_kvdb = true;
     let (validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -1571,17 +1591,19 @@ async fn test_new_registration_flow() {
 
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
-    let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
-    let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
-    let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
-    dbg!(&substrate_context.ws_url);
+    // let force_authoring = true;
+    // let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = integration_test_node_with_unique_ports().await;
+
+    let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
+    dbg!(&substrate_context.node_proc.ws_url);
 
     let add_parent_key_to_kvdb = true;
     let (_validator_ips, _validator_ids) = spawn_testing_validators_parallel(
         add_parent_key_to_kvdb,
         ChainSpecType::Integration,
-        substrate_context.ws_url.clone(),
+        substrate_context.node_proc.ws_url.clone(),
     )
     .await;
 
@@ -1670,8 +1692,8 @@ async fn test_increment_or_wipe_request_limit() {
     initialize_test_logger().await;
     clean_tests();
 
-    // let substrate_context = test_context_stationary().await;
-    let substrate_context = development_node_with_default_config().await;
+    let substrate_context = test_context_stationary().await;
+    // let substrate_context = development_node_with_default_config().await;
 
     let api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
@@ -1721,8 +1743,8 @@ async fn test_increment_or_wipe_request_limit() {
 async fn test_get_oracle_data() {
     initialize_test_logger().await;
 
-    // let cxt = testing_context().await;
-    let cxt = development_node_with_default_config().await;
+    let cxt = testing_context().await;
+    // let cxt = development_node_with_default_config().await;
 
     setup_client().await;
 

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -372,8 +372,6 @@ async fn signature_request_with_derived_account_works() {
     )
     .await;
 
-    dbg!(&validator_ips);
-
     // We first need to jump start the network and grab the resulting network wide verifying key
     // for later
     jump_start_network(&entropy_api, &rpc).await;

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -361,7 +361,6 @@ async fn signature_request_with_derived_account_works() {
     // let substrate_context = test_node_process_testing_state(force_authoring).await;
     let substrate_context = integration_test_node_with_unique_ports().await;
 
-
     let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
@@ -451,7 +450,6 @@ async fn test_signing_fails_if_wrong_participants_are_used() {
     // let force_authoring = true;
     // let substrate_context = test_node_process_testing_state(force_authoring).await;
     let substrate_context = integration_test_node_with_unique_ports().await;
-
 
     let entropy_api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -48,7 +48,10 @@ use entropy_testing_utils::constants::{
 };
 use entropy_testing_utils::{
     constants::{ALICE_STASH_ADDRESS, RANDOM_ACCOUNT},
-    substrate_context::{test_node_process_testing_state, testing_context},
+    substrate_context::{
+        development_node_with_default_config, integration_test_node_with_default_port,
+        test_node_process_testing_state, testing_context, integration_test_node_with_unique_ports,
+    },
     test_context_stationary,
 };
 use futures::future::join_all;
@@ -67,15 +70,16 @@ async fn test_reshare() {
 
     let dave = AccountKeyring::DaveStash;
 
-    let cxt = test_node_process_testing_state(true).await;
+    // let cxt = test_node_process_testing_state(true).await;
+    let cxt = integration_test_node_with_default_port().await;
 
     let add_parent_key_to_kvdb = true;
     let (_validator_ips, _validator_ids) =
         spawn_testing_validators(add_parent_key_to_kvdb, ChainSpecType::Integration).await;
 
     let validator_ports = vec![3001, 3002, 3003, 3004];
-    let api = get_api(&cxt.ws_url).await.unwrap();
-    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
+    let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
 
     let client = reqwest::Client::new();
     let mut key_shares_before = vec![];
@@ -246,7 +250,8 @@ async fn test_reshare_none_called() {
     initialize_test_logger().await;
     clean_tests();
 
-    let _cxt = test_node_process_testing_state(true).await;
+    // let _cxt = test_node_process_testing_state(true).await;
+    let _cxt = integration_test_node_with_default_port().await;
 
     let add_parent_key_to_kvdb = true;
     let (_validator_ips, _validator_ids) =
@@ -265,6 +270,8 @@ async fn test_reshare_none_called() {
 
         assert_eq!(response.text().await.unwrap(), "Chain Fetch: Rotate Keyshare not in progress");
     }
+
+    clean_tests();
 }
 
 #[tokio::test]
@@ -274,9 +281,11 @@ async fn test_reshare_validation_fail() {
     clean_tests();
 
     let dave = AccountKeyring::Dave;
-    let cxt = test_node_process_testing_state(true).await;
-    let api = get_api(&cxt.ws_url).await.unwrap();
-    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
+    // let cxt = test_node_process_testing_state(true).await;
+    let cxt = integration_test_node_with_default_port().await;
+
+    let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
     let kv = setup_client().await;
 
     let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number + 1;
@@ -312,7 +321,9 @@ async fn test_reshare_validation_fail_not_in_reshare() {
     clean_tests();
 
     let alice = AccountKeyring::Alice;
-    let cxt = test_context_stationary().await;
+    // let cxt = test_context_stationary().await;
+    let cxt = development_node_with_default_config().await;
+
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
     let kv = setup_client().await;
@@ -335,7 +346,9 @@ async fn test_empty_next_signer() {
     initialize_test_logger().await;
     clean_tests();
 
-    let cxt = test_context_stationary().await;
+    // let cxt = test_context_stationary().await;
+    let cxt = development_node_with_default_config().await;
+
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
 
@@ -348,7 +361,9 @@ async fn test_empty_next_signer() {
 #[should_panic = "Account does not exist, add balance"]
 async fn test_check_balance_for_fees() {
     initialize_test_logger().await;
-    let cxt = testing_context().await;
+    // let cxt = testing_context().await;
+    let cxt = integration_test_node_with_unique_ports().await;
+
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
 

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -50,7 +50,7 @@ use entropy_testing_utils::{
     constants::{ALICE_STASH_ADDRESS, RANDOM_ACCOUNT},
     substrate_context::{
         development_node_with_default_config, integration_test_node_with_default_port,
-        test_node_process_testing_state, testing_context, integration_test_node_with_unique_ports,
+        integration_test_node_with_unique_ports, test_node_process_testing_state, testing_context,
     },
     test_context_stationary,
 };

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -48,10 +48,7 @@ use entropy_testing_utils::constants::{
 };
 use entropy_testing_utils::{
     constants::{ALICE_STASH_ADDRESS, RANDOM_ACCOUNT},
-    substrate_context::{
-        development_node_with_default_config, integration_test_node_with_default_port,
-        integration_test_node_with_unique_ports, test_node_process_testing_state, testing_context,
-    },
+    substrate_context::{test_node_process_testing_state, testing_context},
     test_context_stationary,
 };
 use futures::future::join_all;
@@ -70,16 +67,15 @@ async fn test_reshare() {
 
     let dave = AccountKeyring::DaveStash;
 
-    // let cxt = test_node_process_testing_state(true).await;
-    let cxt = integration_test_node_with_default_port().await;
+    let cxt = test_node_process_testing_state(true).await;
 
     let add_parent_key_to_kvdb = true;
     let (_validator_ips, _validator_ids) =
         spawn_testing_validators(add_parent_key_to_kvdb, ChainSpecType::Integration).await;
 
     let validator_ports = vec![3001, 3002, 3003, 3004];
-    let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
-    let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
+    let api = get_api(&cxt.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
 
     let client = reqwest::Client::new();
     let mut key_shares_before = vec![];
@@ -250,8 +246,7 @@ async fn test_reshare_none_called() {
     initialize_test_logger().await;
     clean_tests();
 
-    // let _cxt = test_node_process_testing_state(true).await;
-    let _cxt = integration_test_node_with_default_port().await;
+    let _cxt = test_node_process_testing_state(true).await;
 
     let add_parent_key_to_kvdb = true;
     let (_validator_ips, _validator_ids) =
@@ -270,8 +265,6 @@ async fn test_reshare_none_called() {
 
         assert_eq!(response.text().await.unwrap(), "Chain Fetch: Rotate Keyshare not in progress");
     }
-
-    clean_tests();
 }
 
 #[tokio::test]
@@ -281,11 +274,9 @@ async fn test_reshare_validation_fail() {
     clean_tests();
 
     let dave = AccountKeyring::Dave;
-    // let cxt = test_node_process_testing_state(true).await;
-    let cxt = integration_test_node_with_default_port().await;
-
-    let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
-    let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
+    let cxt = test_node_process_testing_state(true).await;
+    let api = get_api(&cxt.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
     let kv = setup_client().await;
 
     let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number + 1;
@@ -321,9 +312,7 @@ async fn test_reshare_validation_fail_not_in_reshare() {
     clean_tests();
 
     let alice = AccountKeyring::Alice;
-    // let cxt = test_context_stationary().await;
-    let cxt = development_node_with_default_config().await;
-
+    let cxt = test_context_stationary().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
     let kv = setup_client().await;
@@ -346,9 +335,7 @@ async fn test_empty_next_signer() {
     initialize_test_logger().await;
     clean_tests();
 
-    // let cxt = test_context_stationary().await;
-    let cxt = development_node_with_default_config().await;
-
+    let cxt = test_context_stationary().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
 
@@ -361,9 +348,7 @@ async fn test_empty_next_signer() {
 #[should_panic = "Account does not exist, add balance"]
 async fn test_check_balance_for_fees() {
     initialize_test_logger().await;
-    // let cxt = testing_context().await;
-    let cxt = integration_test_node_with_unique_ports().await;
-
+    let cxt = testing_context().await;
     let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
 


### PR DESCRIPTION
As mentioned in #1032, the runtime of our tests is now pushing an hour. This PR changes
how our tests are setup in order to allow tests to run in parallel instead of serially.

For example, now the following command runs in parallel:

```
cargo test -p entropy-tss --release -- signature_request_with_derived_account_works test_signature_requests_fail_on_different_conditions --nocapture

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out; finished in 139.16s
```

vs. running this on `master`

```
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 30 filtered out; finished in 240.54s
```

I'll add more details here once it's out of a draft state.
