### PR TITLE
Fix error handling for TDX quote generation in production

### DIFF
--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -186,7 +186,8 @@ pub async fn create_quote(
         context,
     );
 
-    Ok(configfs_tsm::create_quote(input_data.0)?)
+    Ok(configfs_tsm::create_quote(input_data.0)
+        .map_err(|e| AttestationErr::QuoteGeneration(format!("{:?}", e)))?)
 }
 
 /// Querystring for the GET `/attest` endpoint

--- a/crates/threshold-signature-server/src/attestation/errors.rs
+++ b/crates/threshold-signature-server/src/attestation/errors.rs
@@ -39,7 +39,7 @@ pub enum AttestationErr {
     Codec(#[from] parity_scale_codec::Error),
     #[cfg(feature = "production")]
     #[error("Quote generation: {0}")]
-    QuoteGeneration(#[from] std::io::Error),
+    QuoteGeneration(String),
     #[error("Vec<u8> Conversion Error: {0}")]
     Conversion(&'static str),
     #[error("Data is repeated")]


### PR DESCRIPTION
In `entropy-tss`, real (non-mock) TDX quotes are currently only generated when the `production` feature flag is enabled.

Unfortunately that means the code behind that flag is not tested in CI.  I recently set up a test network on TDX hardware to test attestation, and `entropy-tss` would not compile with the `production` feature flag enabled due to the error type which `config-tsm::generate_quote` having changed. This PR fixes that.

I have also made an issue to have the error type improved before the next release of `configfs-tsm`: https://github.com/entropyxyz/configfs-tsm/issues/7

We could also consider adding `cargo check -p entropy-tss --feature production` to our CI.