### PR TITLE
Concurrently process messages in protocol execution loop

### DIFF
--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -31,8 +31,10 @@ pub enum GenericProtocolError<Res: ProtocolResult> {
     Broadcast(#[from] Box<tokio::sync::broadcast::error::SendError<ProtocolMessage>>),
     #[error("Mpsc send error: {0}")]
     Mpsc(#[from] tokio::sync::mpsc::error::SendError<ProtocolMessage>),
-    #[error("Could not get session out of Arc")]
+    #[error("Could not get session out of Arc - session has finalized before message processing finished")]
     ArcUnwrapError,
+    #[error("Message processing task panic or cancellation: {0}")]
+    JoinHandle(#[from] tokio::task::JoinError),
 }
 
 impl<Res: ProtocolResult> From<sessions::LocalError> for GenericProtocolError<Res> {
@@ -64,6 +66,7 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams, PartyId>>>
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
             GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
+            GenericProtocolError::JoinHandle(err) => ProtocolExecutionErr::JoinHandle(err),
         }
     }
 }
@@ -77,6 +80,7 @@ impl From<GenericProtocolError<KeyInitResult<KeyParams, PartyId>>> for ProtocolE
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
             GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
+            GenericProtocolError::JoinHandle(err) => ProtocolExecutionErr::JoinHandle(err),
         }
     }
 }
@@ -90,6 +94,7 @@ impl From<GenericProtocolError<KeyResharingResult<KeyParams, PartyId>>> for Prot
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
             GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
+            GenericProtocolError::JoinHandle(err) => ProtocolExecutionErr::JoinHandle(err),
         }
     }
 }
@@ -103,6 +108,7 @@ impl From<GenericProtocolError<AuxGenResult<KeyParams, PartyId>>> for ProtocolEx
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
             GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
+            GenericProtocolError::JoinHandle(err) => ProtocolExecutionErr::JoinHandle(err),
         }
     }
 }
@@ -144,6 +150,8 @@ pub enum ProtocolExecutionErr {
     UnexpectedMessage,
     #[error("Could not get session out of Arc")]
     ArcUnwrapError,
+    #[error("Message processing task panic or cancellation: {0}")]
+    JoinHandle(#[from] tokio::task::JoinError),
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/errors.rs
+++ b/crates/protocol/src/errors.rs
@@ -31,6 +31,8 @@ pub enum GenericProtocolError<Res: ProtocolResult> {
     Broadcast(#[from] Box<tokio::sync::broadcast::error::SendError<ProtocolMessage>>),
     #[error("Mpsc send error: {0}")]
     Mpsc(#[from] tokio::sync::mpsc::error::SendError<ProtocolMessage>),
+    #[error("Could not get session out of Arc")]
+    ArcUnwrapError,
 }
 
 impl<Res: ProtocolResult> From<sessions::LocalError> for GenericProtocolError<Res> {
@@ -61,6 +63,7 @@ impl From<GenericProtocolError<InteractiveSigningResult<KeyParams, PartyId>>>
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
+            GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
         }
     }
 }
@@ -73,6 +76,7 @@ impl From<GenericProtocolError<KeyInitResult<KeyParams, PartyId>>> for ProtocolE
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
+            GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
         }
     }
 }
@@ -85,6 +89,7 @@ impl From<GenericProtocolError<KeyResharingResult<KeyParams, PartyId>>> for Prot
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
+            GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
         }
     }
 }
@@ -97,6 +102,7 @@ impl From<GenericProtocolError<AuxGenResult<KeyParams, PartyId>>> for ProtocolEx
             GenericProtocolError::IncomingStream(err) => ProtocolExecutionErr::IncomingStream(err),
             GenericProtocolError::Broadcast(err) => ProtocolExecutionErr::Broadcast(err),
             GenericProtocolError::Mpsc(err) => ProtocolExecutionErr::Mpsc(err),
+            GenericProtocolError::ArcUnwrapError => ProtocolExecutionErr::ArcUnwrapError,
         }
     }
 }
