### PR TITLE
Remove declare synced

### DIFF
--- a/pallets/registry/src/benchmarking.rs
+++ b/pallets/registry/src/benchmarking.rs
@@ -25,8 +25,8 @@ use frame_system::{EventRecord, RawOrigin};
 use pallet_programs::{ProgramInfo, Programs};
 use pallet_session::Validators;
 use pallet_staking_extension::{
-    benchmarking::create_validators, IsValidatorSynced, JumpStartDetails, JumpStartProgress,
-    JumpStartStatus, ServerInfo, ThresholdServers, ThresholdToStash,
+    benchmarking::create_validators, JumpStartDetails, JumpStartProgress, JumpStartStatus,
+    ServerInfo, ThresholdServers, ThresholdToStash,
 };
 use sp_runtime::traits::Hash;
 use sp_std::{vec, vec::Vec};
@@ -48,7 +48,6 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 
 pub fn add_non_syncing_validators<T: Config>(
     validator_amount: u32,
-    syncing_validators: u32,
 ) -> Vec<<T as pallet_session::Config>::ValidatorId> {
     let validators = create_validators::<T>(validator_amount, SEED);
     let account = account::<T::AccountId>("ts_account", 1, SEED);
@@ -60,12 +59,6 @@ pub fn add_non_syncing_validators<T: Config>(
     };
     for (c, validator) in validators.iter().enumerate() {
         <ThresholdServers<T>>::insert(validator, server_info.clone());
-        if c >= syncing_validators.try_into().unwrap() {
-            <IsValidatorSynced<T>>::insert(validator, true);
-        }
-    }
-    if syncing_validators == validator_amount {
-        <IsValidatorSynced<T>>::insert(&validators[0], true);
     }
     validators
 }

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -272,7 +272,7 @@ benchmarks! {
     let block_number = 1;
     let nonce = NULL_ARR;
     let x25519_public_key = NULL_ARR;
-    let endpoint = b"http://localhost:3001".to_vec();
+    let endpoint = vec![];
     let validate_also = false;
 
     prep_bond_and_validate::<T>(
@@ -334,16 +334,6 @@ benchmarks! {
             endpoint
         ).into()
     );
-  }
-
-  declare_synced {
-    let caller: T::AccountId = whitelisted_caller();
-    let validator_id_res = <T as pallet_session::Config>::ValidatorId::try_from(caller.clone()).or(Err(Error::<T>::InvalidValidatorId)).unwrap();
-    ThresholdToStash::<T>::insert(caller.clone(), validator_id_res.clone());
-
-  }:  _(RawOrigin::Signed(caller.clone()), true)
-  verify {
-    assert_last_event::<T>(Event::<T>::ValidatorSyncStatus(validator_id_res,  true).into());
   }
 
   confirm_key_reshare_confirmed {

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -172,17 +172,6 @@ pub mod pallet {
     pub type ThresholdToStash<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, T::ValidatorId, OptionQuery>;
 
-    /// Tracks wether the validator's kvdb is synced using a stash key as an identifier
-    #[pallet::storage]
-    #[pallet::getter(fn is_validator_synced)]
-    pub type IsValidatorSynced<T: Config> = StorageMap<
-        _,
-        Blake2_128Concat,
-        <T as pallet_session::Config>::ValidatorId,
-        bool,
-        ValueQuery,
-    >;
-
     #[derive(
         Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen, Default,
     )]
@@ -278,7 +267,6 @@ pub mod pallet {
 
                 ThresholdServers::<T>::insert(validator_stash, server_info.clone());
                 ThresholdToStash::<T>::insert(&server_info.tss_account, validator_stash);
-                IsValidatorSynced::<T>::insert(validator_stash, true);
             }
 
             let refresh_info = RefreshInfo {
@@ -485,7 +473,6 @@ pub mod pallet {
                 let server_info =
                     ThresholdServers::<T>::take(&validator_id).ok_or(Error::<T>::NoThresholdKey)?;
                 ThresholdToStash::<T>::remove(&server_info.tss_account);
-                IsValidatorSynced::<T>::remove(&validator_id);
                 Self::deposit_event(Event::NodeInfoRemoved(controller));
             }
             Ok(Some(<T as Config>::WeightInfo::withdraw_unbonded(
@@ -556,18 +543,6 @@ pub mod pallet {
                 server_info.endpoint,
             ));
 
-            Ok(())
-        }
-
-        /// Let a validator declare if their kvdb is synced or not synced
-        /// `synced`: State of validator's kvdb
-        #[pallet::call_index(6)]
-        #[pallet::weight(<T as Config>::WeightInfo::declare_synced())]
-        pub fn declare_synced(origin: OriginFor<T>, synced: bool) -> DispatchResult {
-            let who = ensure_signed(origin.clone())?;
-            let stash = Self::threshold_to_stash(who).ok_or(Error::<T>::NoThresholdKey)?;
-            IsValidatorSynced::<T>::insert(&stash, synced);
-            Self::deposit_event(Event::ValidatorSyncStatus(stash, synced));
             Ok(())
         }
 

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -14,8 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    mock::*, tests::RuntimeEvent, Error, IsValidatorSynced, NextSignerInfo, NextSigners,
-    ServerInfo, Signers, ThresholdToStash,
+    mock::*, tests::RuntimeEvent, Error, NextSignerInfo, NextSigners, ServerInfo, Signers,
 };
 use codec::Encode;
 use frame_support::{assert_noop, assert_ok};
@@ -49,8 +48,6 @@ fn basic_setup_works() {
         );
         assert_eq!(Staking::threshold_to_stash(7).unwrap(), 5);
         assert_eq!(Staking::threshold_to_stash(8).unwrap(), 6);
-        assert!(Staking::is_validator_synced(5));
-        assert!(Staking::is_validator_synced(6));
     });
 }
 
