### PR TITLE
Add TDX test network chainspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ runtime
 - Protocol message versioning ([#1140](https://github.com/entropyxyz/entropy-core/pull/1140))
 - CLI command to get oracle headings ([#1170](https://github.com/entropyxyz/entropy-core/pull/1170))
 - Add TSS endpoint to get TDX quote ([#1173](https://github.com/entropyxyz/entropy-core/pull/1173))
+- Add TDX test network chainspec ([#1204](https://github.com/entropyxyz/entropy-core/pull/1204))
 
 ### Changed
 - Use correct key rotation endpoint in OCW ([#1104](https://github.com/entropyxyz/entropy-core/pull/1104))

--- a/node/cli/src/chain_spec/dev.rs
+++ b/node/cli/src/chain_spec/dev.rs
@@ -13,7 +13,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::chain_spec::{get_account_id_from_seed, provisioning_certification_key, ChainSpec};
+use crate::chain_spec::{
+    get_account_id_from_seed, provisioning_certification_key, ChainSpec, MrtdValues,
+};
 use crate::endowed_accounts::endowed_accounts_dev;
 
 use entropy_runtime::{
@@ -123,6 +125,7 @@ pub fn development_config() -> ChainSpec {
             vec![],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             devnet_four_node_initial_tss_servers(),
+            None,
         ))
         .build()
 }
@@ -148,6 +151,7 @@ pub fn devnet_local_four_node_config() -> crate::chain_spec::ChainSpec {
             vec![],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             devnet_local_docker_four_node_initial_tss_servers(),
+            None,
         ))
         .build()
 }
@@ -169,6 +173,7 @@ pub fn development_genesis_config(
         String,
         BoundedVecEncodedVerifyingKey,
     )>,
+    accepted_mrtd_values: Option<MrtdValues>,
 ) -> serde_json::Value {
     // Note that any endowed_accounts added here will be included in the `elections` and
     // `technical_committee` genesis configs. If you don't want that, don't push those accounts to
@@ -283,10 +288,10 @@ pub fn development_genesis_config(
             max_instructions_per_programs: INITIAL_MAX_INSTRUCTIONS_PER_PROGRAM,
             total_signers: TOTAL_SIGNERS,
             threshold: SIGNER_THRESHOLD,
-            accepted_mrtd_values: vec![
+            accepted_mrtd_values: accepted_mrtd_values.unwrap_or(vec![
                 BoundedVec::try_from([0; 48].to_vec()).unwrap(),
                 BoundedVec::try_from([1; 48].to_vec()).unwrap(),
-            ],
+            ]),
             ..Default::default()
         },
         "programs": ProgramsConfig {

--- a/node/cli/src/chain_spec/mod.rs
+++ b/node/cli/src/chain_spec/mod.rs
@@ -48,7 +48,10 @@ use serde_json::json;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_core::{sr25519, Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{
+    traits::{ConstU32, IdentifyAccount, Verify},
+    BoundedVec,
+};
 
 type AccountPublic = <Signature as Verify>::Signer;
 
@@ -216,3 +219,6 @@ pub fn authority_keys_from_seed(
         get_from_seed::<AuthorityDiscoveryId>(seed),
     )
 }
+
+/// Accepted build time measurement values for TDX attestation
+pub type MrtdValues = Vec<BoundedVec<u8, ConstU32<48>>>;

--- a/node/cli/src/chain_spec/mod.rs
+++ b/node/cli/src/chain_spec/mod.rs
@@ -33,6 +33,7 @@
 
 pub mod dev;
 pub mod integration_tests;
+pub mod tdx_testnet;
 pub mod testnet;
 
 pub use entropy_runtime::{AccountId, RuntimeGenesisConfig, Signature};

--- a/node/cli/src/chain_spec/tdx_testnet.rs
+++ b/node/cli/src/chain_spec/tdx_testnet.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2023 Entropy Cryptography Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::chain_spec::{dev::development_genesis_config, get_account_id_from_seed, ChainSpec};
+
+use entropy_runtime::wasm_binary_unwrap;
+use entropy_shared::{BoundedVecEncodedVerifyingKey, X25519PublicKey as TssX25519PublicKey};
+use sc_service::ChainType;
+use sp_core::sr25519;
+
+lazy_static::lazy_static! {
+    pub static ref PCK: BoundedVecEncodedVerifyingKey = vec![
+    2, 166, 103, 136, 58, 157, 155, 124, 186, 75, 81, 133, 87, 255, 233, 182, 192, 125, 235, 230,
+    121, 173, 147, 108, 47, 190, 240, 181, 75, 181, 31, 148, 128,
+    ].try_into().unwrap();
+}
+
+fn tdx_devnet_four_node_initial_tss_servers(
+) -> Vec<(sp_runtime::AccountId32, TssX25519PublicKey, String, BoundedVecEncodedVerifyingKey)> {
+    let tss_ip = std::env::var("ENTROPY_TESTNET_TSS_IP")
+        .expect("ENTROPY_TESTNET_TSS_IP environment variable to be set");
+
+    let alice = (
+        crate::chain_spec::tss_account_id::ALICE.clone(),
+        crate::chain_spec::tss_x25519_public_key::ALICE,
+        format!("{tss_ip}:3001"),
+        PCK.clone(),
+    );
+
+    let bob = (
+        crate::chain_spec::tss_account_id::BOB.clone(),
+        crate::chain_spec::tss_x25519_public_key::BOB,
+        format!("{tss_ip}:3002"),
+        PCK.clone(),
+    );
+
+    let charlie = (
+        crate::chain_spec::tss_account_id::CHARLIE.clone(),
+        crate::chain_spec::tss_x25519_public_key::CHARLIE,
+        format!("{tss_ip}:3003"),
+        PCK.clone(),
+    );
+
+    let dave = (
+        crate::chain_spec::tss_account_id::DAVE.clone(),
+        crate::chain_spec::tss_x25519_public_key::DAVE,
+        format!("{tss_ip}:3004"),
+        PCK.clone(),
+    );
+
+    vec![alice, bob, charlie, dave]
+}
+
+/// The configuration used for development.
+///
+/// Since Entropy requires at two-of-three threshold setup, and requires an additional relayer node,
+/// we spin up four validators: Alice, Bob, Charlie and Dave.
+pub fn development_config() -> ChainSpec {
+    ChainSpec::builder(wasm_binary_unwrap(), Default::default())
+        .with_name("Development")
+        .with_id("dev")
+        .with_chain_type(ChainType::Development)
+        .with_properties(crate::chain_spec::entropy_properties())
+        .with_genesis_config_patch(development_genesis_config(
+            vec![
+                crate::chain_spec::authority_keys_from_seed("Alice"),
+                crate::chain_spec::authority_keys_from_seed("Bob"),
+                crate::chain_spec::authority_keys_from_seed("Charlie"),
+                crate::chain_spec::authority_keys_from_seed("Dave"),
+            ],
+            vec![],
+            get_account_id_from_seed::<sr25519::Public>("Alice"),
+            tdx_devnet_four_node_initial_tss_servers(),
+        ))
+        .build()
+}

--- a/node/cli/src/chain_spec/tdx_testnet.rs
+++ b/node/cli/src/chain_spec/tdx_testnet.rs
@@ -19,6 +19,14 @@ use entropy_runtime::wasm_binary_unwrap;
 use entropy_shared::{BoundedVecEncodedVerifyingKey, X25519PublicKey as TssX25519PublicKey};
 use sc_service::ChainType;
 use sp_core::sr25519;
+use sp_runtime::BoundedVec;
+
+/// The build time measurement value from the current entropy-tss VM images
+const ACCEPTED_MRTD: [u8; 48] = [
+    145, 235, 43, 68, 209, 65, 212, 236, 224, 159, 12, 117, 194, 197, 61, 36, 122, 60, 104, 237,
+    215, 250, 254, 138, 53, 32, 201, 66, 166, 4, 164, 7, 222, 3, 174, 109, 197, 248, 127, 39, 66,
+    139, 37, 56, 135, 49, 24, 183,
+];
 
 lazy_static::lazy_static! {
     pub static ref PCK: BoundedVecEncodedVerifyingKey = vec![
@@ -83,6 +91,7 @@ pub fn development_config() -> ChainSpec {
             vec![],
             get_account_id_from_seed::<sr25519::Public>("Alice"),
             tdx_devnet_four_node_initial_tss_servers(),
+            Some(vec![BoundedVec::try_from(ACCEPTED_MRTD.to_vec()).unwrap()]),
         ))
         .build()
 }

--- a/node/cli/src/chain_spec/tdx_testnet.rs
+++ b/node/cli/src/chain_spec/tdx_testnet.rs
@@ -29,6 +29,7 @@ const ACCEPTED_MRTD: [u8; 48] = [
 ];
 
 lazy_static::lazy_static! {
+    /// This is the PCK from the certificates of the current TDX machine we are using for testing
     pub static ref PCK: BoundedVecEncodedVerifyingKey = vec![
     2, 166, 103, 136, 58, 157, 155, 124, 186, 75, 81, 133, 87, 255, 233, 182, 192, 125, 235, 230,
     121, 173, 147, 108, 47, 190, 240, 181, 75, 181, 31, 148, 128,
@@ -71,14 +72,14 @@ fn tdx_devnet_four_node_initial_tss_servers(
     vec![alice, bob, charlie, dave]
 }
 
-/// The configuration used for development.
+/// The configuration used for the TDX testnet.
 ///
 /// Since Entropy requires at two-of-three threshold setup, and requires an additional relayer node,
 /// we spin up four validators: Alice, Bob, Charlie and Dave.
-pub fn development_config() -> ChainSpec {
+pub fn tdx_testnet_config() -> ChainSpec {
     ChainSpec::builder(wasm_binary_unwrap(), Default::default())
-        .with_name("Development")
-        .with_id("dev")
+        .with_name("TDX-testnet")
+        .with_id("tdx")
         .with_chain_type(ChainType::Development)
         .with_properties(crate::chain_spec::entropy_properties())
         .with_genesis_config_patch(development_genesis_config(

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -74,7 +74,7 @@ impl SubstrateCli for Cli {
     // | integration-tests | Two nodes, Four threshold servers, Alice and Bob, Development Configuration |
     // | testnet-local     | Two Nodes, Two threshold servers, Alice and Bob, Testnet Configuration, Docker Compatible |
     // | testnet           | Four nodes, Two threshold servers, Own Seed, Testnet Configuration |
-    // | tdx-testnet       | Four nodes, Four threshold servers, Alice Bob Chalie and Dave, Development Configuration |
+    // | tdx-testnet       | Four nodes, Four threshold servers, Alice Bob Chalie and Dave, Development Configuration adapted for TDX testnet |
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
             "" | "dev" => Box::new(chain_spec::dev::development_config()),

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -74,6 +74,7 @@ impl SubstrateCli for Cli {
     // | integration-tests | Two nodes, Four threshold servers, Alice and Bob, Development Configuration |
     // | testnet-local     | Two Nodes, Two threshold servers, Alice and Bob, Testnet Configuration, Docker Compatible |
     // | testnet           | Four nodes, Two threshold servers, Own Seed, Testnet Configuration |
+    // | tdx-testnet       | Four nodes, Four threshold servers, Alice Bob Chalie and Dave, Development Configuration |
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
             "" | "dev" => Box::new(chain_spec::dev::development_config()),
@@ -88,6 +89,7 @@ impl SubstrateCli for Cli {
             },
             "testnet-local" => Box::new(chain_spec::testnet::testnet_local_config()),
             "testnet" => Box::new(chain_spec::testnet::testnet_config()),
+            "tdx-testnet" => Box::new(chain_spec::tdx_testnet::development_config()),
             path => {
                 Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
             },

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -89,7 +89,7 @@ impl SubstrateCli for Cli {
             },
             "testnet-local" => Box::new(chain_spec::testnet::testnet_local_config()),
             "testnet" => Box::new(chain_spec::testnet::testnet_config()),
-            "tdx-testnet" => Box::new(chain_spec::tdx_testnet::development_config()),
+            "tdx-testnet" => Box::new(chain_spec::tdx_testnet::tdx_testnet_config()),
             path => {
                 Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
             },


### PR DESCRIPTION
This add a chainspec type for the setup i am currently using for a simple test network with the TSS servers running in TDX virtual machines.

It is just the development chainspec with a custom TSS endpoint (we need TSS nodes to have their public IP address), custom PCK certificates (we can't use the mock ones), and a custom accepted MRTD value from the entropy-tss VM image i am currently using.

I don't want to hardcode the IP address as i think it will probably change (hopefully we find something cheaper!), so it is read from an environment variable.

Currently the PCK is hard-coded.  Ideally i would like to read it in from a certificate file, using the same code that the staking extension pallet uses to extract and verify PCKs from certificates. But this would mean having the staking pallet be a direct dependency of the node CLI, which is kinda weird.  Maybe that code should be extracted to a separate crate. Since this code may change anyway if we switch to using [dcap-qvl](https://docs.rs/dcap-qvl), i am going to kick this decision down the road.

For details of how the TSS nodes are deployed see https://github.com/entropyxyz/tdx-build-system/issues/5