### PR TITLE
V0.3.0 hot fix for reshare validation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 At the moment this project **does not** adhere to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/entropyxyz/entropy-core/compare/release/v0.3.0-rc.1...master)
+## [Unreleased](https://github.com/entropyxyz/entropy-core/compare/release/v0.3.0...master)
 
-## [0.3.0-rc.1](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0...release/v0.3.0-rc.1) - 2024-10-04
+## [0.3.0](https://github.com/entropyxyz/entropy-core/compare/release/v0.2.0...release/v0.3.0) - 2024-10-22
 
 ### Breaking Changes
 - In [#799](https://github.com/entropyxyz/entropy-core/pull/799) the concept of subgroups was
   removed in favour of a single pool of signers.
 - In [#801](https://github.com/entropyxyz/entropy-core/pull/801) permissioned access mode was
   removed.
-- In [#879](https://github.com/entropyxyz/entropy-core/pull/879) the network migrated from t-of-N
+- In [#879](https://github.com/entropyxyz/entropy-core/pull/879) the network migrated from N-of-N
   cryptography to `t-of-N` cryptography.
 - In [#938](https://github.com/entropyxyz/entropy-core/pull/938), the chainspec got a couple of new
   fields, `pallet_staking_extension::initial_signers`, `pallet_parameters::total_signers`, and
@@ -37,7 +37,10 @@ At the moment this project **does not** adhere to
   As such, `UserSignatureRequest` no longer requires the `validators_info` field since the the
   relayer adds that in after. The response received from the validator is now a `Vec<Responses>`
   from the signers.
-- In ([#1063](https://github.com/entropyxyz/entropy-core/pull/1063)) the
+- In [#1051](https://github.com/entropyxyz/entropy-core/pull/1051) an extra field representing a provisioning certification key (PCK)
+  was added to the Staking Extension's `threshold_server` genesis configuration in the network
+  chainspecs.
+- In [#1063](https://github.com/entropyxyz/entropy-core/pull/1063) the
   `pallet_staking_extension::validate()` extrinsic was changed so that in order to populate certain
   data structures related to a candidates state (namely `ThresholdToStash` and `ThresholdServer`) an
   attestation from the Attestation pallet must have been received. Success of the `validate()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "entropy-runtime",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-client"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-create-test-keyshares"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-kvdb",
  "entropy-shared",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-kvdb"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "bincode 1.3.3",
  "chacha20poly1305 0.9.1",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-protocol"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-runtime"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-shared"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "blake2 0.10.6",
  "hex-literal",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-test-cli"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-testing-utils"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "entropy-kvdb",
@@ -2754,7 +2754,7 @@ dependencies = [
  "sp-keyring 34.0.0",
  "subxt",
  "synedrion",
- "tdx-quote 0.0.1",
+ "tdx-quote",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-tss"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2813,7 +2813,7 @@ dependencies = [
  "subxt",
  "subxt-signer",
  "synedrion",
- "tdx-quote 0.0.1",
+ "tdx-quote",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-attestation"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -6712,7 +6712,7 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-staking 27.0.0",
  "sp-std 14.0.0",
- "tdx-quote 0.0.1",
+ "tdx-quote",
 ]
 
 [[package]]
@@ -7129,7 +7129,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-oracle"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7180,7 +7180,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-programs"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7198,7 +7198,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-propagation"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7265,7 +7265,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registry"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "bip32",
  "entropy-shared",
@@ -7358,7 +7358,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-slashing"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-extension"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7436,7 +7436,7 @@ dependencies = [
  "sp-runtime 32.0.0",
  "sp-staking 27.0.0",
  "sp-std 14.0.0",
- "tdx-quote 0.1.0",
+ "tdx-quote",
 ]
 
 [[package]]
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-pause"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -14150,16 +14150,6 @@ name = "tdx-quote"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10fe3140395153ccb4050f6eb51fe621a3b6d76da489601aec9fabe2fb1c3e0"
-dependencies = [
- "nom",
- "p256",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "tdx-quote"
-version = "0.1.0"
-source = "git+https://github.com/entropyxyz/tdx-quote?rev=cb167f2#cb167f2aef1c7539c91082ee21c764eac60f6bef"
 dependencies = [
  "nom",
  "p256",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-client"
-version    ="0.3.0-rc.1"
+version    ="0.3.0"
 edition    ="2021"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -11,7 +11,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 [dependencies]
 sha3          ="0.10.8"
 serde         ={ version="1.0", default-features=false, features=["derive"] }
-entropy-shared={ version="0.3.0-rc.1", path="../shared", default-features=false }
+entropy-shared={ version="0.3.0", path="../shared", default-features=false }
 subxt         ={ version="0.35.3", default-features=false, features=["jsonrpsee"] }
 num           ="0.4.3"
 thiserror     ="1.0.64"
@@ -25,7 +25,7 @@ blake2          ={ version="0.10.4", optional=true }
 rand_core       ={ version="0.6.4", optional=true }
 serde_json      ={ version="1.0", optional=true }
 x25519-dalek    ={ version="2.0.1", features=["static_secrets"], optional=true }
-entropy-protocol={ version="0.3.0-rc.1", path="../protocol", optional=true, default-features=false }
+entropy-protocol={ version="0.3.0", path="../protocol", optional=true, default-features=false }
 reqwest         ={ version="0.12.8", features=["json", "stream"], optional=true }
 base64          ={ version="0.22.0", optional=true }
 synedrion       ={ version="0.2.0-beta.0", optional=true }

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-kvdb"
 description="Encrypted key-value database for the Entropy Theshold Signing Server"
-version    ="0.3.0-rc.1"
+version    ="0.3.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -32,7 +32,7 @@ tracing={ version="0.1", default-features=false }
 # Misc
 sled            ="0.34.7"
 bincode         ="1.3.3"
-entropy-protocol={ version="0.3.0-rc.1", path="../protocol" }
+entropy-protocol={ version="0.3.0", path="../protocol" }
 
 [dev-dependencies]
 serial_test="3.1.1"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy-protocol'
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 description="Entropy Signing and DKG protocol execution and transport logic"
 homepage   ='https://entropy.xyz/'
@@ -10,7 +10,7 @@ edition    ='2021'
 
 [dependencies]
 async-trait        ="0.1.83"
-entropy-shared     ={ version="0.3.0-rc.1", path="../shared", default-features=false }
+entropy-shared     ={ version="0.3.0", path="../shared", default-features=false }
 synedrion          ={ version="0.2.0-beta.0" }
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-shared"
 description="Shared types used by the Entropy chain node and Entropy Threshold Signing Server"
-version    ="0.3.0-rc.1"
+version    ="0.3.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-test-cli"
 description="Simple command line interface client for testing Entropy"
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -9,7 +9,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-entropy-client={ version="0.3.0-rc.1", path="../client" }
+entropy-client={ version="0.3.0", path="../client" }
 clap          ={ version="4.5.19", features=["derive"] }
 colored       ="2.0.4"
 subxt         ="0.35.3"
@@ -20,4 +20,4 @@ hex           ="0.4.3"
 bincode       ="1.3.3"
 x25519-dalek  ="2.0.1"
 sp-runtime    ={ version="32.0.0", default-features=false }
-entropy-shared={ version="0.3.0-rc.1", path="../shared" }
+entropy-shared={ version="0.3.0", path="../shared" }

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-testing-utils"
 description="Utilities for testing the Entropy Threshold Signature Server"
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -9,26 +9,24 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-subxt="0.35.3"
-sp-keyring="34.0.0"
-project-root="0.2.2"
-sp-core={ version="31.0.0", default-features=false }
+subxt             ="0.35.3"
+sp-keyring        ="34.0.0"
+project-root      ="0.2.2"
+sp-core           ={ version="31.0.0", default-features=false }
 parity-scale-codec="3.6.12"
-lazy_static="1.5.0"
-hex-literal="0.4.1"
-tokio={ version="1.40", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
-axum={ version="0.7.7" }
-entropy-shared={ version="0.3.0-rc.1", path="../shared" }
-entropy-kvdb={ version="0.3.0-rc.1", path="../kvdb", default-features=false }
-entropy-tss={ version="0.3.0-rc.1", path="../threshold-signature-server", features=[
-  "test_helpers",
-] }
-entropy-protocol={ version="0.3.0-rc.1", path="../protocol" }
-synedrion={ version="0.2.0-beta.0" }
-hex="0.4.3"
-rand_core="0.6.4"
-rand="0.8.5"
-tdx-quote={ version="0.0.1", features=["mock"] }
+lazy_static       ="1.5.0"
+hex-literal       ="0.4.1"
+tokio             ={ version="1.40", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
+axum              ={ version="0.7.7" }
+entropy-shared    ={ version="0.3.0", path="../shared" }
+entropy-kvdb      ={ version="0.3.0", path="../kvdb", default-features=false }
+entropy-tss       ={ version="0.3.0", path="../threshold-signature-server", features=["test_helpers"] }
+entropy-protocol  ={ version="0.3.0", path="../protocol" }
+synedrion         ={ version="0.2.0-beta.0" }
+hex               ="0.4.3"
+rand_core         ="0.6.4"
+rand              ="0.8.5"
+tdx-quote         ={ version="0.0.1", features=["mock"] }
 
 # Logging
 tracing           ="0.1.37"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-tss"
-version    ="0.3.0-rc.1"
+version    ="0.3.0"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 description='Entropy threshold signature scheme (TSS) server'
@@ -40,12 +40,10 @@ parity-scale-codec="3.6.12"
 sp-core           ={ version="31.0.0", default-features=false }
 
 # Entropy
-entropy-shared={ version="0.3.0-rc.1", path="../shared" }
-entropy-kvdb={ version="0.3.0-rc.1", path="../kvdb", default-features=false }
-entropy-protocol={ version="0.3.0-rc.1", path="../protocol", features=["server"] }
-entropy-client={ version="0.3.0-rc.1", path="../client", default-features=false, features=[
-  "native",
-] }
+entropy-shared  ={ version="0.3.0", path="../shared" }
+entropy-kvdb    ={ version="0.3.0", path="../kvdb", default-features=false }
+entropy-protocol={ version="0.3.0", path="../protocol", features=["server"] }
+entropy-client  ={ version="0.3.0", path="../client", default-features=false, features=["native"] }
 
 # Programs
 entropy-programs-runtime="0.10.0"

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -29,7 +29,7 @@ use entropy_protocol::{
 };
 use entropy_shared::{
     HashingAlgorithm, DAVE_VERIFYING_KEY, DEFAULT_VERIFYING_KEY_NOT_REGISTERED, DEVICE_KEY_HASH,
-    EVE_VERIFYING_KEY, NETWORK_PARENT_KEY,
+    NETWORK_PARENT_KEY,
 };
 use entropy_testing_utils::{
     chain_api::{

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy'
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 description="Entropy substrate node"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -90,12 +90,12 @@ pallet-transaction-payment    ={ version="29.0.0" }
 pallet-transaction-payment-rpc={ version="31.0.0" }
 
 # Entropy Dependencies
-entropy-runtime={ version="0.3.0-rc.1", path="../../runtime" }
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-runtime={ version="0.3.0", path="../../runtime" }
+entropy-shared={ version="0.3.0", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-registry={ version="0.3.0-rc.1", path="../../pallets/registry" }
-pallet-staking-extension={ version="0.3.0-rc.1", path="../../pallets/staking" }
+pallet-registry={ version="0.3.0", path="../../pallets/registry" }
+pallet-staking-extension={ version="0.3.0", path="../../pallets/staking" }
 project-root="0.2.2"
 
 [build-dependencies]

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-attestation"
-version   ="0.3.0-rc.1"
+version   ="0.3.0"
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -23,11 +23,11 @@ sp-std            ={ version="14.0.0", default-features=false }
 pallet-session    ={ version="29.0.0", default-features=false, optional=true }
 rand_chacha       ={ version="0.3", default-features=false }
 
-pallet-parameters={ version="0.3.0-rc.1", path="../parameters", default-features=false }
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", features=[
+pallet-parameters={ version="0.3.0", path="../parameters", default-features=false }
+entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-pallet-staking-extension={ version="0.3.0-rc.1", path="../staking", default-features=false }
+pallet-staking-extension={ version="0.3.0", path="../staking", default-features=false }
 tdx-quote="0.0.1"
 
 [dev-dependencies]

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-oracle"
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/parameters/Cargo.toml
+++ b/pallets/parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-parameters"
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -19,7 +19,7 @@ sp-runtime        ={ version="32.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 pallet-session    ={ version="29.0.0", default-features=false }
 
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 

--- a/pallets/programs/Cargo.toml
+++ b/pallets/programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-programs'
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/propagation/Cargo.toml
+++ b/pallets/propagation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-propagation'
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -26,13 +26,13 @@ sp-io                ={ version="31.0.0", default-features=false }
 sp-runtime           ={ version="32.0.0", default-features=false }
 sp-staking           ={ version="27.0.0", default-features=false }
 
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.3.0", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-registry={ version="0.3.0-rc.1", path="../registry", default-features=false }
-pallet-programs={ version="0.3.0-rc.1", path="../programs", default-features=false }
-pallet-staking-extension={ version="0.3.0-rc.1", path="../staking", default-features=false }
-pallet-attestation={ version="0.3.0-rc.1", path="../attestation", default-features=false }
+pallet-registry={ version="0.3.0", path="../registry", default-features=false }
+pallet-programs={ version="0.3.0", path="../programs", default-features=false }
+pallet-staking-extension={ version="0.3.0", path="../staking", default-features=false }
+pallet-attestation={ version="0.3.0", path="../attestation", default-features=false }
 
 [dev-dependencies]
 parking_lot="0.12.3"
@@ -47,7 +47,7 @@ pallet-staking-reward-curve    ={ version="11.0.0" }
 pallet-timestamp               ={ version="28.0.0", default-features=false }
 sp-keystore                    ={ version="0.35.0" }
 sp-npos-elections              ={ version="27.0.0", default-features=false }
-pallet-parameters              ={ version="0.3.0-rc.1", path="../parameters", default-features=false }
+pallet-parameters              ={ version="0.3.0", path="../parameters", default-features=false }
 
 [features]
 default=['std']

--- a/pallets/propagation/src/lib.rs
+++ b/pallets/propagation/src/lib.rs
@@ -158,11 +158,11 @@ pub mod pallet {
         /// Submits a request to do a key refresh on the signers parent key.
         pub fn post_reshare(block_number: BlockNumberFor<T>) -> Result<(), http::Error> {
             let reshare_data = pallet_staking_extension::Pallet::<T>::reshare_data();
-            if reshare_data.block_number != block_number {
+            if reshare_data.block_number != block_number + sp_runtime::traits::One::one() {
                 return Ok(());
             }
 
-            let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(2_000));
+            let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(10_000));
             let kind = sp_core::offchain::StorageKind::PERSISTENT;
             let from_local = sp_io::offchain::local_storage_get(kind, b"reshare_validators")
                 .unwrap_or_else(|| b"http://localhost:3001/validator/reshare".to_vec());

--- a/pallets/propagation/src/tests.rs
+++ b/pallets/propagation/src/tests.rs
@@ -88,7 +88,7 @@ fn knows_how_to_mock_several_http_calls() {
         // doesn't trigger no reshare block
         Propagation::post_reshare(7).unwrap();
         pallet_staking_extension::ReshareData::<Test>::put(ReshareInfo {
-            block_number: 7,
+            block_number: 8,
             new_signer: 1u64.encode(),
         });
         // now triggers

--- a/pallets/registry/Cargo.toml
+++ b/pallets/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-registry'
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -29,12 +29,12 @@ sp-core           ={ version="29.0.0", default-features=false }
 sp-runtime        ={ version="32.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-pallet-programs={ version="0.3.0-rc.1", path="../programs", default-features=false }
-pallet-staking-extension={ version="0.3.0-rc.1", path="../staking", default-features=false }
-pallet-parameters={ version="0.3.0-rc.1", path="../parameters", default-features=false }
+pallet-programs={ version="0.3.0", path="../programs", default-features=false }
+pallet-staking-extension={ version="0.3.0", path="../staking", default-features=false }
+pallet-parameters={ version="0.3.0", path="../parameters", default-features=false }
 
 [dev-dependencies]
 frame-election-provider-support={ version="29.0.0", default-features=false }

--- a/pallets/slashing/Cargo.toml
+++ b/pallets/slashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-slashing'
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-staking-extension'
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -29,16 +29,14 @@ sp-staking        ={ version="27.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 sp-consensus-babe ={ version="0.33.0", default-features=false }
 
-pallet-parameters={ version="0.3.0-rc.1", path="../parameters", default-features=false }
-entropy-shared={ version="0.3.0-rc.1", path="../../crates/shared", features=[
+pallet-parameters={ version="0.3.0", path="../parameters", default-features=false }
+entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 
 # We only use this in benchmarks and tests. Since the benches don't run with the `test` feature we need to
 # import it here _and_ as a `dev-dependency`.
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote", rev="cb167f2", features=[
-  "mock",
-], optional=true }
+tdx-quote={ version="0.0.1", features=["mock"], optional=true }
 
 [dev-dependencies]
 frame-election-provider-support={ version="29.0.0", default-features=false }
@@ -50,8 +48,8 @@ sp-io                          ={ version="31.0.0", default-features=false }
 sp-npos-elections              ={ version="27.0.0", default-features=false }
 
 rand_core         ="0.6.4"
-tdx-quote         ={ git="https://github.com/entropyxyz/tdx-quote", rev="cb167f2", features=["mock"] }
-pallet-attestation={ version="0.3.0-rc.1", path="../attestation" }
+tdx-quote         ={ version="0.0.1", features=["mock"] }
+pallet-attestation={ version="0.3.0", path="../attestation" }
 
 [features]
 default=['std']

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -746,7 +746,7 @@ pub mod pallet {
             // trigger reshare at next block
             let current_block_number = <frame_system::Pallet<T>>::block_number();
             let reshare_info = ReshareInfo {
-                block_number: current_block_number + sp_runtime::traits::One::one(),
+                block_number: current_block_number - sp_runtime::traits::One::one(),
                 new_signer,
             };
 

--- a/pallets/transaction-pause/Cargo.toml
+++ b/pallets/transaction-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-transaction-pause"
-version   ='0.3.0-rc.1'
+version   ='0.3.0'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -25,7 +25,7 @@ pallet-balances={ version="29.0.0" }
 sp-core        ={ version="29.0.0" }
 sp-io          ={ version="31.0.0" }
 
-pallet-programs={ version="0.3.0-rc.1", default-features=false, path="../programs" }
+pallet-programs={ version="0.3.0", default-features=false, path="../programs" }
 
 [features]
 default=["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ='entropy-runtime'
 description="The substrate runtime for the Entropy chain node"
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -95,17 +95,17 @@ pallet-utility                               ={ version="29.0.0", default-featur
 pallet-vesting                               ={ version="29.0.0", default-features=false }
 
 # Entropy Pallets
-pallet-programs         ={ version='0.3.0-rc.1', path='../pallets/programs', default-features=false }
-pallet-propagation      ={ version='0.3.0-rc.1', path='../pallets/propagation', default-features=false }
-pallet-registry         ={ version='0.3.0-rc.1', path='../pallets/registry', default-features=false }
-pallet-slashing         ={ version='0.3.0-rc.1', path='../pallets/slashing', default-features=false }
-pallet-staking-extension={ version='0.3.0-rc.1', path='../pallets/staking', default-features=false }
-pallet-transaction-pause={ version='0.3.0-rc.1', path='../pallets/transaction-pause', default-features=false }
-pallet-parameters       ={ version='0.3.0-rc.1', path='../pallets/parameters', default-features=false }
-pallet-attestation      ={ version='0.3.0-rc.1', path='../pallets/attestation', default-features=false }
-pallet-oracle           ={ version='0.3.0-rc.1', path='../pallets/oracle', default-features=false }
+pallet-programs         ={ version='0.3.0', path='../pallets/programs', default-features=false }
+pallet-propagation      ={ version='0.3.0', path='../pallets/propagation', default-features=false }
+pallet-registry         ={ version='0.3.0', path='../pallets/registry', default-features=false }
+pallet-slashing         ={ version='0.3.0', path='../pallets/slashing', default-features=false }
+pallet-staking-extension={ version='0.3.0', path='../pallets/staking', default-features=false }
+pallet-transaction-pause={ version='0.3.0', path='../pallets/transaction-pause', default-features=false }
+pallet-parameters       ={ version='0.3.0', path='../pallets/parameters', default-features=false }
+pallet-attestation      ={ version='0.3.0', path='../pallets/attestation', default-features=false }
+pallet-oracle           ={ version='0.3.0', path='../pallets/oracle', default-features=false }
 
-entropy-shared={ version="0.3.0-rc.1", path="../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.3.0", path="../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // We update this if the runtime behaviour has changed. When this happens we set the
     // `impl_version` to `0`.
     #[allow(clippy::zero_prefixed_literal)]
-    spec_version: 00_03_00,
+    spec_version: 00_04_00,
 
     // We only bump this if the runtime behaviour remains unchanged, but the implementations details
     // have changed.

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-create-test-keyshares"
 description="Makes a set of keyshares for testing entropy-tss"
-version    ='0.3.0-rc.1'
+version    ='0.3.0'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -10,14 +10,14 @@ edition    ='2021'
 publish    =false
 
 [dependencies]
-entropy-testing-utils={ version="0.3.0-rc.1", path="../../crates/testing-utils" }
+entropy-testing-utils={ version="0.3.0", path="../../crates/testing-utils" }
 tokio                ={ version="1.40", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
-entropy-shared       ={ version="0.3.0-rc.1", path="../../crates/shared" }
-entropy-kvdb         ={ version="0.3.0-rc.1", path="../../crates/kvdb", default-features=false }
+entropy-shared       ={ version="0.3.0", path="../../crates/shared" }
+entropy-kvdb         ={ version="0.3.0", path="../../crates/kvdb", default-features=false }
 sp-core              ="31.0.0"
 
 # Unreleased version of Synedrion with support for child key derivations.
 synedrion={ version="0.2.0-beta.0" }
-entropy-tss={ version="0.3.0-rc.1", path="../../crates/threshold-signature-server", features=[
+entropy-tss={ version="0.3.0", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }


### PR DESCRIPTION
Currently reshare on testnet is failing due to a validation error that data is stale. This lines up the block number generated for reshare and the block number expected by the tss. 

Regression test is difficult and needs more thinking. 