### PR TITLE
Add TSS endpoint to get TDX quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@ At the moment this project **does not** adhere to
   `change_threshold_accounts()` extrinsics got new TDX `quote` related parameters added.
 - In [#1134](https://github.com/entropyxyz/entropy-core/pull/1134/) the `--no-sync` option was
   removed.
-- In [#1153](https://github.com/entropyxyz/entropy-core/pull/1153/) the program runtime was updated to accept 
+- In [#1153](https://github.com/entropyxyz/entropy-core/pull/1153/) the program runtime was updated to accept
 multiple oracle inputs, this means any programs that were compiled and used need to be recompiled to the new
 runtime
 
 ### Added
 - Protocol message versioning ([#1140](https://github.com/entropyxyz/entropy-core/pull/1140))
+- Add TSS endpoint to get TDX quote ([#1173](https://github.com/entropyxyz/entropy-core/pull/1173))
 
 ### Changed
 - Use correct key rotation endpoint in OCW ([#1104](https://github.com/entropyxyz/entropy-core/pull/1104))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "entropy-client",
  "entropy-shared",
  "hex",
+ "reqwest",
  "serde",
  "serde_json",
  "sp-core 31.0.0",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -39,7 +39,9 @@ use crate::{
     },
     client::entropy::staking_extension::events::{EndpointChanged, ThresholdAccountChanged},
     substrate::{get_registered_details, submit_transaction_with_pair},
-    user::{get_all_signers_from_chain, get_validators_not_signer_for_relay, UserSignatureRequest},
+    user::{
+        self, get_all_signers_from_chain, get_validators_not_signer_for_relay, UserSignatureRequest,
+    },
     Hasher,
 };
 
@@ -426,6 +428,9 @@ async fn jumpstart_inner(
 /// some point in the near future.
 ///
 /// The returned `nonce` must be used when generating a `quote` for the chain.
+///
+/// This wraps [user::request_attestation] to convert the error to a [ClientError] consistant with
+/// other functions in this module
 #[tracing::instrument(
     skip_all,
     fields(
@@ -435,19 +440,7 @@ async fn jumpstart_inner(
 pub async fn request_attestation(
     api: &OnlineClient<EntropyConfig>,
     rpc: &LegacyRpcMethods<EntropyConfig>,
-    attestee: sr25519::Pair,
-) -> Result<Vec<u8>, ClientError> {
-    tracing::debug!("{} is requesting an attestation.", attestee.public());
-
-    let request_attestation = entropy::tx().attestation().request_attestation();
-
-    let result =
-        submit_transaction_with_pair(api, rpc, &attestee, &request_attestation, None).await?;
-    let result_event = result
-        .find_first::<entropy::attestation::events::AttestationIssued>()?
-        .ok_or(crate::errors::SubstrateError::NoEvent)?;
-
-    let nonce = result_event.0;
-
-    Ok(nonce)
+    attestee: &sr25519::Pair,
+) -> Result<[u8; 32], ClientError> {
+    Ok(user::request_attestation(api, rpc, attestee).await?)
 }

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -49,6 +49,17 @@ pub enum SubgroupGetError {
     JoinError(#[from] tokio::task::JoinError),
 }
 
+/// An error when making an attestation request
+#[derive(Debug, Error)]
+pub enum AttestationRequestError {
+    #[error("Generic Substrate error: {0}")]
+    GenericSubstrate(#[from] subxt::error::Error),
+    #[error("Substrate client: {0}")]
+    SubstrateClient(#[from] crate::substrate::SubstrateError),
+    #[error("Recieved nonce is not 32 bytes")]
+    BadNonce,
+}
+
 #[cfg(feature = "full-client")]
 #[derive(Debug, Error)]
 pub enum ClientError {
@@ -108,4 +119,6 @@ pub enum ClientError {
     BadVerifyingKeyLength,
     #[error("There are no validators which can act as a relay node for signature requests")]
     NoNonSigningValidators,
+    #[error("Attestation request: {0}")]
+    AttestationRequest(#[from] AttestationRequestError),
 }

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -116,7 +116,7 @@ async fn test_change_threshold_accounts() {
     .unwrap();
 
     // When we request an attestation we get a nonce back that we must use when generating our quote.
-    let nonce = request_attestation(&api, &rpc, tss_signer_pair.signer().clone()).await.unwrap();
+    let nonce = request_attestation(&api, &rpc, tss_signer_pair.signer()).await.unwrap();
     let nonce: [u8; 32] = nonce.try_into().unwrap();
 
     let mut pck_seeder = StdRng::from_seed(tss_public_key.0.clone());

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -15,13 +15,14 @@
 //! User interaction related
 use crate::{
     chain_api::{entropy, EntropyConfig},
-    substrate::query_chain,
+    substrate::{query_chain, submit_transaction_with_pair},
 };
 use entropy_shared::{user::ValidatorInfo, BlockNumber, HashingAlgorithm};
 use serde::{Deserialize, Serialize};
+use sp_core::{sr25519, Pair};
 use subxt::{backend::legacy::LegacyRpcMethods, OnlineClient};
 
-pub use crate::errors::SubgroupGetError;
+pub use crate::errors::{AttestationRequestError, SubgroupGetError};
 
 /// Represents an unparsed, transaction request coming from the client.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -142,4 +143,34 @@ pub async fn get_all_signers_from_chain(
     }
 
     Ok(all_signers)
+}
+
+/// An extrinsic to indicate to the chain that it should expect an attestation from the `signer` at
+/// some point in the near future.
+///
+/// The returned `nonce` must be used when generating a `quote` for the chain.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        attestee = ?attestee.public(),
+    )
+)]
+pub async fn request_attestation(
+    api: &OnlineClient<EntropyConfig>,
+    rpc: &LegacyRpcMethods<EntropyConfig>,
+    attestee: &sr25519::Pair,
+) -> Result<[u8; 32], AttestationRequestError> {
+    tracing::debug!("{} is requesting an attestation.", attestee.public());
+
+    let request_attestation = entropy::tx().attestation().request_attestation();
+
+    let result =
+        submit_transaction_with_pair(api, rpc, attestee, &request_attestation, None).await?;
+    let result_event = result
+        .find_first::<entropy::attestation::events::AttestationIssued>()?
+        .ok_or(crate::errors::SubstrateError::NoEvent)?;
+
+    let nonce = result_event.0.try_into().map_err(|_| AttestationRequestError::BadNonce)?;
+
+    Ok(nonce)
 }

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -23,3 +23,4 @@ sp-runtime    ={ version="32.0.0", default-features=false }
 entropy-shared={ version="0.3.0", path="../shared" }
 serde_json    ="1.0.133"
 serde         ={ version="1.0.215", features=["derive"] }
+reqwest       ="0.12.9"

--- a/crates/test-cli/src/lib.rs
+++ b/crates/test-cli/src/lib.rs
@@ -189,6 +189,14 @@ enum CliCommand {
         #[arg(short, long)]
         mnemonic_option: Option<String>,
     },
+    /// Request a TDX quote from a TS server and write it to a file
+    GetTdxQuote {
+        /// The socket address of the TS server, eg: 127.0.0.1:3002
+        tss_endpoint: String,
+        /// The filename to write the quote to. Defaults to quote.dat
+        #[arg(short, long)]
+        output_filename: Option<String>,
+    },
 }
 
 impl Cli {
@@ -556,6 +564,18 @@ pub async fn run_command(
                 Ok("{}".to_string())
             } else {
                 Ok("Succesfully jumpstarted network.".to_string())
+            }
+        },
+        CliCommand::GetTdxQuote { tss_endpoint, output_filename } => {
+            let quote_bytes =
+                reqwest::get(format!("http://{}/attest", tss_endpoint)).await?.bytes().await?;
+            let output_filename = output_filename.unwrap_or("quote.dat".into());
+
+            std::fs::write(&output_filename, quote_bytes)?;
+            if cli.json {
+                Ok("{}".to_string())
+            } else {
+                Ok(format!("Succesfully written quote to {}", output_filename))
             }
         },
     }

--- a/crates/test-cli/src/lib.rs
+++ b/crates/test-cli/src/lib.rs
@@ -189,12 +189,12 @@ enum CliCommand {
         #[arg(short, long)]
         mnemonic_option: Option<String>,
     },
-    /// Request a TDX quote from a TS server and write it to a file
+    /// Request a TDX quote from a TSS server and write it to a file.
     GetTdxQuote {
-        /// The socket address of the TS server, eg: 127.0.0.1:3002
+        /// The socket address of the TS server, eg: `127.0.0.1:3002`
         tss_endpoint: String,
-        /// The filename to write the quote to. Defaults to quote.dat
-        #[arg(short, long)]
+        /// The filename to write the quote to. Defaults to `quote.dat`
+        #[arg(long)]
         output_filename: Option<String>,
     },
 }

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -90,7 +90,7 @@ pub async fn get_attest(
     let rpc = get_rpc(&app_state.configuration.endpoint).await?;
 
     // Request attestation to get nonce
-    let nonce = request_attestation(&api, &rpc, signer.signer()).await.unwrap();
+    let nonce = request_attestation(&api, &rpc, signer.signer()).await?;
 
     // We also need the current block number as input
     let block_number =

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -24,6 +24,7 @@ use crate::{
     AppState,
 };
 use axum::{body::Bytes, extract::State, http::StatusCode};
+use entropy_client::user::request_attestation;
 use entropy_kvdb::kv_manager::KvManager;
 use entropy_shared::OcwMessageAttestationRequest;
 use parity_scale_codec::Decode;
@@ -75,6 +76,30 @@ pub async fn attest(
     submit_transaction(&api, &rpc, &signer, &attest_tx, None).await?;
 
     Ok(StatusCode::OK)
+}
+
+/// Retrieve a quote by requesting a nonce from the chain and return the quote in the HTTP response
+/// body.
+/// This is used by node operators to get a quote for use in the `validate`, `change_endpoint`
+/// and `change_tss_accounts` extrinsics.
+pub async fn get_attest(
+    State(app_state): State<AppState>,
+) -> Result<(StatusCode, Vec<u8>), AttestationErr> {
+    let (signer, x25519_secret) = get_signer_and_x25519_secret(&app_state.kv_store).await?;
+    let api = get_api(&app_state.configuration.endpoint).await?;
+    let rpc = get_rpc(&app_state.configuration.endpoint).await?;
+
+    // Request attestation to get nonce
+    let nonce = request_attestation(&api, &rpc, signer.signer()).await.unwrap();
+
+    // We also need the current block number as input
+    let block_number =
+        rpc.chain_get_header(None).await?.ok_or_else(|| AttestationErr::BlockNumber)?.number;
+
+    // We add 1 to the block number as this will be processed in the next block
+    let quote = create_quote(block_number + 1, nonce, &signer, &x25519_secret).await?;
+
+    Ok((StatusCode::OK, quote))
 }
 
 /// Create a mock quote for testing on non-TDX hardware

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -80,6 +80,7 @@ pub async fn attest(
 
 /// Retrieve a quote by requesting a nonce from the chain and return the quote in the HTTP response
 /// body.
+///
 /// This is used by node operators to get a quote for use in the `validate`, `change_endpoint`
 /// and `change_tss_accounts` extrinsics.
 pub async fn get_attest(

--- a/crates/threshold-signature-server/src/attestation/errors.rs
+++ b/crates/threshold-signature-server/src/attestation/errors.rs
@@ -48,6 +48,8 @@ pub enum AttestationErr {
     Kv(#[from] entropy_kvdb::kv_manager::error::KvError),
     #[error("Data is stale")]
     StaleData,
+    #[error("Attestation request: {0}")]
+    AttestationRequest(#[from] entropy_client::errors::AttestationRequestError),
 }
 
 impl IntoResponse for AttestationErr {

--- a/crates/threshold-signature-server/src/attestation/tests.rs
+++ b/crates/threshold-signature-server/src/attestation/tests.rs
@@ -27,10 +27,40 @@ use crate::{
 use entropy_kvdb::clean_tests;
 use entropy_shared::OcwMessageAttestationRequest;
 use entropy_testing_utils::{
-    constants::TSS_ACCOUNTS,
+    constants::{BOB_STASH_ADDRESS, TSS_ACCOUNTS},
     substrate_context::{test_context_stationary, test_node_process_stationary},
 };
 use serial_test::serial;
+use subxt::utils::AccountId32;
+use tdx_quote::{decode_verifying_key, Quote};
+
+#[tokio::test]
+#[serial]
+async fn test_get_attest() {
+    initialize_test_logger().await;
+    clean_tests();
+
+    let cxt = test_node_process_stationary().await;
+    let (_validator_ips, _validator_ids) =
+        spawn_testing_validators(ChainSpecType::Integration).await;
+
+    let api = get_api(&cxt.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
+
+    let quote_bytes =
+        reqwest::get("http://127.0.0.1:3002/attest").await.unwrap().bytes().await.unwrap();
+    let quote = Quote::from_bytes(&quote_bytes).unwrap();
+
+    let query =
+        entropy::storage().staking_extension().threshold_servers(&AccountId32(BOB_STASH_ADDRESS.0));
+    let server_info = query_chain(&api, &rpc, query, None).await.unwrap().unwrap();
+
+    let provisioning_certification_key =
+        decode_verifying_key(&server_info.provisioning_certification_key.0.try_into().unwrap())
+            .unwrap();
+
+    assert!(quote.verify_with_pck(provisioning_certification_key).is_ok())
+}
 
 #[ignore]
 #[tokio::test]

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -182,7 +182,7 @@ pub use crate::helpers::{
     validator::{get_signer, get_signer_and_x25519_secret},
 };
 use crate::{
-    attestation::api::attest,
+    attestation::api::{attest, get_attest},
     health::api::healthz,
     launch::Configuration,
     node_info::api::{hashes, version as get_version},
@@ -214,6 +214,7 @@ pub fn app(app_state: AppState) -> Router {
         .route("/validator/reshare", post(new_reshare))
         .route("/rotate_network_key", post(rotate_network_key))
         .route("/attest", post(attest))
+        .route("/attest", get(get_attest))
         .route("/healthz", get(healthz))
         .route("/version", get(get_version))
         .route("/hashes", get(hashes))


### PR DESCRIPTION
Part of https://github.com/entropyxyz/entropy-core/issues/982 - see https://github.com/entropyxyz/entropy-core/issues/982#issuecomment-2456757856

This adds an endpoint to the TSS server which allows the operator to get a quote for use in the `validate`, `change_endpoint`, and `change_tss_accounts` extrinsics.

In doing this i noticed a possible problem with our design.  I have made an issue: https://github.com/entropyxyz/entropy-core/issues/1174