### PR TITLE
Reshare in a spawned task and fix propagation pallet rotate keyshares endpoint lookup key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ runtime
 - Remove declare synced ([#1134](https://github.com/entropyxyz/entropy-core/pull/1134/))
 - Update programs to accept multiple oracle data ([#1153](https://github.com/entropyxyz/entropy-core/pull/1153/))
 
+### Fixed
+
+- Reshare in a spawned task and fix propagation pallet rotate keyshares endpoint lookup key ([#1185](https://github.com/entropyxyz/entropy-core/pull/1185))
+
 ## [0.3.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0...release/v0.3.0) - 2024-10-22
 
 ### Breaking Changes

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -44,6 +44,7 @@ use subxt::{
     OnlineClient,
 };
 use synedrion::{KeyResharingInputs, NewHolder, OldHolder};
+use x25519_dalek::StaticSecret;
 
 /// HTTP POST endpoint called by the off-chain worker (propagation pallet) during network reshare.
 ///
@@ -61,20 +62,48 @@ pub async fn new_reshare(
     let rpc = get_rpc(&app_state.configuration.endpoint).await?;
     validate_new_reshare(&api, &rpc, &data, &app_state.kv_store).await?;
 
+    let (signer, x25519_secret_key) = get_signer_and_x25519_secret(&app_state.kv_store)
+        .await
+        .map_err(|e| ValidatorErr::UserError(e.to_string()))?;
+
     let next_signers_query = entropy::storage().staking_extension().next_signers();
     let next_signers = query_chain(&api, &rpc, next_signers_query, None)
         .await?
         .ok_or_else(|| ValidatorErr::ChainFetch("Error getting next signers"))?
         .next_signers;
-
     let validators_info = get_validators_info(&api, &rpc, next_signers)
         .await
         .map_err(|e| ValidatorErr::UserError(e.to_string()))?;
 
-    let (signer, x25519_secret_key) = get_signer_and_x25519_secret(&app_state.kv_store)
-        .await
-        .map_err(|e| ValidatorErr::UserError(e.to_string()))?;
+    let is_proper_signer = validators_info
+        .iter()
+        .any(|validator_info| validator_info.tss_account == *signer.account_id());
 
+    if !is_proper_signer {
+        return Ok(StatusCode::MISDIRECTED_REQUEST);
+    }
+
+    // Do reshare in a separate task so we can already respond
+    tokio::spawn(async move {
+        if let Err(err) =
+            do_reshare(api, &rpc, signer, &x25519_secret_key, data, validators_info, app_state)
+                .await
+        {
+            tracing::error!("Error during reshare: {err}");
+        }
+    });
+    Ok(StatusCode::OK)
+}
+
+async fn do_reshare(
+    api: OnlineClient<EntropyConfig>,
+    rpc: &LegacyRpcMethods<EntropyConfig>,
+    signer: PairSigner<EntropyConfig, sr25519::Pair>,
+    x25519_secret_key: &StaticSecret,
+    data: OcwMessageReshare,
+    validators_info: Vec<ValidatorInfo>,
+    app_state: AppState,
+) -> Result<(), ValidatorErr> {
     let verifying_key_query = entropy::storage().staking_extension().jump_start_progress();
     let parent_key_details = query_chain(&api, &rpc, verifying_key_query, None)
         .await?
@@ -92,15 +121,6 @@ pub async fn new_reshare(
             .map_err(|_| ValidatorErr::Conversion("Verifying key conversion"))?,
     )
     .map_err(|e| ValidatorErr::VerifyingKeyError(e.to_string()))?;
-
-    let is_proper_signer = validators_info
-        .iter()
-        .any(|validator_info| validator_info.tss_account == *signer.account_id());
-
-    if !is_proper_signer {
-        return Ok(StatusCode::MISDIRECTED_REQUEST);
-    }
-
     let my_stash_address = get_stash_address(&api, &rpc, signer.account_id())
         .await
         .map_err(|e| ValidatorErr::UserError(e.to_string()))?;
@@ -158,6 +178,7 @@ pub async fn new_reshare(
         converted_validator_info.push(validator_info.clone());
         tss_accounts.push(validator_info.tss_account.clone());
     }
+
     let channels = get_channels(
         &app_state.listener_state,
         converted_validator_info,
@@ -167,7 +188,6 @@ pub async fn new_reshare(
         &x25519_secret_key,
     )
     .await?;
-
     let (new_key_share, aux_info) =
         execute_reshare(session_id.clone(), channels, signer.signer(), inputs, &new_holders, None)
             .await?;
@@ -185,7 +205,7 @@ pub async fn new_reshare(
 
     // TODO: Error handling really complex needs to be thought about.
     confirm_key_reshare(&api, &rpc, &signer).await?;
-    Ok(StatusCode::OK)
+    Ok(())
 }
 
 /// HTTP POST endpoint called by the off-chain worker (propagation pallet) after a network key reshare.

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -146,7 +146,6 @@ async fn test_reshare() {
             HashSet::from_iter(signer_ids.into_iter().map(|id| id.0))
         };
         if new_signer_ids != old_signer_ids {
-            println!("Signers have changed");
             break;
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -369,7 +369,7 @@ pub fn new_full_base(
             );
             offchain_db.local_storage_set(
                 sp_core::offchain::StorageKind::PERSISTENT,
-                b"rotate_keyshares",
+                b"rotate_network_key",
                 &format!("{}/rotate_network_key", endpoint).into_bytes(),
             );
             offchain_db.local_storage_set(


### PR DESCRIPTION
When fixing the reshare test in https://github.com/entropyxyz/entropy-core/pull/1162 i found two problems which mean the resharing will not work in production.

1. The lookup key for the rotate keyshares endpoint is incorrect
2. The http client used by the propagation pallet has a timeout set to two seconds.  When this timeout is met, the http client closes the connection, causing axum to kill the task handling the request. This causes the reshare to stop mid-protocol.  This is fixed here by running the protocol in a spawned task, as we do with DKG.

I have fixed these in https://github.com/entropyxyz/entropy-core/pull/1162 - but since that PR makes quite some changes to our test setup, and still needs some cleaning up, i wanted to put the fixes in a separate PR, so its clear what they are, and so it could be used for a fix for our current testnet (resharing will not work without these fixes).

If we want to fix things with a runtime upgrade and not need to update the TSS code, we could bump up the timeout instead of spawning a task for the reshare.  But i think long term it is better to use a separate task, because amount of time the reshare takes depends on many factors. 