### PR TITLE
Use context, not block number in TDX quote input data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ At the moment this project **does not** adhere to
 - In [#1153](https://github.com/entropyxyz/entropy-core/pull/1153/) the program runtime was updated to accept
 multiple oracle inputs, this means any programs that were compiled and used need to be recompiled to the new
 runtime
+- In [#1179](https://github.com/entropyxyz/entropy-core/pull/1179) the format of TDX Quote input data has
+  been changed.
 
 ### Added
 - Protocol message versioning ([#1140](https://github.com/entropyxyz/entropy-core/pull/1140))
@@ -36,6 +38,7 @@ runtime
 - Add quote guards to `ServerInfo` related extrinsics ([#1123](https://github.com/entropyxyz/entropy-core/pull/1123/))
 - Remove declare synced ([#1134](https://github.com/entropyxyz/entropy-core/pull/1134/))
 - Update programs to accept multiple oracle data ([#1153](https://github.com/entropyxyz/entropy-core/pull/1153/))
+- Use context, not block number in TDX quote input data ([#1179](https://github.com/entropyxyz/entropy-core/pull/1179))
 
 ## [0.3.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0...release/v0.3.0) - 2024-10-22
 

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -17,6 +17,7 @@ use crate::{
     update_programs,
 };
 
+use entropy_shared::{QuoteContext, QuoteInputData};
 use entropy_testing_utils::{
     constants::{TEST_PROGRAM_WASM_BYTECODE, TSS_ACCOUNTS, X25519_PUBLIC_KEYS},
     helpers::encode_verifying_key,
@@ -54,11 +55,8 @@ async fn test_change_endpoint() {
         let signing_key = tdx_quote::SigningKey::random(&mut OsRng);
         let public_key = sr25519::Public(tss_account_id.0);
 
-        // We need to add `1` here since the quote is being checked in the next block
-        let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number + 1;
-
         let input_data =
-            entropy_shared::QuoteInputData::new(public_key, x25519_public_key, nonce, block_number);
+            QuoteInputData::new(public_key, x25519_public_key, nonce, QuoteContext::ChangeEndpoint);
 
         let mut pck_seeder = StdRng::from_seed(public_key.0);
         let pck = tdx_quote::SigningKey::random(&mut pck_seeder);
@@ -129,14 +127,11 @@ async fn test_change_threshold_accounts() {
     let pck_certificate_chain = vec![tss_public_key.0.to_vec()];
 
     let quote = {
-        // We need to add `1` here since the quote is being checked in the next block
-        let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number + 1;
-
         let input_data = entropy_shared::QuoteInputData::new(
             tss_public_key,
             *x25519_public_key.as_bytes(),
             nonce,
-            block_number,
+            QuoteContext::ChangeThresholdAccounts,
         );
 
         let signing_key = tdx_quote::SigningKey::random(&mut OsRng);

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -136,6 +136,7 @@ impl QuoteInputData {
 
 /// An indicator as to the context in which a quote is intended to be used
 #[derive(Clone, Encode, Decode, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum QuoteContext {
     /// To be used in the `validate` extrinsic
     Validate,

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -73,7 +73,7 @@ pub async fn attest(
             .ok_or_else(|| AttestationErr::Unexpected)?
     };
 
-    // TODO #1181 since this endpoint is currently only used in tests we dont know what the context should be
+    // TODO (#1181): since this endpoint is currently only used in tests we don't know what the context should be
     let context = QuoteContext::Validate;
 
     let quote = create_quote(nonce, &signer, &x25519_secret, context).await?;

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -73,7 +73,9 @@ pub async fn attest(
             .ok_or_else(|| AttestationErr::Unexpected)?
     };
 
-    let context = QuoteContext::Validate; // TODO
+    // TODO #1181 since this endpoint is currently only used in tests we dont know what the context should be
+    let context = QuoteContext::Validate;
+
     let quote = create_quote(nonce, &signer, &x25519_secret, context).await?;
 
     // Submit the quote
@@ -106,7 +108,9 @@ pub async fn get_attest(
 
     let context = match context_querystring.context.as_str() {
         "validate" => QuoteContext::Validate,
-        _ => panic!("Bad context"),
+        "change_endpoint" => QuoteContext::ChangeEndpoint,
+        "change_threshold_accounts" => QuoteContext::ChangeThresholdAccounts,
+        _ => return Err(AttestationErr::UnknownContext),
     };
 
     let quote = create_quote(nonce, &signer, &x25519_secret, context).await?;

--- a/crates/threshold-signature-server/src/attestation/errors.rs
+++ b/crates/threshold-signature-server/src/attestation/errors.rs
@@ -50,6 +50,8 @@ pub enum AttestationErr {
     StaleData,
     #[error("Attestation request: {0}")]
     AttestationRequest(#[from] entropy_client::errors::AttestationRequestError),
+    #[error("Invalid or unknown context value given in query string")]
+    UnknownContext,
 }
 
 impl IntoResponse for AttestationErr {

--- a/crates/threshold-signature-server/src/attestation/tests.rs
+++ b/crates/threshold-signature-server/src/attestation/tests.rs
@@ -47,8 +47,12 @@ async fn test_get_attest() {
     let api = get_api(&cxt.ws_url).await.unwrap();
     let rpc = get_rpc(&cxt.ws_url).await.unwrap();
 
-    let quote_bytes =
-        reqwest::get("http://127.0.0.1:3002/attest").await.unwrap().bytes().await.unwrap();
+    let quote_bytes = reqwest::get("http://127.0.0.1:3002/attest?context=validate")
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
     let quote = Quote::from_bytes(&quote_bytes).unwrap();
 
     let query =

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::mock::*;
-use entropy_shared::{AttestationHandler, QuoteInputData};
+use entropy_shared::{AttestationHandler, QuoteContext, QuoteInputData};
 use frame_support::{assert_noop, assert_ok};
 use rand_core::OsRng;
 
@@ -32,13 +32,12 @@ fn verify_quote_works() {
         let pck_encoded = tdx_quote::encode_verifying_key(pck.verifying_key()).unwrap();
 
         let x25519_public_key = [0; 32];
-        let block_number = 0;
 
         let input_data = QuoteInputData::new(
             ATTESTEE, // TSS Account ID
             x25519_public_key,
             nonce,
-            block_number,
+            QuoteContext::Validate,
         );
 
         let quote = tdx_quote::Quote::mock(attestation_key.clone(), pck, input_data.0);
@@ -47,6 +46,7 @@ fn verify_quote_works() {
             x25519_public_key,
             sp_runtime::BoundedVec::try_from(pck_encoded.to_vec()).unwrap(),
             quote.as_bytes().to_vec(),
+            QuoteContext::Validate,
         ));
     })
 }
@@ -63,13 +63,12 @@ fn verify_quote_fails_with_mismatched_input_data() {
         let pck_encoded = tdx_quote::encode_verifying_key(pck.verifying_key()).unwrap();
 
         let x25519_public_key = [0; 32];
-        let block_number = 0;
 
         let input_data = QuoteInputData::new(
             ATTESTEE, // TSS Account ID
             x25519_public_key,
             nonce,
-            block_number,
+            QuoteContext::Validate,
         );
 
         let quote = tdx_quote::Quote::mock(attestation_key.clone(), pck, input_data.0);
@@ -83,6 +82,7 @@ fn verify_quote_fails_with_mismatched_input_data() {
                 x25519_public_key,
                 sp_runtime::BoundedVec::try_from(pck_encoded.to_vec()).unwrap(),
                 quote.as_bytes().to_vec(),
+                QuoteContext::Validate,
             ),
             crate::Error::<Test>::UnexpectedAttestation,
         );
@@ -96,6 +96,7 @@ fn verify_quote_fails_with_mismatched_input_data() {
                 mismatched_x25519_public_key,
                 sp_runtime::BoundedVec::try_from(pck_encoded.to_vec()).unwrap(),
                 quote.as_bytes().to_vec(),
+                QuoteContext::Validate,
             ),
             crate::Error::<Test>::IncorrectInputData,
         );
@@ -116,6 +117,7 @@ fn verify_quote_fails_with_mismatched_input_data() {
                 x25519_public_key,
                 sp_runtime::BoundedVec::try_from(mismatched_pck_encoded.to_vec()).unwrap(),
                 quote.as_bytes().to_vec(),
+                QuoteContext::Validate,
             ),
             crate::Error::<Test>::PckVerification
         );

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -19,7 +19,7 @@ use super::*;
 use crate::pck::{signing_key_from_seed, MOCK_PCK_DERIVED_FROM_NULL_ARRAY};
 #[allow(unused_imports)]
 use crate::Pallet as Staking;
-use entropy_shared::{AttestationHandler, MAX_SIGNERS};
+use entropy_shared::{AttestationHandler, QuoteContext, MAX_SIGNERS};
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::{
     assert_ok, ensure,

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -78,7 +78,6 @@ fn prepare_attestation_for_validate<T: Config>(
     threshold: T::AccountId,
     x25519_public_key: [u8; 32],
     endpoint: Vec<u8>,
-    block_number: u32,
 ) -> (Vec<u8>, JoiningServerInfo<T::AccountId>) {
     let nonce = NULL_ARR;
     let quote = {
@@ -91,8 +90,12 @@ fn prepare_attestation_for_validate<T: Config>(
 
         let attestation_key = tdx_quote::SigningKey::from_bytes(&ATTESTATION_KEY.into()).unwrap();
 
-        let input_data =
-            entropy_shared::QuoteInputData::new(&threshold, x25519_public_key, nonce, block_number);
+        let input_data = entropy_shared::QuoteInputData::new(
+            &threshold,
+            x25519_public_key,
+            nonce,
+            QuoteContext::Validate,
+        );
 
         tdx_quote::Quote::mock(attestation_key.clone(), pck, input_data.0).as_bytes().to_vec()
     };
@@ -132,14 +135,9 @@ fn prep_bond_and_validate<T: Config>(
     ));
 
     if validate_also {
-        let block_number = 0;
         let endpoint = b"http://localhost:3001".to_vec();
-        let (quote, joining_server_info) = prepare_attestation_for_validate::<T>(
-            threshold,
-            x25519_public_key,
-            endpoint,
-            block_number,
-        );
+        let (quote, joining_server_info) =
+            prepare_attestation_for_validate::<T>(threshold, x25519_public_key, endpoint);
 
         assert_ok!(<Staking<T>>::validate(
             RawOrigin::Signed(bonder.clone()).into(),
@@ -185,13 +183,10 @@ benchmarks! {
         x25519_public_key.clone(),
     );
 
-    // For quote verification this needs to be the _next_ block, and right now we're at block `0`.
-    let block_number = 1;
     let quote = prepare_attestation_for_validate::<T>(
         threshold,
         x25519_public_key,
         endpoint.clone().to_vec(),
-        block_number,
     )
     .0;
   }:  _(RawOrigin::Signed(bonder.clone()), endpoint.to_vec(), quote)
@@ -229,12 +224,10 @@ benchmarks! {
     );
 
     // For quote verification this needs to be the _next_ block, and right now we're at block `0`.
-    let block_number = 1;
     let (quote , joining_server_info) = prepare_attestation_for_validate::<T>(
         new_threshold.clone(),
         x25519_public_key,
         endpoint.clone().to_vec(),
-        block_number,
     );
 
     let pck_certificate_chain = joining_server_info.pck_certificate_chain;
@@ -383,10 +376,8 @@ benchmarks! {
         x25519_public_key.clone()
     );
 
-    // For quote verification this needs to be the _next_ block, and right now we're at block `0`.
-    let block_number = 1;
     let (quote, joining_server_info) =
-        prepare_attestation_for_validate::<T>(threshold_account.clone(), x25519_public_key, endpoint.clone(), block_number);
+        prepare_attestation_for_validate::<T>(threshold_account.clone(), x25519_public_key, endpoint.clone());
   }:  _(RawOrigin::Signed(bonder.clone()), ValidatorPrefs::default(), joining_server_info, quote)
   verify {
     assert_last_event::<T>(

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -60,7 +60,7 @@ use sp_staking::SessionIndex;
 #[frame_support::pallet]
 pub mod pallet {
     use entropy_shared::{
-        ValidatorInfo, X25519PublicKey, MAX_SIGNERS, TEST_RESHARE_BLOCK_NUMBER,
+        QuoteContext, ValidatorInfo, X25519PublicKey, MAX_SIGNERS, TEST_RESHARE_BLOCK_NUMBER,
         VERIFICATION_KEY_LENGTH,
     };
     use frame_support::{
@@ -417,7 +417,8 @@ pub mod pallet {
                             &server_info.tss_account.clone(),
                             server_info.x25519_public_key,
                             server_info.provisioning_certification_key.clone(),
-                            quote
+                            quote,
+                            QuoteContext::ChangeEndpoint,
                         )
                         .is_ok(),
                         Error::<T>::FailedAttestationCheck
@@ -492,7 +493,8 @@ pub mod pallet {
                                 &tss_account.clone(),
                                 x25519_public_key,
                                 provisioning_certification_key.clone(),
-                                quote
+                                quote,
+                                QuoteContext::ChangeThresholdAccounts,
                             )
                             .is_ok(),
                             Error::<T>::FailedAttestationCheck
@@ -645,7 +647,8 @@ pub mod pallet {
                     &server_info.tss_account.clone(),
                     server_info.x25519_public_key,
                     server_info.provisioning_certification_key.clone(),
-                    quote
+                    quote,
+                    QuoteContext::Validate,
                 )
                 .is_ok(),
                 Error::<T>::FailedAttestationCheck

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -16,6 +16,7 @@
 use core::convert::{TryFrom, TryInto};
 use std::cell::RefCell;
 
+use entropy_shared::QuoteContext;
 use frame_election_provider_support::{
     bounds::{ElectionBounds, ElectionBoundsBuilder},
     onchain, SequentialPhragmen, VoteWeight,
@@ -400,6 +401,7 @@ impl entropy_shared::AttestationHandler<AccountId> for MockAttestationHandler {
         _x25519_public_key: entropy_shared::X25519PublicKey,
         _provisioning_certification_key: entropy_shared::BoundedVecEncodedVerifyingKey,
         quote: Vec<u8>,
+        _context: QuoteContext,
     ) -> Result<(), sp_runtime::DispatchError> {
         let quote: Result<[u8; 32], _> = quote.try_into();
         match quote {


### PR DESCRIPTION
Closes https://github.com/entropyxyz/entropy-core/issues/1174

This removes block number from the quote input data as this is time sensitive and it can be difficult to know at the moment of creating the quote when it will be validated.

Instead we use a `QuoteContext` enum which indicates the context in which this quote is intended to be used.

This can currently be one of:
- The `validate` extrinsic
- The `change_endpoint` extrinsic
- The `change_threshold_accounts` extrinsic