### PR TITLE
Use tdx-quote v0.0.3 - not git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14280,8 +14280,9 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tdx-quote"
-version = "0.0.1"
-source = "git+https://github.com/entropyxyz/tdx-quote.git?rev=67a9d011809d0c9109d1ac42aeb809a84b663be6#67a9d011809d0c9109d1ac42aeb809a84b663be6"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbbeffe2d73f07728bcbb581f8faa9098d813ba0fafbcab5e763a2fa4491e80"
 dependencies = [
  "nom",
  "p256",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -38,12 +38,10 @@ js-sys={ version="0.3.74", optional=true }
 tokio ={ version="1.42", features=["time"] }
 
 [dev-dependencies]
-serial_test="3.2.0"
-sp-keyring="34.0.0"
+serial_test          ="3.2.0"
+sp-keyring           ="34.0.0"
 entropy-testing-utils={ path="../testing-utils" }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", features=[
-  "mock",
-] }
+tdx-quote            ={ version="0.0.3", features=["mock"] }
 
 [features]
 default=["native", "full-client-native"]

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -9,26 +9,24 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-subxt="0.35.3"
-sp-keyring="34.0.0"
-project-root="0.2.2"
-sp-core={ version="31.0.0", default-features=false }
+subxt             ="0.35.3"
+sp-keyring        ="34.0.0"
+project-root      ="0.2.2"
+sp-core           ={ version="31.0.0", default-features=false }
 parity-scale-codec="3.6.12"
-lazy_static="1.5.0"
-hex-literal="0.4.1"
-tokio={ version="1.42", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
-axum={ version="0.8.1" }
-entropy-shared={ version="0.3.0", path="../shared" }
-entropy-kvdb={ version="0.3.0", path="../kvdb", default-features=false }
-entropy-tss={ version="0.3.0", path="../threshold-signature-server", features=["test_helpers"] }
-entropy-protocol={ version="0.3.0", path="../protocol" }
-synedrion="0.2.0"
-hex="0.4.3"
-rand_core="0.6.4"
-rand="0.8.5"
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", features=[
-  "mock",
-] }
+lazy_static       ="1.5.0"
+hex-literal       ="0.4.1"
+tokio             ={ version="1.42", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
+axum              ={ version="0.8.1" }
+entropy-shared    ={ version="0.3.0", path="../shared" }
+entropy-kvdb      ={ version="0.3.0", path="../kvdb", default-features=false }
+entropy-tss       ={ version="0.3.0", path="../threshold-signature-server", features=["test_helpers"] }
+entropy-protocol  ={ version="0.3.0", path="../protocol" }
+synedrion         ="0.2.0"
+hex               ="0.4.3"
+rand_core         ="0.6.4"
+rand              ="0.8.5"
+tdx-quote         ={ version="0.0.3", features=["mock"] }
 
 # Logging
 tracing           ="0.1.41"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -59,39 +59,35 @@ uuid                    ={ version="1.11.0", features=["v4"] }
 
 # Misc
 tokio-tungstenite="0.26.1"
-bincode="1.3.3"
-bip32={ version="0.5.2" }
-bip39={ version="2.1.0", features=["zeroize"] }
-bytes={ version="1.9", default-features=false, features=["serde"] }
-base64="0.22.1"
-clap={ version="4.5.24", features=["derive"] }
-num="0.4.3"
-snow="0.9.6"
-sha3="0.10.8"
-hostname="0.4"
-sha1="0.10.6"
-sha2="0.10.8"
-hkdf="0.12.4"
-project-root={ version="0.2.2", optional=true }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", optional=true, features=[
-  "mock",
-] }
-configfs-tsm={ version="0.0.1", optional=true }
+bincode          ="1.3.3"
+bip32            ={ version="0.5.2" }
+bip39            ={ version="2.1.0", features=["zeroize"] }
+bytes            ={ version="1.9", default-features=false, features=["serde"] }
+base64           ="0.22.1"
+clap             ={ version="4.5.24", features=["derive"] }
+num              ="0.4.3"
+snow             ="0.9.6"
+sha3             ="0.10.8"
+hostname         ="0.4"
+sha1             ="0.10.6"
+sha2             ="0.10.8"
+hkdf             ="0.12.4"
+project-root     ={ version="0.2.2", optional=true }
+tdx-quote        ={ version="0.0.3", optional=true, features=["mock"] }
+configfs-tsm     ={ version="0.0.1", optional=true }
 
 [dev-dependencies]
-serial_test="3.2.0"
-hex-literal="0.4.1"
+serial_test ="3.2.0"
+hex-literal ="0.4.1"
 project-root="0.2.2"
 more-asserts="0.3.1"
-lazy_static="1.5.0"
-blake3="1.5.5"
-ethers-core="2.0.14"
-schnorrkel={ version="0.11.4", default-features=false, features=["std"] }
-schemars={ version="0.8.21" }
+lazy_static ="1.5.0"
+blake3      ="1.5.5"
+ethers-core ="2.0.14"
+schnorrkel  ={ version="0.11.4", default-features=false, features=["std"] }
+schemars    ={ version="0.8.21" }
 subxt-signer="0.35.3"
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", features=[
-  "mock",
-] }
+tdx-quote   ={ version="0.0.3", features=["mock"] }
 
 # Note: We don't specify versions here because otherwise we run into a cyclical dependency between
 # `entropy-tss` and `entropy-testing-utils` when we try and publish the `entropy-tss` crate.

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -28,21 +28,19 @@ entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 pallet-staking-extension={ version="0.3.0", path="../staking", default-features=false }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6" }
+tdx-quote="0.0.3"
 
 [dev-dependencies]
-pallet-session={ version="29.0.0", default-features=false }
-pallet-staking={ version="29.0.0", default-features=false }
-pallet-balances={ version="29.0.0", default-features=false }
-pallet-bags-list={ version="28.0.0", default-features=false }
-pallet-timestamp={ version="28.0.0", default-features=false }
-sp-npos-elections={ version="27.0.0", default-features=false }
+pallet-session                 ={ version="29.0.0", default-features=false }
+pallet-staking                 ={ version="29.0.0", default-features=false }
+pallet-balances                ={ version="29.0.0", default-features=false }
+pallet-bags-list               ={ version="28.0.0", default-features=false }
+pallet-timestamp               ={ version="28.0.0", default-features=false }
+sp-npos-elections              ={ version="27.0.0", default-features=false }
 frame-election-provider-support={ version="29.0.0", default-features=false }
-pallet-staking-reward-curve={ version="11.0.0" }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", features=[
-  "mock",
-] }
-rand_core="0.6.4"
+pallet-staking-reward-curve    ={ version="11.0.0" }
+tdx-quote                      ={ version="0.0.3", features=["mock"] }
+rand_core                      ="0.6.4"
 
 pallet-slashing={ version="0.3.0", path="../slashing", default-features=false }
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -35,9 +35,7 @@ pallet-slashing={ version="0.3.0", path="../slashing", default-features=false }
 entropy-shared={ version="0.3.0", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-tdx-quote={ git="https://github.com/entropyxyz/tdx-quote.git", rev="67a9d011809d0c9109d1ac42aeb809a84b663be6", features=[
-  "mock",
-], optional=true }
+tdx-quote={ version="0.0.3", features=["mock"], optional=true }
 
 [dev-dependencies]
 frame-election-provider-support={ version="29.0.0", default-features=false }


### PR DESCRIPTION
`tdx-quote` is now published as 0.0.3.  This PR uses that rather than the git version.