### PR TITLE
Run multiple test validator

### DIFF
--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -138,7 +138,7 @@ async fn test_remove_program_reference_counter() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -75,7 +75,7 @@ pub const MAX_SIGNERS: u8 = 15;
 pub const SIGNER_THRESHOLD: u8 = 2;
 
 /// For testing to line up chain mock data and reshare_test
-pub const TEST_RESHARE_BLOCK_NUMBER: u32 = 5;
+pub const TEST_RESHARE_BLOCK_NUMBER: u32 = 7;
 
 /// Program version number, must be incremented if version number changes
 pub const PROGRAM_VERSION_NUMBER: u8 = 0;

--- a/crates/testing-utils/src/helpers.rs
+++ b/crates/testing-utils/src/helpers.rs
@@ -43,7 +43,7 @@ pub async fn spawn_tss_nodes_and_start_chain(
             // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
             // able to get our chain in the right state to be jump started.
             let force_authoring = true;
-            let substrate_context = test_node_process_testing_state(force_authoring).await;
+            let substrate_context = &&test_node_process_testing_state(force_authoring).await[0];
             (
                 get_api(&substrate_context.ws_url).await.unwrap(),
                 get_rpc(&substrate_context.ws_url).await.unwrap(),

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -45,11 +45,17 @@ where
     R: Config,
 {
     /// Construct a builder for spawning a test node process.
-    pub fn build<S>(program: S, chain_type: String, force_authoring: bool, bootnode: Option<String>) -> TestNodeProcessBuilder
+    pub fn build<S>(
+        program: S,
+        chain_type: String,
+        force_authoring: bool,
+        bootnode: Option<String>,
+        threshold_url: Option<String>,
+    ) -> TestNodeProcessBuilder
     where
         S: AsRef<OsStr> + Clone,
     {
-        TestNodeProcessBuilder::new(program, chain_type, force_authoring, bootnode)
+        TestNodeProcessBuilder::new(program, chain_type, force_authoring, bootnode, threshold_url)
     }
 
     /// Attempt to kill the running substrate process.
@@ -76,11 +82,18 @@ pub struct TestNodeProcessBuilder {
     scan_port_range: bool,
     chain_type: String,
     force_authoring: bool,
-    bootnode: Option<String>
+    bootnode: Option<String>,
+    tss_server_endpoint: Option<String>,
 }
 
 impl TestNodeProcessBuilder {
-    pub fn new<P>(node_path: P, chain_type: String, force_authoring: bool, bootnode: Option<String>) -> TestNodeProcessBuilder
+    pub fn new<P>(
+        node_path: P,
+        chain_type: String,
+        force_authoring: bool,
+        bootnode: Option<String>,
+        tss_server_endpoint: Option<String>,
+    ) -> TestNodeProcessBuilder
     where
         P: AsRef<OsStr>,
     {
@@ -90,7 +103,8 @@ impl TestNodeProcessBuilder {
             scan_port_range: false,
             chain_type,
             force_authoring,
-            bootnode
+            bootnode,
+            tss_server_endpoint,
         }
     }
 
@@ -129,6 +143,10 @@ impl TestNodeProcessBuilder {
             cmd.arg(arg);
         }
 
+        if let Some(tss_server_endpoint) = &self.tss_server_endpoint {
+            let arg = format!("--tss-server-endpoint={}", tss_server_endpoint.as_str());
+            cmd.arg(arg);
+        }
 
         let ws_port = if self.scan_port_range {
             let (p2p_port, _http_port, ws_port) = next_open_port()

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -18,7 +18,8 @@ use subxt::{config::substrate::SubstrateExtrinsicParams, OnlineClient};
 
 use super::node_proc::TestNodeProcess;
 use crate::chain_api::*;
-
+use std::time::{Duration, self};
+use std::thread;
 /// Verifies that the Entropy node binary exists.
 ///
 /// If a path is provided using the `ENTROPY_NODE` environment variable, that will take priority.
@@ -62,11 +63,12 @@ pub async fn test_node_process_with(
     key: AccountKeyring,
     chain_type: String,
     force_authoring: bool,
+    bootnode: Option<String>
 ) -> TestNodeProcess<EntropyConfig> {
     let path = get_path();
     let path = path.to_str().expect("Path should've been checked to be valid earlier.");
 
-    let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
+    let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring, bootnode)
         .with_authority(key)
         .scan_for_open_ports()
         .spawn::<EntropyConfig>()
@@ -78,11 +80,12 @@ pub async fn test_node(
     key: AccountKeyring,
     chain_type: String,
     force_authoring: bool,
+    bootnode: Option<String>
 ) -> TestNodeProcess<EntropyConfig> {
     let path = get_path();
     let path = path.to_str().expect("Path should've been checked to be valid earlier.");
 
-    let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring)
+    let proc = TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring, bootnode)
         .with_authority(key)
         .spawn::<EntropyConfig>()
         .await;
@@ -90,11 +93,11 @@ pub async fn test_node(
 }
 
 pub async fn test_node_process() -> TestNodeProcess<EntropyConfig> {
-    test_node_process_with(AccountKeyring::Alice, "--dev".to_string(), false).await
+    test_node_process_with(AccountKeyring::Alice, "--dev".to_string(), false, None).await
 }
 
 pub async fn test_node_process_stationary() -> TestNodeProcess<EntropyConfig> {
-    test_node(AccountKeyring::Alice, "--dev".to_string(), false).await
+    test_node(AccountKeyring::Alice, "--dev".to_string(), false, None).await
 }
 
 /// Tests chain with test state in chain config
@@ -102,8 +105,15 @@ pub async fn test_node_process_stationary() -> TestNodeProcess<EntropyConfig> {
 /// Allowing `force_authoring` will produce blocks.
 pub async fn test_node_process_testing_state(
     force_authoring: bool,
-) -> TestNodeProcess<EntropyConfig> {
-    test_node(AccountKeyring::Alice, "--chain=integration-tests".to_string(), force_authoring).await
+) -> Vec<TestNodeProcess<EntropyConfig>> {
+    let alice_bootnode = Some("/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWM7EoKJfwgzAR1nAVmYRuuFq2f3GpJPLrdfhQaRsKjn38".to_string());
+    let result = test_node(AccountKeyring::Alice, "--chain=integration-tests".to_string(), force_authoring, None).await;
+    thread::sleep(time::Duration::from_secs(5));
+    let result_bob = test_node_process_with(AccountKeyring::Bob, "--chain=integration-tests".to_string(), force_authoring, alice_bootnode.clone()).await;
+    let result_charlie = test_node_process_with(AccountKeyring::Charlie, "--chain=integration-tests".to_string(), force_authoring, alice_bootnode.clone()).await;
+    let result_dave = test_node_process_with(AccountKeyring::Dave, "--chain=integration-tests".to_string(), force_authoring, alice_bootnode.clone()).await;
+
+    vec![result, result_bob, result_charlie, result_dave]
 }
 
 /// Spins up Substrate node and a connected `subxt` client.

--- a/crates/threshold-signature-server/src/signing_client/tests.rs
+++ b/crates/threshold-signature-server/src/signing_client/tests.rs
@@ -44,7 +44,7 @@ use sp_keyring::AccountKeyring;
 async fn test_proactive_refresh() {
     initialize_test_logger().await;
     clean_tests();
-    let _cxt = test_node_process_testing_state(false).await;
+    let _cxt = &test_node_process_testing_state(false).await[0];
 
     let (validator_ips, _ids) = spawn_testing_validators(ChainSpecType::Integration).await;
     let signing_committee_ips = &validator_ips[..3].to_vec();

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -182,7 +182,7 @@ async fn test_signature_requests_fail_on_different_conditions() {
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
@@ -418,7 +418,7 @@ async fn test_signature_requests_fail_validator_info_wrong() {
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
@@ -495,7 +495,7 @@ async fn signature_request_with_derived_account_works() {
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
@@ -540,7 +540,7 @@ async fn test_signing_fails_if_wrong_participants_are_used() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -658,7 +658,7 @@ async fn test_request_limit_are_updated_during_signing() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -763,7 +763,7 @@ async fn test_fails_to_sign_if_non_signing_group_participants_are_used() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -863,7 +863,7 @@ async fn test_program_with_config() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -949,7 +949,7 @@ async fn test_jumpstart_network() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -1103,7 +1103,7 @@ async fn test_fail_infinite_program() {
         get_signer_and_x25519_secret_from_mnemonic(&mnemonic.to_string()).unwrap();
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
@@ -1199,7 +1199,7 @@ async fn test_device_key_proxy() {
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
@@ -1336,7 +1336,7 @@ async fn test_faucet() {
     let (_validator_ips, _validator_ids) =
         spawn_testing_validators(ChainSpecType::Development).await;
     let relayer_ip_and_key = ("localhost:3001".to_string(), X25519_PUBLIC_KEYS[0]);
-    let substrate_context = test_node_process_testing_state(true).await;
+    let substrate_context = &test_node_process_testing_state(true).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 
@@ -1493,7 +1493,7 @@ async fn test_registration_flow() {
     // Here we need to use `--chain=integration-tests` and force authoring otherwise we won't be
     // able to get our chain in the right state to be jump started.
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
     let entropy_api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();
 

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -71,7 +71,7 @@ async fn test_reshare() {
     initialize_test_logger().await;
     clean_tests();
 
-    let cxt = test_node_process_testing_state(true).await;
+    let cxt = &test_node_process_testing_state(true).await[0];
 
     let (_validator_ips, _validator_ids) =
         spawn_testing_validators(ChainSpecType::Integration).await;
@@ -316,7 +316,7 @@ async fn test_reshare_validation_fail() {
     clean_tests();
 
     let dave = AccountKeyring::Dave;
-    let cxt = test_node_process_testing_state(true).await;
+    let cxt = &test_node_process_testing_state(true).await[0];
     let api = get_api(&cxt.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.ws_url).await.unwrap();
     let kv = setup_client().await;

--- a/crates/threshold-signature-server/tests/register_and_sign.rs
+++ b/crates/threshold-signature-server/tests/register_and_sign.rs
@@ -44,7 +44,7 @@ async fn integration_test_register_and_sign() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();

--- a/crates/threshold-signature-server/tests/sign_eth_tx.rs
+++ b/crates/threshold-signature-server/tests/sign_eth_tx.rs
@@ -52,7 +52,7 @@ async fn integration_test_sign_eth_tx() {
         spawn_testing_validators(ChainSpecType::Integration).await;
 
     let force_authoring = true;
-    let substrate_context = test_node_process_testing_state(force_authoring).await;
+    let substrate_context = &test_node_process_testing_state(force_authoring).await[0];
 
     let api = get_api(&substrate_context.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.ws_url).await.unwrap();


### PR DESCRIPTION
Reduces testing time significantly as blocks all come in, in 6 seconds instead of being skipped. 


Can push this farther by adding this to the other substrate spin up methods (there are few and it may not have as added an effect)