### PR TITLE
Fix master build

### DIFF
--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -221,7 +221,7 @@ async fn test_reshare() {
     }
 
     // Check that rotating the network key wont work again later
-    run_to_block(&rpc, block_number + 7).await;
+    run_to_block(&rpc, block_number + 9).await;
 
     let response_stale =
         client.post("http://127.0.0.1:3001/validator/rotate_network_key").send().await.unwrap();


### PR DESCRIPTION
Fixes master build by not querying potentially missed event then repinging until the event block had been pruned, this instead just goes to non pruning state of the chain