### PR TITLE
Allow different versions for programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ runtime
 - Use context, not block number in TDX quote input data ([#1179](https://github.com/entropyxyz/entropy-core/pull/1179))
 - Allow offchain worker requests to all TSS nodes in entropy-tss test environment ([#1147](https://github.com/entropyxyz/entropy-core/pull/1147))
 - Extract PCK certificate chain from quotes ([#1209](https://github.com/entropyxyz/entropy-core/pull/1209))
+- Allow different versions for programs ([#1250](https://github.com/entropyxyz/entropy-core/pull/1250))
 
 ### Fixed
 

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -161,6 +161,7 @@ pub async fn compute_hash(
     }
 }
 
+/// Gets and launches a runtime for a program version
 pub fn get_programs_runtime(version: u8, fuel: u64) -> Result<Runtime, UserErr> {
     match version {
         0 => Ok(Runtime::new(ProgramConfig { fuel })),

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -24,7 +24,7 @@ use axum::{
 use base64::prelude::{Engine, BASE64_STANDARD};
 use entropy_client::substrate::get_registered_details;
 use entropy_kvdb::kv_manager::{helpers::serialize as key_serialize, KvManager};
-use entropy_programs_runtime::{Config as ProgramConfig, Runtime, SignatureRequest};
+use entropy_programs_runtime::SignatureRequest;
 use entropy_protocol::SigningSessionInfo;
 use entropy_shared::{HashingAlgorithm, OcwMessageDkg, NETWORK_PARENT_KEY};
 use futures::{channel::mpsc, future::join_all, StreamExt};
@@ -50,7 +50,7 @@ use crate::{
             get_oracle_data, get_program, get_signers_from_chain, get_validators_info, query_chain,
             submit_transaction,
         },
-        user::{check_in_registration_group, compute_hash, do_dkg},
+        user::{check_in_registration_group, compute_hash, do_dkg, get_programs_runtime},
         validator::get_signer_and_x25519_secret,
     },
     validation::{check_stale, EncryptedSignedMessage},
@@ -302,7 +302,7 @@ pub async fn sign_tx(
         .ok_or_else(|| UserErr::OptionUnwrapError("Error Getting Block Number".to_string()))?
         .number;
 
-    let (mut runtime, user_details, message) = pre_sign_checks(
+    let (fuel, user_details, message) = pre_sign_checks(
         &api,
         &rpc,
         relayer_sig_request.user_signature_request.clone(),
@@ -315,7 +315,7 @@ pub async fn sign_tx(
         &api,
         &rpc,
         &relayer_sig_request.user_signature_request.hash,
-        &mut runtime,
+        fuel,
         &user_details.programs_data.0,
         message.as_slice(),
     )
@@ -649,7 +649,7 @@ pub async fn pre_sign_checks(
     user_sig_req: UserSignatureRequest,
     block_number: u32,
     string_verifying_key: String,
-) -> Result<(Runtime, RegisteredInfo, Vec<u8>), UserErr> {
+) -> Result<(u64, RegisteredInfo, Vec<u8>), UserErr> {
     check_stale(user_sig_req.block_number, block_number).await?;
 
     // Probably impossible but block signing from parent key anyways
@@ -685,13 +685,12 @@ pub async fn pre_sign_checks(
         .await?
         .ok_or_else(|| UserErr::ChainFetch("Max instructions per program error"))?;
 
-    let mut runtime = Runtime::new(ProgramConfig { fuel });
-
     for (i, program_data) in user_details.programs_data.0.iter().enumerate() {
         let program_info = get_program(api, rpc, &program_data.program_pointer).await?;
         let oracle_data = get_oracle_data(api, rpc, program_info.oracle_data_pointers.0).await?;
         let auxilary_data = auxilary_data_vec[i].as_ref().map(hex::decode).transpose()?;
         let signature_request = SignatureRequest { message: message.clone(), auxilary_data };
+        let mut runtime = get_programs_runtime(program_info.version_number, fuel)?;
         runtime.evaluate(
             &program_info.bytecode,
             &signature_request,
@@ -700,5 +699,5 @@ pub async fn pre_sign_checks(
         )?;
     }
 
-    Ok((runtime, user_details, message))
+    Ok((fuel, user_details, message))
 }

--- a/crates/threshold-signature-server/src/user/errors.rs
+++ b/crates/threshold-signature-server/src/user/errors.rs
@@ -177,6 +177,8 @@ pub enum UserErr {
     TooFewSigners,
     #[error("Non signer sent from relayer")]
     IncorrectSigner,
+    #[error("Program Version not supported")]
+    ProgramVersion,
 }
 
 impl From<hkdf::InvalidLength> for UserErr {

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -21,7 +21,6 @@ use entropy_client::{
     user::{get_all_signers_from_chain, UserSignatureRequest},
 };
 use entropy_kvdb::clean_tests;
-use entropy_programs_runtime::Runtime;
 use entropy_protocol::{
     decode_verifying_key,
     protocol_transport::{noise::noise_handshake_initiator, SubscribeMessage},

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -931,7 +931,6 @@ async fn test_compute_hash() {
     let api = get_api(&substrate_context.node_proc.ws_url).await.unwrap();
     let rpc = get_rpc(&substrate_context.node_proc.ws_url).await.unwrap();
 
-    let mut runtime = Runtime::default();
     let program_hash = test_client::store_program(
         &api,
         &rpc,
@@ -949,7 +948,7 @@ async fn test_compute_hash() {
         &api,
         &rpc,
         &HashingAlgorithm::Custom(0),
-        &mut runtime,
+        10000000u64,
         &vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }],
         PREIMAGE_SHOULD_SUCCEED,
     )


### PR DESCRIPTION
Add a way for programs to have different versions

Can be made more efficient by caching runtime version and using cached instead of spinning up a new one (#1251)