### PR TITLE
Single line for release checklist command

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -49,8 +49,7 @@ tagged as the final release.
     - Register an account using:
         - `cargo run -p entropy-test-cli -- register ./crates/testing-utils/template_barebones.wasm -m //One`
     - Request a signature using:
-        - `cargo run -p entropy-test-cli -- sign \
-            $VERIFYING_KEY "Hello, Docker Compose"`
+        - `cargo run -p entropy-test-cli -- sign $VERIFYING_KEY "Hello, Docker Compose"`
 - [ ] Publish a test release tag
     - E.g `git tag test/hc/release/vX.Y.Z-rc.1 && git push origin test/hc/release/vX.Y.Z-rc.1`
 - [ ] Double check that the _published_ images still run correctly using the Docker compose from

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -47,8 +47,7 @@ tagged as the final release.
     - Jumpstart the network using:
         - `cargo run -p entropy-test-cli -- jumpstart-network`
     - Register an account using:
-        - `cargo run -p entropy-test-cli -- register \
-            ./crates/testing-utils/template_barebones.wasm -m //One`
+        - `cargo run -p entropy-test-cli -- register ./crates/testing-utils/template_barebones.wasm -m //One`
     - Request a signature using:
         - `cargo run -p entropy-test-cli -- sign \
             $VERIFYING_KEY "Hello, Docker Compose"`


### PR DESCRIPTION
The backslash, when treated literally, will cause the `entropy-test-cli` to fail to load its subcommand. In Markdown, this should either have been written as:

```
the command \
    with a new line
```

or just remove the slash and leave the single-line code formatting. I propose this simpler, latter option.