### PR TITLE
Add entropy-shared check script

### DIFF
--- a/scripts/check-entropy-shared.sh
+++ b/scripts/check-entropy-shared.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# This script checks that entropy-shared will compile with all the different combinations of feature
+# flags / targets which will be used. This is useful to check that changes to entropy-shared have
+# not broken anything without needing to run the entire CI pipeline.
+#
+# Used by entropy-tss
+cargo check -p entropy-shared
+# Used by entropy-tss in production
+cargo check -p entropy-shared -F production
+# Used by entropy-protocol
+cargo check -p entropy-shared -F std -F user-native --no-default-features
+# Used by entropy-protocol built for wasm
+cargo check -p entropy-shared -F user-wasm -F wasm --no-default-features --target wasm32-unknown-unknown
+# Used by pallets
+cargo check -p entropy-shared -F wasm-no-std --no-default-features --target wasm32-unknown-unknown
+# Used by pallets in production
+cargo check -p entropy-shared -F wasm-no-std -F production --no-default-features --target wasm32-unknown-unknown


### PR DESCRIPTION
This is a small PR which adds a script which runs `cargo check` on `entropy-shared` with all the different combinations of feature flags / targets which will be used. 

This is useful to check that changes to entropy-shared have not broken anything, without needing to run the entire CI pipeline.

I found this useful recently when getting into a big muddle after making some changes there, so i would like to keep this script in the scripts directory for next time.