### PR TITLE
Bump to Synedrion `v0.2.0-beta.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14056,8 +14056,9 @@ dependencies = [
 
 [[package]]
 name = "synedrion"
-version = "0.1.0"
-source = "git+https://github.com/entropyxyz/synedrion?rev=1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa#1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa"
+version = "0.2.0-beta.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68ecdc79fc2be671be2abe5391d25b38fca840e18665ef2a177aa925f6740ac"
 dependencies = [
  "base64 0.21.7",
  "bincode 2.0.0-rc.3",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,7 +28,7 @@ x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
 entropy-protocol={ version="0.2.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.8", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa", optional=true }
+synedrion       ={ version="0.2.0-beta.0", optional=true }
 hex             ={ version="0.4.3", optional=true }
 anyhow          ="1.0.89"
 

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -23,7 +23,7 @@ zeroize         ={ version="1.8", features=["zeroize_derive"], default-features=
 rpassword       ={ version="7.3.1", default-features=false }
 scrypt          ={ version="0.11.0", default-features=false, features=["std"] }
 chacha20poly1305={ version="0.9", features=["alloc"], default-features=false }
-synedrion       ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
+synedrion       ={ version="0.2.0-beta.0" }
 
 # Async
 tokio  ={ version="1.40", features=["macros", "sync", "fs", "rt-multi-thread", "io-util"] }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,7 +11,7 @@ edition    ='2021'
 [dependencies]
 async-trait        ="0.1.83"
 entropy-shared     ={ version="0.2.0", path="../shared", default-features=false }
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
+synedrion          ={ version="0.2.0-beta.0" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }
 sp-core            ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server", features=["test_helpers"] }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion         ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
+synedrion={ version="0.2.0-beta.0" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -22,7 +22,7 @@ entropy-shared    ={ version="0.2.0", path="../shared" }
 entropy-kvdb      ={ version="0.2.0", path="../kvdb", default-features=false }
 entropy-tss       ={ version="0.2.0", path="../threshold-signature-server", features=["test_helpers"] }
 entropy-protocol  ={ version="0.2.0", path="../protocol" }
-synedrion={ version="0.2.0-beta.0" }
+synedrion         ={ version="0.2.0-beta.0" }
 hex               ="0.4.3"
 rand_core         ="0.6.4"
 rand              ="0.8.5"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -22,7 +22,7 @@ zeroize            ="1.8.1"
 hex                ="0.4.3"
 reqwest-eventsource="0.6"
 serde_derive       ="1.0.147"
-synedrion          ={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
+synedrion          ={ version="0.2.0-beta.0" }
 strum              ="0.26.2"
 backoff            ={ version="0.4.0", features=["tokio"] }
 

--- a/pallets/registry/Cargo.toml
+++ b/pallets/registry/Cargo.toml
@@ -16,7 +16,7 @@ bip32     ={ version="0.5.2", default-features=false, features=["alloc"] }
 codec     ={ package="parity-scale-codec", version="3.6.3", default-features=false, features=["derive"] }
 log       ={ version="0.4.22", default-features=false }
 scale-info={ version="2.11", default-features=false, features=["derive"] }
-synedrion ={ git="https://github.com/entropyxyz/synedrion/", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa", default-features=false }
+synedrion ={ version="0.2.0-beta.0", default-features=false }
 rand      ={ version="0.8.5", default-features=false, features=["alloc"] }
 
 frame-benchmarking={ version="29.0.0", default-features=false, optional=true }

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -17,7 +17,7 @@ entropy-kvdb         ={ version="0.2.0-rc.1", path="../../crates/kvdb", default-
 sp-core              ="31.0.0"
 
 # Unreleased version of Synedrion with support for child key derivations.
-synedrion={ git="https://github.com/entropyxyz/synedrion", rev="1d210d149dfeb0dca1dd41d7fac4d0bf03c686fa" }
+synedrion={ version="0.2.0-beta.0" }
 entropy-tss={ version="0.2.0-rc.1", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }


### PR DESCRIPTION
Bumps Synedrion to a published version, allowing us to release our own workspace.

There are no functional changes from the pinned revision we were previously using.
