### PR TITLE
Avoid panic by checking that we have a non-signing validator before selecting one

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -116,6 +116,9 @@ pub async fn sign(
     let message_hash = Hasher::keccak(&message);
 
     let validators_info = get_validators_not_signer_for_relay(api, rpc).await?;
+    if validators_info.is_empty() {
+        return Err(ClientError::NoNonSigningValidators);
+    }
 
     tracing::debug!("Validators info {:?}", validators_info);
     let block_number = rpc.chain_get_header(None).await?.ok_or(ClientError::BlockNumber)?.number;

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -96,8 +96,6 @@ pub enum ClientError {
     TryFromSlice(#[from] std::array::TryFromSliceError),
     #[error("User is not registered on-chain")]
     NotRegistered,
-    #[error("No synced validators")]
-    NoSyncedValidators,
     #[error("Cannot confirm program was created")]
     CannotConfirmProgramCreated,
     #[error("Cannot confirm program was removed")]
@@ -108,4 +106,6 @@ pub enum ClientError {
     CannotQuerySynced,
     #[error("Verifying key has incorrect length")]
     BadVerifyingKeyLength,
+    #[error("There are no validators which can act as a relay node for signature requests")]
+    NoNonSigningValidators,
 }


### PR DESCRIPTION
Ahead of us making a release i wanted to try out our current setup with docker-compose. I should have known it was not going to work with the relaying because we have 3 nodes and all are signers - so there is no-one to be a relayer for our signature requests.

This is what happens when we try to sign:
```
~/r/s/e/e/c/test-cli (master●●)[130] $ cargo run --release -- sign -m //Alice 0380b55a941d514baf9e5c4b96239cda40c1854f83919262029bdfec340aed4c13 'heysdlafkjsdlfkj'
    Finished `release` profile [optimized] target(s) in 0.51s
     Running `/home/turnip/radish/src/entropy/entropy-core/target/release/entropy-test-cli sign -m //Alice 0380b55a941d514baf9e5c4b96239cda40c1854f83919262029bdfec340aed4c13 heysdlafkjsdlfkj`
User account for current call: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
thread 'main' panicked at /home/turnip/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/rng.rs:134:9:
cannot sample empty range
```

`entropy-client::sign` panics, rather than returning an error.  This fixes that. 