@@ -325,8 +322,6 @@ fn it_deletes_when_no_bond_left() {
             VALID_QUOTE.to_vec(),
         ));
 
-        IsValidatorSynced::<Test>::insert(2, true);
-
         let ServerInfo { tss_account, endpoint, .. } = Staking::threshold_server(2).unwrap();
         assert_eq!(endpoint, vec![20]);
         assert_eq!(tss_account, 3);
@@ -359,8 +354,6 @@ fn it_deletes_when_no_bond_left() {
         lock = Balances::locks(2);
         assert_eq!(lock[0].amount, 50);
         assert_eq!(lock.len(), 1);
-        // validator still synced
-        assert_eq!(Staking::is_validator_synced(2), true);
 
         let ServerInfo { tss_account, endpoint, .. } = Staking::threshold_server(2).unwrap();
         assert_eq!(endpoint, vec![20]);
@@ -377,8 +370,6 @@ fn it_deletes_when_no_bond_left() {
         assert_eq!(lock.len(), 0);
         assert_eq!(Staking::threshold_server(2), None);
         assert_eq!(Staking::threshold_to_stash(3), None);
-        // validator no longer synced
-        assert_eq!(Staking::is_validator_synced(2), false);
 
         assert_ok!(FrameStaking::bond(
             RuntimeOrigin::signed(7),
@@ -422,21 +413,6 @@ fn it_deletes_when_no_bond_left() {
             Staking::withdraw_unbonded(RuntimeOrigin::signed(9), 0),
             Error::<Test>::NoUnnominatingWhenNextSigner
         );
-    });
-}
-
-#[test]
-fn it_declares_synced() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(
-            Staking::declare_synced(RuntimeOrigin::signed(5), true),
-            Error::<Test>::NoThresholdKey
-        );
-
-        ThresholdToStash::<Test>::insert(5, 5);
-
-        assert_ok!(Staking::declare_synced(RuntimeOrigin::signed(5), true));
-        assert!(Staking::is_validator_synced(5));
     });
 }
 

--- a/pallets/staking/src/weights.rs
+++ b/pallets/staking/src/weights.rs
@@ -58,7 +58,6 @@ pub trait WeightInfo {
 	fn unbond(c: u32, n: u32) -> Weight;
 	fn withdraw_unbonded(c: u32, n: u32) -> Weight;
 	fn validate() -> Weight;
-	fn declare_synced() -> Weight;
 	fn confirm_key_reshare_confirmed(c: u32) -> Weight;
 	fn confirm_key_reshare_completed() -> Weight;
 	fn new_session_base_weight(s: u32) -> Weight;
@@ -251,19 +250,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(60_000_000, 4556)
 			.saturating_add(T::DbWeight::get().reads(11_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
-	}
-	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
-	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `StakingExtension::IsValidatorSynced` (r:0 w:1)
-	/// Proof: `StakingExtension::IsValidatorSynced` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn declare_synced() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `285`
-		//  Estimated: `3750`
-		// Minimum execution time: 12_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 3750)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
 	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -526,19 +512,6 @@ impl WeightInfo for () {
 		Weight::from_parts(60_000_000, 4556)
 			.saturating_add(RocksDbWeight::get().reads(11_u64))
 			.saturating_add(RocksDbWeight::get().writes(7_u64))
-	}
-	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
-	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `StakingExtension::IsValidatorSynced` (r:0 w:1)
-	/// Proof: `StakingExtension::IsValidatorSynced` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn declare_synced() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `285`
-		//  Estimated: `3750`
-		// Minimum execution time: 12_000_000 picoseconds.
-		Weight::from_parts(13_000_000, 3750)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
 	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/runtime/src/weights/pallet_staking_extension.rs
+++ b/runtime/src/weights/pallet_staking_extension.rs
@@ -240,20 +240,6 @@ impl<T: frame_system::Config> pallet_staking_extension::WeightInfo for WeightInf
 	}
 	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
 	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `StakingExtension::IsValidatorSynced` (r:0 w:1)
-	/// Proof: `StakingExtension::IsValidatorSynced` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn declare_synced() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `353`
-		//  Estimated: `3818`
-		// Minimum execution time: 16_110_000 picoseconds.
-		Weight::from_parts(16_488_000, 0)
-			.saturating_add(Weight::from_parts(0, 3818))
-			.saturating_add(T::DbWeight::get().reads(1))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `StakingExtension::ThresholdToStash` (r:1 w:0)
-	/// Proof: `StakingExtension::ThresholdToStash` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `StakingExtension::NextSigners` (r:1 w:1)
 	/// Proof: `StakingExtension::NextSigners` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// The range of component `c` is `[0, 15]`.


### PR DESCRIPTION
This is a holdover of subgroups, validators are immediately synced as there is only one parent key