### PR TITLE
Protocol message versioning

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -46,6 +46,9 @@ use synedrion::{
     AuxInfo, ThresholdKeyShare,
 };
 
+pub const PROTOCOL_MESSAGE_VERSION: u32 = 1;
+pub const SUPPORTED_PROTOCOL_MESSAGE_VERSIONS: [u32; 1] = [1];
+
 /// Identifies a party participating in a protocol session
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PartyId(AccountId32);

--- a/crates/protocol/src/protocol_transport/errors.rs
+++ b/crates/protocol/src/protocol_transport/errors.rs
@@ -65,3 +65,12 @@ pub enum EncryptedConnectionErr {
     #[error("Could not get remote public key")]
     RemotePublicKey,
 }
+
+/// Error when checking supported protocol versions
+#[derive(Debug, Error, PartialEq)]
+pub enum ProtocolVersionMismatchError {
+    #[error("This version of the protocol is newer than ours - we are on version {0}")]
+    VersionTooNew(u32),
+    #[error("This version of the protocol is no longer supported - the oldest we support is {0}")]
+    VersionTooOld(u32),
+}

--- a/crates/protocol/src/protocol_transport/subscribe_message.rs
+++ b/crates/protocol/src/protocol_transport/subscribe_message.rs
@@ -13,10 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::SessionId;
+use crate::{SessionId, PROTOCOL_MESSAGE_VERSION, SUPPORTED_PROTOCOL_MESSAGE_VERSIONS};
 use serde::{Deserialize, Serialize};
 use sp_core::{sr25519, Pair};
 use subxt::utils::AccountId32;
+
+use super::errors::ProtocolVersionMismatchError;
 
 /// A message sent by a party when initiating a websocket connection to participate
 /// in the signing or DKG protcol
@@ -29,14 +31,20 @@ pub struct SubscribeMessage {
     pub public_key: sr25519::Public,
     /// Signature to authenticate connecting party
     pub signature: sr25519::Signature,
+    /// Specifies the version of the protocol messages which will be used for this session
+    pub version: u32,
 }
 
 impl SubscribeMessage {
     pub fn new(session_id: SessionId, pair: &sr25519::Pair) -> Result<Self, bincode::Error> {
         let session_id_serialized = bincode::serialize(&session_id)?;
-
         let signature = pair.sign(&session_id_serialized);
-        Ok(Self { session_id, public_key: pair.public(), signature })
+        Ok(Self {
+            session_id,
+            public_key: pair.public(),
+            signature,
+            version: PROTOCOL_MESSAGE_VERSION,
+        })
     }
 
     pub fn account_id(&self) -> AccountId32 {
@@ -46,5 +54,50 @@ impl SubscribeMessage {
     pub fn verify(&self) -> Result<bool, bincode::Error> {
         let session_id_serialized = bincode::serialize(&self.session_id)?;
         Ok(sr25519::Pair::verify(&self.signature, session_id_serialized, &self.public_key))
+    }
+
+    pub fn check_supported(&self) -> Result<(), ProtocolVersionMismatchError> {
+        if self.version > PROTOCOL_MESSAGE_VERSION {
+            Err(ProtocolVersionMismatchError::VersionTooNew(PROTOCOL_MESSAGE_VERSION))
+        } else if !SUPPORTED_PROTOCOL_MESSAGE_VERSIONS.contains(&self.version) {
+            Err(ProtocolVersionMismatchError::VersionTooOld(
+                *SUPPORTED_PROTOCOL_MESSAGE_VERSIONS
+                    .iter()
+                    .min()
+                    .expect("At least one protocol message version must be supported"),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_protocol_version_check() {
+        let session_id = SessionId::Dkg { block_number: 0 };
+        let pair = sr25519::Pair::from_seed(&[0; 32]);
+        let subscribe_message = SubscribeMessage::new(session_id.clone(), &pair).unwrap();
+        assert!(subscribe_message.check_supported().is_ok());
+
+        let session_id_serialized = bincode::serialize(&session_id).unwrap();
+        let signature = pair.sign(&session_id_serialized);
+        let mut subscribe_message =
+            SubscribeMessage { session_id, public_key: pair.public(), signature, version: 0 };
+        assert_eq!(
+            subscribe_message.check_supported(),
+            Err(ProtocolVersionMismatchError::VersionTooOld(
+                *SUPPORTED_PROTOCOL_MESSAGE_VERSIONS.iter().min().unwrap()
+            ))
+        );
+
+        subscribe_message.version = 2;
+        assert_eq!(
+            subscribe_message.check_supported(),
+            Err(ProtocolVersionMismatchError::VersionTooNew(PROTOCOL_MESSAGE_VERSION))
+        );
     }
 }

--- a/crates/threshold-signature-server/src/signing_client/errors.rs
+++ b/crates/threshold-signature-server/src/signing_client/errors.rs
@@ -139,6 +139,10 @@ pub enum SubscribeErr {
     UserError(String),
     #[error("Listener: {0}")]
     Listener(#[from] entropy_protocol::errors::ListenerErr),
+    #[error("Protocol version mismatch: {0}")]
+    VersionMismatch(
+        #[from] entropy_protocol::protocol_transport::errors::ProtocolVersionMismatchError,
+    ),
 }
 
 impl IntoResponse for SubscribeErr {


### PR DESCRIPTION
This adds a version number to the `SubscribeMessage` sent at the beginning of each protocol session, and checks that it matches the current version (or a list of supported backward compatible versions which currently only contains the current version).

We could also add a version number to `ProtocolMessage`, but i decided not to - i think check the version once at the beginning of each protocol session is enough - i don't think we need to check individual messages during a session as well.