### PR TITLE
Only fire DKG off-chain worker request when needed

### DIFF
--- a/pallets/propagation/src/lib.rs
+++ b/pallets/propagation/src/lib.rs
@@ -112,7 +112,9 @@ pub mod pallet {
             let validators_info = pallet_registry::Pallet::<T>::jumpstart_dkg(
                 block_number.saturating_sub(1u32.into()),
             );
-
+            if validators_info.is_empty() {
+                return Ok(());
+            }
             let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(2_000));
             let kind = sp_core::offchain::StorageKind::PERSISTENT;
             let from_local = sp_io::offchain::local_storage_get(kind, b"propagation")

--- a/pallets/propagation/src/tests.rs
+++ b/pallets/propagation/src/tests.rs
@@ -33,7 +33,11 @@ fn knows_how_to_mock_several_http_calls() {
             uri: "http://localhost:3001/generate_network_key".into(),
             sent: true,
             response: Some([].to_vec()),
-            body: [0, 0, 0, 0, 0].to_vec(),
+            body: [
+                0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 16, 116, 101, 115, 116, 20, 16, 116, 101, 115, 116,
+            ]
+            .to_vec(),
             ..Default::default()
         });
 
@@ -69,17 +73,18 @@ fn knows_how_to_mock_several_http_calls() {
     });
 
     t.execute_with(|| {
+        let validators_info = vec![ValidatorInfo {
+            x25519_public_key: [0u8; 32],
+            ip_address: "test".encode(),
+            tss_account: "test".encode(),
+        }];
+        pallet_registry::JumpstartDkg::<Test>::insert(0, validators_info.clone());
+
         Propagation::post_dkg(1).unwrap();
 
         Propagation::post_proactive_refresh(6).unwrap();
-        let ocw_message = RefreshInfo {
-            validators_info: vec![ValidatorInfo {
-                x25519_public_key: [0u8; 32],
-                ip_address: "test".encode(),
-                tss_account: "test".encode(),
-            }],
-            proactive_refresh_keys: vec![1.encode(), 2.encode()],
-        };
+        let ocw_message =
+            RefreshInfo { validators_info, proactive_refresh_keys: vec![1.encode(), 2.encode()] };
         pallet_staking_extension::ProactiveRefresh::<Test>::put(ocw_message);
         Propagation::post_proactive_refresh(6).unwrap();
         Propagation::on_initialize(6);


### PR DESCRIPTION
Currently dkg request fires every block, now it only fires when it is needed