### PR TITLE
Use debug when displaying public key for attestation client function

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -160,7 +160,7 @@ pub async fn request_attestation(
     rpc: &LegacyRpcMethods<EntropyConfig>,
     attestee: &sr25519::Pair,
 ) -> Result<[u8; 32], AttestationRequestError> {
-    tracing::debug!("{} is requesting an attestation.", attestee.public());
+    tracing::debug!("{:?} is requesting an attestation.", attestee.public());
 
     let request_attestation = entropy::tx().attestation().request_attestation();
 


### PR DESCRIPTION
When building `entropy-client` for the status page i get the following error:

```
  Compiling entropy-client v0.3.0 (https://github.com/entropyxyz/entropy-core.git#425b2819)
error[E0277]: `sp_core::sr25519::Public` doesn't implement `std::fmt::Display`
   --> /home/turnip/.cargo/git/checkouts/entropy-core-6e6c2c3deec0f284/425b281/crates/client/src/user.rs:163:57
    |
163 |     tracing::debug!("{} is requesting an attestation.", attestee.public());
    |                                                         ^^^^^^^^^^^^^^^^^ `sp_core::sr25519::Public` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `sp_core::sr25519::Public`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: this error originates in the macro `$crate::__macro_support::format_args` which comes from the expansion of the macro `tracing::debug` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Im not sure why we don't get this problem in CI for this repo, its probably related to available traits or feature flags. But anyway this PR should fix it.