### PR TITLE
Downgrade parity-scale-codec as version we currently use has been yanked

### DIFF
--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -13,7 +13,7 @@ subxt             ="0.35.3"
 sp-keyring        ="34.0.0"
 project-root      ="0.2.2"
 sp-core           ={ version="31.0.0", default-features=false }
-parity-scale-codec="3.7.0"
+parity-scale-codec="3.6.12"
 lazy_static       ="1.5.0"
 hex-literal       ="0.4.1"
 tokio             ={ version="1.42", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -36,7 +36,7 @@ axum   ={ version="0.7.9", features=["ws"] }
 
 # Substrate
 subxt             ="0.35.3"
-parity-scale-codec="3.7.0"
+parity-scale-codec="3.6.12"
 sp-core           ={ version="31.0.0", default-features=false }
 
 # Entropy


### PR DESCRIPTION
I am sometimes seeing the error:
```
error: failed to select a version for the requirement `parity-scale-codec = "^3.7.0"`
candidate versions found which didn't match: 3.6.12, 3.6.11, 3.6.10, ...
location searched: crates.io index
required by package `entropy-testing-utils v0.3.0 (https://github.com/entropyxyz/entropy-core.git#d192cdc0)`
    ... which satisfies git dependency `entropy-testing-utils` of package `entropy-chain-nodes-test v0.1.0 (/home/turnip/radish/src/entropy/entropy-chain-nodes-test)`
if you are looking for the prerelease package it needs to be specified explicitly
    parity-scale-codec = { version = "3.6.8-alpha.1" }
```

This is because `parity-scale-codec` 3.7.0 has been yanked. This PR downgrades it to the latest stable version.