### PR TITLE
Hot fix for reshare issue

### DIFF
--- a/pallets/propagation/src/lib.rs
+++ b/pallets/propagation/src/lib.rs
@@ -158,11 +158,11 @@ pub mod pallet {
         /// Submits a request to do a key refresh on the signers parent key.
         pub fn post_reshare(block_number: BlockNumberFor<T>) -> Result<(), http::Error> {
             let reshare_data = pallet_staking_extension::Pallet::<T>::reshare_data();
-            if reshare_data.block_number != block_number {
+            if reshare_data.block_number != block_number + sp_runtime::traits::One::one() {
                 return Ok(());
             }
 
-            let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(2_000));
+            let deadline = sp_io::offchain::timestamp().add(Duration::from_millis(10_000));
             let kind = sp_core::offchain::StorageKind::PERSISTENT;
             let from_local = sp_io::offchain::local_storage_get(kind, b"reshare_validators")
                 .unwrap_or_else(|| b"http://localhost:3001/validator/reshare".to_vec());

--- a/pallets/propagation/src/lib.rs
+++ b/pallets/propagation/src/lib.rs
@@ -158,7 +158,7 @@ pub mod pallet {
         /// Submits a request to do a key refresh on the signers parent key.
         pub fn post_reshare(block_number: BlockNumberFor<T>) -> Result<(), http::Error> {
             let reshare_data = pallet_staking_extension::Pallet::<T>::reshare_data();
-            if reshare_data.block_number != block_number + sp_runtime::traits::One::one() {
+            if reshare_data.block_number + sp_runtime::traits::One::one() != block_number {
                 return Ok(());
             }
 

--- a/pallets/propagation/src/lib.rs
+++ b/pallets/propagation/src/lib.rs
@@ -159,6 +159,7 @@ pub mod pallet {
         pub fn post_reshare(block_number: BlockNumberFor<T>) -> Result<(), http::Error> {
             let reshare_data = pallet_staking_extension::Pallet::<T>::reshare_data();
             if reshare_data.block_number + sp_runtime::traits::One::one() != block_number {
+                log::warn!("reshare block numbers: {:?}, {:?}", reshare_data.block_number + sp_runtime::traits::One::one(), block_number);
                 return Ok(());
             }
 

--- a/pallets/propagation/src/tests.rs
+++ b/pallets/propagation/src/tests.rs
@@ -88,7 +88,7 @@ fn knows_how_to_mock_several_http_calls() {
         // doesn't trigger no reshare block
         Propagation::post_reshare(7).unwrap();
         pallet_staking_extension::ReshareData::<Test>::put(ReshareInfo {
-            block_number: 8,
+            block_number: 6,
             new_signer: 1u64.encode(),
         });
         // now triggers

--- a/pallets/propagation/src/tests.rs
+++ b/pallets/propagation/src/tests.rs
@@ -88,7 +88,7 @@ fn knows_how_to_mock_several_http_calls() {
         // doesn't trigger no reshare block
         Propagation::post_reshare(7).unwrap();
         pallet_staking_extension::ReshareData::<Test>::put(ReshareInfo {
-            block_number: 7,
+            block_number: 8,
             new_signer: 1u64.encode(),
         });
         // now triggers

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -710,6 +710,7 @@ pub mod pallet {
             // Since not enough validators do not allow rotation
             // TODO: https://github.com/entropyxyz/entropy-core/issues/943
             if validators.len() <= current_signers_length {
+                log::warn!("validtor length less than current signer");
                 return Ok(weight);
             }
 

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -746,7 +746,7 @@ pub mod pallet {
             // trigger reshare at next block
             let current_block_number = <frame_system::Pallet<T>>::block_number();
             let reshare_info = ReshareInfo {
-                block_number: current_block_number + sp_runtime::traits::One::one(),
+                block_number: current_block_number - sp_runtime::traits::One::one(),
                 new_signer,
             };
 

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -482,7 +482,7 @@ fn it_tests_new_session_handler() {
 
         assert_eq!(
             Staking::reshare_data().block_number,
-            101,
+            99,
             "Check reshare block start at 100 + 1"
         );
         assert_eq!(
@@ -494,17 +494,6 @@ fn it_tests_new_session_handler() {
             Staking::jump_start_progress().parent_key_threshold,
             2,
             "parent key threhsold updated"
-        );
-
-        assert_eq!(
-            Staking::reshare_data().block_number,
-            101,
-            "Check reshare block start at 100 + 1"
-        );
-        assert_eq!(
-            Staking::reshare_data().new_signer,
-            1u64.encode(),
-            "Check reshare next signer up is 1"
         );
 
         assert_ok!(Staking::new_session_handler(&[6, 5, 3]));
@@ -522,6 +511,7 @@ fn it_tests_new_session_handler_signer_size_changes() {
     new_test_ext().execute_with(|| {
         // Start with current validators as 5 and 6 based off the Mock `GenesisConfig`.
         Signers::<Test>::put(vec![5, 6]);
+        System::set_block_number(100);
 
         assert_ok!(Staking::new_session_handler(&[6, 5, 3, 4]));
         // Signer size increased is reflected as 5 is not removed from vec

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // We update this if the runtime behaviour has changed. When this happens we set the
     // `impl_version` to `0`.
     #[allow(clippy::zero_prefixed_literal)]
-    spec_version: 00_03_01,
+    spec_version: 00_03_02,
 
     // We only bump this if the runtime behaviour remains unchanged, but the implementations details
     // have changed.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // We update this if the runtime behaviour has changed. When this happens we set the
     // `impl_version` to `0`.
     #[allow(clippy::zero_prefixed_literal)]
-    spec_version: 00_03_00,
+    spec_version: 00_04_00,
 
     // We only bump this if the runtime behaviour remains unchanged, but the implementations details
     // have changed.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -208,7 +208,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // We update this if the runtime behaviour has changed. When this happens we set the
     // `impl_version` to `0`.
     #[allow(clippy::zero_prefixed_literal)]
-    spec_version: 00_04_00,
+    spec_version: 00_03_01,
 
     // We only bump this if the runtime behaviour remains unchanged, but the implementations details
     // have changed.


### PR DESCRIPTION
Currently reshare on testnet is failing due to a validation error that data is stale. This lines up the block number generated for reshare and the block number expected by the tss.

Regression test is difficult and needs more thinking.