### PR TITLE
Remove forbidden key check

### DIFF
--- a/crates/threshold-signature-server/src/user/errors.rs
+++ b/crates/threshold-signature-server/src/user/errors.rs
@@ -139,8 +139,6 @@ pub enum UserErr {
     ChainFetch(&'static str),
     #[error("Too many requests - wait a block")]
     TooManyRequests,
-    #[error("The given key is forbidden")]
-    ForbiddenKey,
     #[error("No existing keyshare found for this user")]
     UserDoesNotExist,
     #[error("The remote TSS server rejected the keyshare: {0}")]

--- a/crates/threshold-signature-server/src/validator/api.rs
+++ b/crates/threshold-signature-server/src/validator/api.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     get_signer_and_x25519_secret,
     helpers::{
-        launch::{FORBIDDEN_KEYS, LATEST_BLOCK_NUMBER_RESHARE},
+        launch::LATEST_BLOCK_NUMBER_RESHARE,
         substrate::{get_stash_address, get_validators_info, query_chain, submit_transaction},
     },
     signing_client::{api::get_channels, ProtocolErr},
@@ -373,14 +373,6 @@ pub async fn check_balance_for_fees(
         is_min_balance = true
     };
     Ok(is_min_balance)
-}
-
-pub fn check_forbidden_key(key: &str) -> Result<(), ValidatorErr> {
-    let forbidden = FORBIDDEN_KEYS.contains(&key);
-    if forbidden {
-        return Err(ValidatorErr::ForbiddenKey);
-    }
-    Ok(())
 }
 
 /// Filters out new signer from next signers to get old holders

--- a/crates/threshold-signature-server/src/validator/errors.rs
+++ b/crates/threshold-signature-server/src/validator/errors.rs
@@ -41,8 +41,6 @@ pub enum ValidatorErr {
     Kv(#[from] entropy_kvdb::kv_manager::error::KvError),
     #[error("User Error: {0}")]
     UserErr(#[from] crate::user::UserErr),
-    #[error("Forbidden Key")]
-    ForbiddenKey,
     #[error("Validation Error: {0}")]
     ValidationErr(#[from] crate::validation::errors::ValidationErr),
     #[error("anyhow error: {0}")]

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -12,19 +12,16 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-use super::api::{check_balance_for_fees, check_forbidden_key};
+use super::api::check_balance_for_fees;
 use crate::{
     helpers::{
-        launch::{FORBIDDEN_KEYS, LATEST_BLOCK_NUMBER_RESHARE},
+        launch::LATEST_BLOCK_NUMBER_RESHARE,
         tests::{
             call_set_storage, get_port, initialize_test_logger, run_to_block, setup_client,
             spawn_testing_validators, unsafe_get,
         },
     },
-    validator::{
-        api::{is_signer_or_delete_parent_key, prune_old_holders, validate_new_reshare},
-        errors::ValidatorErr,
-    },
+    validator::api::{is_signer_or_delete_parent_key, prune_old_holders, validate_new_reshare},
 };
 use entropy_client::{self as test_client};
 use entropy_client::{
@@ -385,16 +382,6 @@ async fn test_check_balance_for_fees() {
     let _ = check_balance_for_fees(&api, &rpc, (&RANDOM_ACCOUNT).to_string(), MIN_BALANCE)
         .await
         .unwrap();
-}
-
-#[tokio::test]
-async fn test_forbidden_keys() {
-    initialize_test_logger().await;
-    let should_fail = check_forbidden_key(FORBIDDEN_KEYS[0]);
-    assert_eq!(should_fail.unwrap_err().to_string(), ValidatorErr::ForbiddenKey.to_string());
-
-    let should_pass = check_forbidden_key("test");
-    assert_eq!(should_pass.unwrap(), ());
 }
 
 #[tokio::test]


### PR DESCRIPTION
The forbidden key check function is only called in tests and can be removed since we no longer have http routes which allow reading data from the kvdb.

Closes https://github.com/entropyxyz/entropy-core/issues/1221