@@ -136,6 +142,8 @@ pub enum ProtocolExecutionErr {
     BadVerifyingKey(String),
     #[error("Expected verifying key but got a protocol message")]
     UnexpectedMessage,
+    #[error("Could not get session out of Arc")]
+    ArcUnwrapError,
 }
 
 #[derive(Debug, Error)]

--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -114,13 +114,7 @@ where
         let current_round = session.current_round();
         let session_arc = Arc::new(session);
 
-        loop {
-            {
-                // let session = session_arc.read().unwrap();
-                if session_arc.can_finalize(&accum)? {
-                    break;
-                }
-            }
+        while !session_arc.can_finalize(&accum)? {
             tokio::select! {
                 // Incoming message from remote peer
                 maybe_message = rx.recv() => {

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -22,7 +22,7 @@ use futures::future;
 use rand_core::OsRng;
 use serial_test::serial;
 use sp_core::{sr25519, Pair};
-use std::time::Instant;
+use std::{cmp::min, time::Instant};
 use subxt::utils::AccountId32;
 use synedrion::{ecdsa::VerifyingKey, AuxInfo, KeyShare, ThresholdKeyShare};
 use tokio::{net::TcpListener, runtime::Runtime, sync::oneshot};
@@ -33,37 +33,40 @@ use helpers::{server, ProtocolOutput};
 
 use std::collections::BTreeSet;
 
+/// The maximum number of worker threads that tokio should use
+const MAX_THREADS: usize = 16;
+
 #[test]
 #[serial]
 fn sign_protocol_with_time_logged() {
-    let cpus = num_cpus::get();
-    get_tokio_runtime(cpus).block_on(async {
-        test_sign_with_parties(cpus).await;
+    let num_parties = min(num_cpus::get(), MAX_THREADS);
+    get_tokio_runtime(num_parties).block_on(async {
+        test_sign_with_parties(num_parties).await;
     })
 }
 
 #[test]
 #[serial]
 fn refresh_protocol_with_time_logged() {
-    let cpus = num_cpus::get();
-    get_tokio_runtime(cpus).block_on(async {
-        test_refresh_with_parties(cpus).await;
+    let num_parties = min(num_cpus::get(), MAX_THREADS);
+    get_tokio_runtime(num_parties).block_on(async {
+        test_refresh_with_parties(num_parties).await;
     })
 }
 
 #[test]
 #[serial]
 fn dkg_protocol_with_time_logged() {
-    let cpus = num_cpus::get();
-    get_tokio_runtime(cpus).block_on(async {
-        test_dkg_with_parties(cpus).await;
+    let num_parties = min(num_cpus::get(), MAX_THREADS);
+    get_tokio_runtime(num_parties).block_on(async {
+        test_dkg_with_parties(num_parties).await;
     })
 }
 
 #[test]
 #[serial]
 fn t_of_n_dkg_and_sign() {
-    let cpus = num_cpus::get();
+    let cpus = min(num_cpus::get(), MAX_THREADS);
     // For this test we need at least 3 parties
     let parties = 3;
     get_tokio_runtime(cpus).block_on(async {


### PR DESCRIPTION
Related issue: https://github.com/entropyxyz/entropy-core/issues/641

Now that some fixes in synedrion mean that `Session` is `sync`, and we only need read access to `Session` to process / create messages, message processing / creation from different peers during a round should be able to happen concurrently without needing a mutex. Things are a bit more complicated than last time i tried to do this because we have to handle messages from future sub-protocol for the DKG flow (which is now composed of 3 sub-protocols).

This PR adds concurrency both for processing incoming messages (calls to `session.process_message`) and outgoing messages (calls to `session.make_message`).

Since most of the time goes into processing incoming messages (according to my benchmarks from a while back), i was expecting this to speed things up significantly with a large number of parties. Unfortunately, it does not make too much difference (on my laptop, the signing protocol with 8 parties went from 19.7s to 17.9s).  I think the problem is that i am simulating all parties on one machine, so i don't really benefit from the concurrency - cpu cores are spread across all parties so the total time taken doesn't change much. I hope that in production this wont be the case, because the other parties will be running on other machines.

Trying this on our TDX box, which has 32 cores, the signing protocol with 16 parties takes 12.94s on this branch and 15.25s on master.  I was hoping for a bigger difference.