### PR TITLE
Add no current signer guard

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -794,6 +794,11 @@ pub mod pallet {
                 return Ok(weight);
             }
 
+            // Network not jumpstarted
+            if current_signers_length == 0 {
+                return Ok(weight);
+            }
+
             let mut new_signers: Vec<Vec<u8>> = vec![];
             let mut count = 0u32;
             let mut remove_indicies_len = 0;

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -524,6 +524,13 @@ fn it_deletes_when_no_bond_left() {
 }
 
 #[test]
+fn it_doesnt_panic_when_no_signers() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Staking::new_session_handler(&[1, 2, 3]));
+    });
+}
+
+#[test]
 fn it_tests_new_session_handler() {
     new_test_ext().execute_with(|| {
         // Start with current validators as 5 and 6 based off the Mock `GenesisConfig`.


### PR DESCRIPTION
Adds a guard for no current signer which will also act as a not jumpstarted guard as jumpstarting sets signers. Doing it this way saves a look up and is a little more protective IMO