### PR TITLE
Generate mnemonic internally in `entropy-tss`

### DIFF
--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -217,37 +217,6 @@ pub struct StartupArgs {
     /// Returns the AccountID and Diffie-Hellman Public Keys associated with this server.
     #[arg(long = "setup-only")]
     pub setup_only: bool,
-
-    /// The BIP-39 mnemonic (i.e seed phrase) to use for deriving the Threshold Signature Server
-    /// SR25519 account ID and the X25519 public key.
-    ///
-    /// The SR25519 account is responsible for signing and submitting extrinsics to the Entropy
-    /// network.
-    ///
-    /// The X25519 public key is used for encrypting/decrypting messages to other threshold
-    /// servers.
-    ///
-    /// Note that this may keep a mnemonic in your shell history. If you would like to avoid this
-    /// use one of the alternative options, or tools like the 1Password CLI.
-    ///
-    /// **Alternatives**: There are two other ways to supply the mnemonic to the TSS: the
-    /// `--mnemonic-file` flag and the `THRESHOLD_SERVER_MNEMONIC` environment variable.
-    ///
-    /// **Warning**: Passing this flag will overwrite any existing mnemonic! If you would like to
-    /// use an existing mnemonic omit this flag when running the process.
-    #[arg(long = "mnemonic")]
-    pub mnemonic: Option<bip39::Mnemonic>,
-
-    /// The path to a file containing the BIP-39 mnemonic (i.e seed phrase) to use for deriving the
-    /// Threshold Signature Server SR25519 account ID and the X25519 public key.
-    ///
-    /// **Alternatives**: There are two other ways to supply the mnemonic to the TSS: the
-    /// `--mnemonic` flag and the `THRESHOLD_SERVER_MNEMONIC` environment variable.
-    ///
-    /// **Warning**: Passing this flag will overwrite any existing mnemonic! If you would like to
-    /// use an existing mnemonic omit this flag when running the process.
-    #[arg(long = "mnemonic-file", conflicts_with = "mnemonic")]
-    pub mnemonic_file: Option<PathBuf>,
 }
 
 pub async fn has_mnemonic(kv: &KvManager) -> bool {

--- a/crates/threshold-signature-server/src/main.rs
+++ b/crates/threshold-signature-server/src/main.rs
@@ -20,8 +20,8 @@ use clap::Parser;
 use entropy_tss::{
     app,
     launch::{
-        development_mnemonic, load_kv_store, setup_latest_block_number, setup_mnemonic, setup_only,
-        Configuration, StartupArgs, ValidatorName,
+        development_mnemonic, has_mnemonic, load_kv_store, setup_latest_block_number,
+        setup_mnemonic, setup_only, Configuration, StartupArgs, ValidatorName,
     },
     AppState,
 };
@@ -66,39 +66,14 @@ async fn main() {
 
     let app_state = AppState::new(configuration.clone(), kv_store.clone());
 
-    // We consider the inputs in order of most to least explicit: CLI flag, supplied file,
-    // environment variable.
-    let user_mnemonic = args
-        .mnemonic
-        .or_else(|| {
-            args.mnemonic_file.map(|path| {
-                let file = std::fs::read(path).expect("Unable to read mnemonic file.");
-                let mnemonic = std::str::from_utf8(&file)
-                    .expect("Unable to convert provided mnemonic to UTF-8 string.")
-                    .trim();
-
-                bip39::Mnemonic::parse_normalized(mnemonic)
-                    .expect("Unable to parse given mnemonic.")
-            })
-        })
-        .or_else(|| {
-            std::env::var("THRESHOLD_SERVER_MNEMONIC").ok().map(|mnemonic| {
-                bip39::Mnemonic::parse_normalized(&mnemonic)
-                    .expect("Unable to parse given mnemonic.")
-            })
-        });
-
-    if let Some(mnemonic) = user_mnemonic {
-        setup_mnemonic(&kv_store, mnemonic).await
-    } else if cfg!(test) || validator_name.is_some() {
+    if cfg!(test) || validator_name.is_some() {
         setup_mnemonic(&kv_store, development_mnemonic(&validator_name)).await
-    } else {
-        let has_mnemonic = entropy_tss::launch::has_mnemonic(&kv_store).await;
-        assert!(
-            has_mnemonic,
-            "No mnemonic provided. Please provide one or use a development account."
-        );
-    };
+    } else if !has_mnemonic(&kv_store).await {
+        let mut rng = rand::thread_rng();
+        let mnemonic =
+            bip39::Mnemonic::generate_in_with(&mut rng, bip39::Language::English, 24).unwrap();
+        setup_mnemonic(&kv_store, mnemonic).await
+    }
 
     setup_latest_block_number(&kv_store).await.expect("Issue setting up Latest Block Number");
 


### PR DESCRIPTION
Addresses https://github.com/entropyxyz/entropy-core/issues/1015 by not allowing mnemonics to be passed in (except in development / testing) via the command line or an environment variable. Instead they are always randomly generated internally.

However i think this does not completely resolve the issue - see https://github.com/entropyxyz/entropy-core/issues/1127