### PR TITLE
Test CLI - if no configuration / aux info interfaces files are provided, default to an empty vector

### DIFF
--- a/crates/test-cli/src/lib.rs
+++ b/crates/test-cli/src/lib.rs
@@ -326,16 +326,18 @@ pub async fn run_command(
 
             let config_interface = match config_interface_file {
                 Some(file_name) => fs::read(file_name)?,
-                None => fs::read(
-                    config_interface_file_option.expect("No config interface file passed"),
-                )?,
+                None => match config_interface_file_option {
+                    Some(config_interface_file) => fs::read(config_interface_file)?,
+                    None => Vec::new(),
+                },
             };
 
             let aux_data_interface = match aux_data_interface_file {
                 Some(file_name) => fs::read(file_name)?,
-                None => fs::read(
-                    aux_data_interface_file_option.expect("No aux data interface file passed"),
-                )?,
+                None => match aux_data_interface_file_option {
+                    Some(aux_data_interface_file) => fs::read(aux_data_interface_file)?,
+                    None => Vec::new(),
+                },
             };
 
             let program_version_number = match program_version_number_option {


### PR DESCRIPTION
Closes https://github.com/entropyxyz/entropy-core/issues/1085