### PR TITLE
Add endpoints to migrate an encrypted key-value store dump for upgrading `entropy-tss` 

### DIFF
--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -137,4 +137,8 @@ pub enum ClientError {
     SessionKeyLength,
     #[error("Strip prefix error")]
     StripPrefix,
+    #[error("Bad response when requesting backup: {0} {1}")]
+    RequestBackup(reqwest::StatusCode, String),
+    #[error("Cannot recover backup when TSS node is in a running state")]
+    CannotRecoverBackupWhenNodeRunning,
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -28,3 +28,18 @@ mod tests;
 pub mod client;
 #[cfg(feature = "full-client")]
 pub use client::*;
+
+use entropy_shared::X25519PublicKey;
+use serde::{Deserialize, Serialize};
+use subxt::utils::AccountId32;
+
+/// Public signing and encryption keys associated with a TS server
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct TssPublicKeys {
+    /// Indicates that all prerequisite checks have passed
+    pub ready: bool,
+    /// The TSS account ID
+    pub tss_account: AccountId32,
+    /// The public encryption key
+    pub x25519_public_key: X25519PublicKey,
+}

--- a/crates/kvdb/src/encrypted_sled/kv.rs
+++ b/crates/kvdb/src/encrypted_sled/kv.rs
@@ -28,6 +28,8 @@ use rand::RngCore;
 use sled::IVec;
 use zeroize::Zeroize;
 
+use crate::DbDump;
+
 use super::{
     constants::*,
     record::EncryptedRecord,
@@ -165,7 +167,7 @@ impl EncryptedDb {
     }
 
     /// Dump key-value tuples directly out of the db without decrypting, for db migration export
-    pub fn export_encrypted_db(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
+    pub fn export_encrypted_db(&self) -> DbDump {
         self.kv
             .iter()
             .filter_map(|kv_result| {
@@ -176,7 +178,7 @@ impl EncryptedDb {
     }
 
     /// Import encrypted key-value tuples directly into the db without encrypting, for db migration import
-    pub fn import_encrypted_db(&self, db_dump: Vec<(Vec<u8>, Vec<u8>)>) -> EncryptedDbResult<()> {
+    pub fn import_encrypted_db(&self, db_dump: DbDump) -> EncryptedDbResult<()> {
         for (key, value) in db_dump {
             self.kv.insert(key, value)?;
         }

--- a/crates/kvdb/src/encrypted_sled/kv.rs
+++ b/crates/kvdb/src/encrypted_sled/kv.rs
@@ -163,4 +163,23 @@ impl EncryptedDb {
     pub fn was_recovered(&self) -> bool {
         self.kv.was_recovered()
     }
+
+    /// Dump key-value tuples directly out of the db without decrypting, for db migration export
+    pub fn export_encrypted_db(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
+        self.kv
+            .iter()
+            .filter_map(|kv_result| {
+                let kv = kv_result.ok()?;
+                Some((kv.0.to_vec(), kv.1.to_vec()))
+            })
+            .collect()
+    }
+
+    /// Import encrypted key-value tuples directly into the db without encrypting, for db migration import
+    pub fn import_encrypted_db(&self, db_dump: Vec<(Vec<u8>, Vec<u8>)>) -> EncryptedDbResult<()> {
+        for (key, value) in db_dump {
+            self.kv.insert(key, value)?;
+        }
+        Ok(())
+    }
 }

--- a/crates/kvdb/src/kv_manager/error.rs
+++ b/crates/kvdb/src/kv_manager/error.rs
@@ -36,6 +36,10 @@ pub enum KvError {
     DeleteErr(InnerKvError),
     #[error("Exits Error: {0}")]
     ExistsErr(InnerKvError),
+    #[error("Export Error: {0}")]
+    ExportErr(InnerKvError),
+    #[error("Import Error: {0}")]
+    ImportErr(InnerKvError),
 }
 pub type KvResult<Success> = Result<Success, KvError>;
 

--- a/crates/kvdb/src/kv_manager/kv.rs
+++ b/crates/kvdb/src/kv_manager/kv.rs
@@ -32,7 +32,7 @@ use super::{
         KeyReservation, DEFAULT_KV_NAME, DEFAULT_KV_PATH,
     },
 };
-use crate::encrypted_sled;
+use crate::{encrypted_sled, DbDump};
 
 #[derive(Clone)]
 pub struct Kv<V> {
@@ -124,14 +124,14 @@ where
     }
 
     /// Dump key-value tuples directly out of the db without decrypting, for db migration export
-    pub async fn export_db(&self) -> KvResult<Vec<(Vec<u8>, Vec<u8>)>> {
+    pub async fn export_db(&self) -> KvResult<DbDump> {
         let (resp_tx, resp_rx) = oneshot::channel();
         self.sender.send(ExportDb { resp: resp_tx }).map_err(|e| SendErr(e.to_string()))?;
         resp_rx.await?.map_err(ExportErr)
     }
 
     /// Import encrypted key-value tuples directly into the db without encrypting, for db migration import
-    pub async fn import_db(&self, db_dump: Vec<(Vec<u8>, Vec<u8>)>) -> KvResult<()> {
+    pub async fn import_db(&self, db_dump: DbDump) -> KvResult<()> {
         let (resp_tx, resp_rx) = oneshot::channel();
         self.sender
             .send(ImportDb { db_dump, resp: resp_tx })

--- a/crates/kvdb/src/kv_manager/sled_bindings.rs
+++ b/crates/kvdb/src/kv_manager/sled_bindings.rs
@@ -25,7 +25,7 @@ use super::{
     helpers::{deserialize, serialize},
     types::{KeyReservation, DEFAULT_RESERVE},
 };
-use crate::encrypted_sled;
+use crate::{encrypted_sled, DbDump};
 
 /// Reserves a key. New key's value is [DEFAULT_RESERVE].
 /// Returns [SledErr] of [LogicalErr] on failure.
@@ -117,13 +117,10 @@ pub(super) fn handle_exists(kv: &encrypted_sled::Db, key: &str) -> InnerKvResult
     })
 }
 
-pub(super) fn handle_export_db(kv: &encrypted_sled::Db) -> InnerKvResult<Vec<(Vec<u8>, Vec<u8>)>> {
+pub(super) fn handle_export_db(kv: &encrypted_sled::Db) -> InnerKvResult<DbDump> {
     Ok(kv.export_encrypted_db())
 }
 
-pub(super) fn handle_import_db(
-    kv: &encrypted_sled::Db,
-    db_dump: Vec<(Vec<u8>, Vec<u8>)>,
-) -> InnerKvResult<()> {
+pub(super) fn handle_import_db(kv: &encrypted_sled::Db, db_dump: DbDump) -> InnerKvResult<()> {
     Ok(kv.import_encrypted_db(db_dump)?)
 }

--- a/crates/kvdb/src/kv_manager/sled_bindings.rs
+++ b/crates/kvdb/src/kv_manager/sled_bindings.rs
@@ -116,3 +116,14 @@ pub(super) fn handle_exists(kv: &encrypted_sled::Db, key: &str) -> InnerKvResult
         LogicalErr(format!("Could not perform 'contains_key' for key <{key}> due to error: {err}"))
     })
 }
+
+pub(super) fn handle_export_db(kv: &encrypted_sled::Db) -> InnerKvResult<Vec<(Vec<u8>, Vec<u8>)>> {
+    Ok(kv.export_encrypted_db())
+}
+
+pub(super) fn handle_import_db(
+    kv: &encrypted_sled::Db,
+    db_dump: Vec<(Vec<u8>, Vec<u8>)>,
+) -> InnerKvResult<()> {
+    Ok(kv.import_encrypted_db(db_dump)?)
+}

--- a/crates/kvdb/src/kv_manager/types.rs
+++ b/crates/kvdb/src/kv_manager/types.rs
@@ -17,6 +17,8 @@
 
 use std::fmt::Debug;
 
+use crate::DbDump;
+
 // default KV store names
 pub const DEFAULT_KV_NAME: &str = "kv";
 
@@ -70,10 +72,10 @@ pub(super) enum Command<V> {
         resp: Responder<()>,
     },
     ExportDb {
-        resp: Responder<Vec<(Vec<u8>, Vec<u8>)>>,
+        resp: Responder<DbDump>,
     },
     ImportDb {
-        db_dump: Vec<(Vec<u8>, Vec<u8>)>,
+        db_dump: DbDump,
         resp: Responder<()>,
     },
 }

--- a/crates/kvdb/src/kv_manager/types.rs
+++ b/crates/kvdb/src/kv_manager/types.rs
@@ -69,4 +69,11 @@ pub(super) enum Command<V> {
         key: String,
         resp: Responder<()>,
     },
+    ExportDb {
+        resp: Responder<Vec<(Vec<u8>, Vec<u8>)>>,
+    },
+    ImportDb {
+        db_dump: Vec<(Vec<u8>, Vec<u8>)>,
+        resp: Responder<()>,
+    },
 }

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -18,6 +18,10 @@ pub mod encrypted_sled;
 pub mod kv_manager;
 use std::{fs, path::PathBuf};
 
+/// Type alias for a database dump, which consists of a vector of raw key-value tuples
+/// as they appear in the db (with value encryption)
+pub type DbDump = Vec<(Vec<u8>, Vec<u8>)>;
+
 pub fn get_db_path(testing: bool) -> String {
     let mut root: PathBuf = std::env::current_dir().expect("could not get home directory");
     root.push(".entropy");

--- a/crates/threshold-signature-server/src/backup_provider/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/api.rs
@@ -245,7 +245,7 @@ pub async fn make_key_backup(
 }
 
 /// Store the details of a TSS node who has a backup of our encryption key in a file
-fn store_key_provider_details(
+pub(crate) fn store_key_provider_details(
     mut path: PathBuf,
     backup_provider_details: BackupProviderDetails,
 ) -> Result<(), BackupProviderError> {

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
@@ -107,6 +107,7 @@ pub async fn recover_encrypted_db(
     let db_backup: DbBackup = deserialize(&signed_message.message.0).unwrap();
 
     // TODO version check
+    // Based on version, filter db keys into the ones that are still relevant
 
     let storage_path = app_state.kv_store.storage_path().to_path_buf();
     store_key_provider_details(storage_path, db_backup.backup_provider_details)?;

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
@@ -113,14 +113,8 @@ pub async fn recover_encrypted_db(
     store_key_provider_details(storage_path, db_backup.backup_provider_details)?;
     app_state.kv_store.kv().import_db(db_backup.db_dump).await?;
 
-    // TODO now we need to check that we can move to a ready state, and do an on-chain check that
-    // the stash account is correct.
-    // eg: loop with a timer, polling app_state.is_ready()
-    // Do stash account check like above
-    // If it fails we probably need to restore the old db.
-    // Another approach would be to make the on-chain check before, reading the TSS account ID
-    // directly out of the db dump
-    //
-    // But then we should still check here that we can get to ready state
+    // Shut down gracefully so we can restart with the new secret keys and do an encryption key
+    // recovery
+    app_state.shutdown().await;
     Ok(())
 }

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
@@ -87,7 +87,7 @@ pub async fn backup_encrypted_db(
         db_dump: app_state.kv_store.kv().export_db().await?,
     };
 
-    Ok(serialize(&db_backup).map_err(|_| BackupEncryptedDbError::CannotSerializeBackup)?)
+    serialize(&db_backup).map_err(|_| BackupEncryptedDbError::CannotSerializeBackup)
 }
 
 /// HTTP POST route which takes an encrypted db backup together with recovery details and recovers

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/api.rs
@@ -1,0 +1,125 @@
+// Copyright (C) 2023 Entropy Cryptography Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//! Backup and restore encrypted DB before / after entropy-tss version upgrade
+use crate::{
+    backup_provider::api::{
+        get_key_provider_details, store_key_provider_details, BackupProviderDetails,
+    },
+    chain_api::entropy,
+    helpers::substrate::query_chain,
+    node_info::api::version,
+    validation::EncryptedSignedMessage,
+    AppState, SubxtAccountId32,
+};
+use axum::{extract::State, Json};
+use entropy_kvdb::{
+    kv_manager::helpers::{deserialize, serialize},
+    DbDump,
+};
+use entropy_shared::NEXT_NETWORK_PARENT_KEY;
+use serde::{Deserialize, Serialize};
+
+use super::errors::BackupEncryptedDbError;
+
+/// The backup payload
+#[derive(Debug, Serialize, Deserialize)]
+struct DbBackup {
+    /// entropy-tss version info so we know which version this backup was made with
+    version: String,
+    /// Details of the TSS node who holds the encryption key for this db
+    backup_provider_details: BackupProviderDetails,
+    /// The encrypted key-value store dump
+    db_dump: DbDump,
+}
+
+/// HTTP POST route which produces and encrypted db backup together with recovery details
+pub async fn backup_encrypted_db(
+    State(app_state): State<AppState>,
+    Json(encrypted_nonce): Json<EncryptedSignedMessage>,
+) -> Result<Vec<u8>, BackupEncryptedDbError> {
+    if !app_state.is_ready() {
+        return Err(BackupEncryptedDbError::NotReady);
+    }
+
+    let signed_message = encrypted_nonce.decrypt(&app_state.x25519_secret, &[])?;
+    let stash_account = SubxtAccountId32(signed_message.sender.0);
+
+    // To prove that the caller is the node operator, check that this is our associated stash
+    // account
+    let threshold_address_query =
+        entropy::storage().staking_extension().threshold_to_stash(app_state.subxt_account_id());
+    let (api, rpc) = app_state.get_api_rpc().await?;
+    let actual_stash_account = query_chain(&api, &rpc, threshold_address_query, None)
+        .await?
+        .ok_or(BackupEncryptedDbError::CannotGetStashAccount)?;
+    if actual_stash_account != stash_account {
+        return Err(BackupEncryptedDbError::Unauthorized);
+    }
+
+    // TODO to protect against replay attacts the message should contain a nonce
+    // let nonce: [u8; 32] =
+    //     signed_message.message.0.try_into().map_err(|_| BackupEncryptedDbError::BadNonceLength)?;
+
+    // Check that we are not a signer
+    if app_state.kv_store.kv().exists(&hex::encode(NEXT_NETWORK_PARENT_KEY)).await?
+        || app_state.kv_store.kv().exists(&hex::encode(NEXT_NETWORK_PARENT_KEY)).await?
+    {
+        return Err(BackupEncryptedDbError::CannotUpgradeWhileSigner);
+    }
+
+    // Make the backup
+    let storage_path = app_state.kv_store.storage_path().to_path_buf();
+    let db_backup = DbBackup {
+        version: version().await,
+        backup_provider_details: get_key_provider_details(storage_path)?,
+        db_dump: app_state.kv_store.kv().export_db().await?,
+    };
+
+    Ok(serialize(&db_backup).unwrap())
+}
+
+/// HTTP POST route which takes an encrypted db backup together with recovery details and recovers
+/// them
+pub async fn recover_encrypted_db(
+    State(app_state): State<AppState>,
+    Json(encrypted_db_backup): Json<EncryptedSignedMessage>,
+) -> Result<(), BackupEncryptedDbError> {
+    // This can only be called in a non-ready state - that is you cant recover a backup when the
+    // node is already up and running
+    if app_state.is_ready() {
+        return Err(BackupEncryptedDbError::Ready);
+    }
+    let signed_message = encrypted_db_backup.decrypt(&app_state.x25519_secret, &[])?;
+    let _stash_account = SubxtAccountId32(signed_message.sender.0);
+
+    let db_backup: DbBackup = deserialize(&signed_message.message.0).unwrap();
+
+    // TODO version check
+
+    let storage_path = app_state.kv_store.storage_path().to_path_buf();
+    store_key_provider_details(storage_path, db_backup.backup_provider_details)?;
+    app_state.kv_store.kv().import_db(db_backup.db_dump).await?;
+
+    // TODO now we need to check that we can move to a ready state, and do an on-chain check that
+    // the stash account is correct.
+    // eg: loop with a timer, polling app_state.is_ready()
+    // Do stash account check like above
+    // If it fails we probably need to restore the old db.
+    // Another approach would be to make the on-chain check before, reading the TSS account ID
+    // directly out of the db dump
+    //
+    // But then we should still check here that we can get to ready state
+    Ok(())
+}

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
@@ -39,7 +39,7 @@ pub enum BackupEncryptedDbError {
     SubstrateClient(#[from] entropy_client::substrate::SubstrateError),
     #[error("Cannot get stash account from chain")]
     CannotGetStashAccount,
-    #[error("You are not authorized to request a backup from this TSS node")]
+    #[error("Only the stash account associated with this TSS node may make this request")]
     Unauthorized,
     #[error("You cannot restore a db backup when the node is ready")]
     Ready,

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
@@ -43,6 +43,10 @@ pub enum BackupEncryptedDbError {
     Unauthorized,
     #[error("You cannot restore a db backup when the node is ready")]
     Ready,
+    #[error("Cannot deserialize provided backup")]
+    CannotDeserializeBackup,
+    #[error("Cannot serialize db backup")]
+    CannotSerializeBackup,
 }
 
 impl IntoResponse for BackupEncryptedDbError {

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
@@ -47,6 +47,12 @@ pub enum BackupEncryptedDbError {
     CannotDeserializeBackup,
     #[error("Cannot serialize db backup")]
     CannotSerializeBackup,
+    #[error("An x25519 public key of length 32 bytes must be given")]
+    BadResponsePublicKeyLength,
+    #[error("No connection to chain node")]
+    NotConnectedToChain,
+    #[error("Backup version mismatch. We are {0}, backup is from {1}")]
+    VersionMismatch(String, String),
 }
 
 impl IntoResponse for BackupEncryptedDbError {

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/errors.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2023 Entropy Cryptography Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use thiserror::Error;
+
+use crate::backup_provider::errors::BackupProviderError;
+
+/// An error relating to backing-up or recovering a key-value database encryption key
+#[derive(Debug, Error)]
+pub enum BackupEncryptedDbError {
+    #[error("Key-value DB: {0}")]
+    KvDb(#[from] entropy_kvdb::kv_manager::error::KvError),
+    #[error("It is not possible to upgrade entropy-tss while you are a signer")]
+    CannotUpgradeWhileSigner,
+    #[error("Backup Provider: {0}")]
+    BackupProvider(#[from] BackupProviderError),
+    #[error("Node has started fresh and not yet successfully set up")]
+    NotReady,
+    #[error("Encryption: {0}")]
+    Encryption(#[from] crate::validation::EncryptedSignedMessageErr),
+    #[error("Generic Substrate error: {0}")]
+    GenericSubstrate(#[from] subxt::error::Error),
+    #[error("Substrate: {0}")]
+    SubstrateClient(#[from] entropy_client::substrate::SubstrateError),
+    #[error("Cannot get stash account from chain")]
+    CannotGetStashAccount,
+    #[error("You are not authorized to request a backup from this TSS node")]
+    Unauthorized,
+    #[error("You cannot restore a db backup when the node is ready")]
+    Ready,
+}
+
+impl IntoResponse for BackupEncryptedDbError {
+    fn into_response(self) -> Response {
+        tracing::error!("{:?}", format!("{self}"));
+        let body = format!("{self}").into_bytes();
+        (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+    }
+}

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
@@ -12,20 +12,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//! Backup and restore encrypted DB before / after entropy-tss version upgrade
-use crate::{backup_provider::api::get_key_provider_details, AppState};
-use axum::{extract::State, Json};
 
-/// HTTP GET route which produces and encrypted db backup together with recovery details
-pub async fn backup_encrypted_db_for_version_upgrade(
-    State(app_state): State<AppState>,
-) -> Result<Json<()>, bool> {
-    // TODO this should take a nonce signed with the associated stash account to prove that the
-    // caller is the node operator
-
-    let storage_path = app_state.kv_store.storage_path().to_path_buf();
-    let key_provider_details = get_key_provider_details(storage_path).unwrap();
-    let db_dump = app_state.kv_store.kv().export_db().await.unwrap();
-    // TODO bincode serialize it
-    Ok(Json(()))
-}
+pub mod api;
+pub mod errors;

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
@@ -22,5 +22,7 @@ pub async fn backup_encrypted_db_for_version_upgrade(
 ) -> Result<Json<()>, bool> {
     let storage_path = app_state.kv_store.storage_path().to_path_buf();
     let key_provider_details = get_key_provider_details(storage_path).unwrap();
+    let db_dump = app_state.kv_store.kv().export_db().await.unwrap();
+    // TODO bincode serialize it
     Ok(Json(()))
 }

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
@@ -15,3 +15,6 @@
 
 pub mod api;
 pub mod errors;
+
+#[cfg(test)]
+mod tests;

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
@@ -12,11 +12,15 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//! Backup and restore encrypted DB before / after entropy-tss version upgrade
+use crate::{backup_provider::api::get_key_provider_details, AppState};
+use axum::{extract::State, Json};
 
-//! Backup database encryption key provider service
-pub mod api;
-pub mod errors;
-pub mod version_upgrade;
-
-#[cfg(test)]
-mod tests;
+/// HTTP GET route which produces and encrypted db backup together with recovery details
+pub async fn backup_encrypted_db_for_version_upgrade(
+    State(app_state): State<AppState>,
+) -> Result<Json<()>, bool> {
+    let storage_path = app_state.kv_store.storage_path().to_path_buf();
+    let key_provider_details = get_key_provider_details(storage_path).unwrap();
+    Ok(Json(()))
+}

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/mod.rs
@@ -20,6 +20,9 @@ use axum::{extract::State, Json};
 pub async fn backup_encrypted_db_for_version_upgrade(
     State(app_state): State<AppState>,
 ) -> Result<Json<()>, bool> {
+    // TODO this should take a nonce signed with the associated stash account to prove that the
+    // caller is the node operator
+
     let storage_path = app_state.kv_store.storage_path().to_path_buf();
     let key_provider_details = get_key_provider_details(storage_path).unwrap();
     let db_dump = app_state.kv_store.kv().export_db().await.unwrap();

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/tests.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/tests.rs
@@ -1,0 +1,87 @@
+// Copyright (C) 2023 Entropy Cryptography Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    backup_provider::api::make_key_backup,
+    chain_api::entropy,
+    helpers::{
+        tests::initialize_test_logger, validator::get_signer_and_x25519_secret_from_mnemonic,
+    },
+    launch::{development_mnemonic, ValidatorName},
+    SubxtAccountId32,
+};
+use entropy_client::{client::request_backup_encrypted_db, substrate::query_chain};
+use entropy_kvdb::clean_tests;
+use entropy_testing_utils::{
+    constants::TSS_ACCOUNTS, helpers::spawn_tss_nodes_and_start_chain, ChainSpecType,
+};
+use serial_test::serial;
+use sp_core::{sr25519, Pair};
+use std::path::PathBuf;
+
+#[tokio::test]
+#[serial]
+async fn encrypted_db_backup_test() {
+    clean_tests();
+    initialize_test_logger().await;
+
+    let (_ctx, api, rpc, _validator_ips, _validator_ids) =
+        spawn_tss_nodes_and_start_chain(ChainSpecType::IntegrationJumpStarted).await;
+
+    // Db dumps can only be made by non-signers, so find who is not currently a signer and get
+    // their stash stash_account
+    let (non_signer_stash_account, position) = {
+        let stash_accounts = vec![
+            sr25519::Pair::from_string("//Alice//stash", None).unwrap(),
+            sr25519::Pair::from_string("//Bob//stash", None).unwrap(),
+            sr25519::Pair::from_string("//Charlie//stash", None).unwrap(),
+            sr25519::Pair::from_string("//Dave//stash", None).unwrap(),
+        ];
+        // Get current signers
+        let signer_query = entropy::storage().staking_extension().signers();
+        let signer_stash_accounts =
+            query_chain(&api, &rpc, signer_query, None).await.unwrap().unwrap();
+
+        let position = stash_accounts
+            .iter()
+            .position(|s| !signer_stash_accounts.contains(&SubxtAccountId32(s.public().0)))
+            .unwrap();
+        let stash_account = stash_accounts[position].clone();
+        (stash_account, position)
+    };
+
+    // Make an encryption key backup - without this we are unable to backup the encrypted db as it
+    // expects to find the associated details
+    let storage_path: PathBuf =
+        format!(".entropy/testing/test_db_validator{}", position + 1).into();
+    // For testing we use TSS account ID as the db encryption key
+    let key = TSS_ACCOUNTS[position].0;
+
+    let validator_name = match position {
+        0 => ValidatorName::Alice,
+        2 => ValidatorName::Alice,
+        3 => ValidatorName::Alice,
+        4 => ValidatorName::Alice,
+        _ => panic!("Unexpected position"),
+    };
+    let mnemonic = development_mnemonic(&Some(validator_name));
+    let (tss_signer, _static_secret) =
+        get_signer_and_x25519_secret_from_mnemonic(&mnemonic.to_string()).unwrap();
+
+    make_key_backup(&api, &rpc, key, tss_signer.signer(), storage_path.clone()).await.unwrap();
+
+    // Get a db dump
+    let _db_dump = request_backup_encrypted_db(&api, &rpc, non_signer_stash_account).await.unwrap();
+}

--- a/crates/threshold-signature-server/src/backup_provider/version_upgrade/tests.rs
+++ b/crates/threshold-signature-server/src/backup_provider/version_upgrade/tests.rs
@@ -16,14 +16,19 @@
 use crate::{
     backup_provider::api::make_key_backup,
     chain_api::entropy,
+    get_api, get_rpc,
     helpers::{
-        tests::initialize_test_logger, validator::get_signer_and_x25519_secret_from_mnemonic,
+        tests::{create_clients, initialize_test_logger},
+        validator::get_signer_and_x25519_secret_from_mnemonic,
     },
     launch::{development_mnemonic, ValidatorName},
     SubxtAccountId32,
 };
-use entropy_client::{client::request_backup_encrypted_db, substrate::query_chain};
+use entropy_client::{
+    client::request_backup_encrypted_db, request_recover_encrypted_db, substrate::query_chain,
+};
 use entropy_kvdb::clean_tests;
+use entropy_testing_utils::test_node_process_testing_state;
 use entropy_testing_utils::{
     constants::TSS_ACCOUNTS, helpers::spawn_tss_nodes_and_start_chain, ChainSpecType,
 };
@@ -31,57 +36,100 @@ use serial_test::serial;
 use sp_core::{sr25519, Pair};
 use std::path::PathBuf;
 
-#[tokio::test]
+#[test]
 #[serial]
-async fn encrypted_db_backup_test() {
+fn encrypted_db_backup_test() {
     clean_tests();
-    initialize_test_logger().await;
 
-    let (_ctx, api, rpc, _validator_ips, _validator_ids) =
-        spawn_tss_nodes_and_start_chain(ChainSpecType::IntegrationJumpStarted).await;
+    // To simulate stopping the TSS node we make the backup in and starting a fresh one for recovery
+    // we use one tokio runtime to make the backup which allows us to drop the TSS task before
+    // starting another one for the recovery
+    let (db_dump, stash_account, port) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            initialize_test_logger().await;
 
-    // Db dumps can only be made by non-signers, so find who is not currently a signer and get
-    // their stash stash_account
-    let (non_signer_stash_account, position) = {
-        let stash_accounts = vec![
-            sr25519::Pair::from_string("//Alice//stash", None).unwrap(),
-            sr25519::Pair::from_string("//Bob//stash", None).unwrap(),
-            sr25519::Pair::from_string("//Charlie//stash", None).unwrap(),
-            sr25519::Pair::from_string("//Dave//stash", None).unwrap(),
-        ];
-        // Get current signers
-        let signer_query = entropy::storage().staking_extension().signers();
-        let signer_stash_accounts =
-            query_chain(&api, &rpc, signer_query, None).await.unwrap().unwrap();
+            let (_ctx, api, rpc, _validator_ips, _validator_ids) =
+                spawn_tss_nodes_and_start_chain(ChainSpecType::IntegrationJumpStarted).await;
 
-        let position = stash_accounts
-            .iter()
-            .position(|s| !signer_stash_accounts.contains(&SubxtAccountId32(s.public().0)))
-            .unwrap();
-        let stash_account = stash_accounts[position].clone();
-        (stash_account, position)
-    };
+            // Db dumps can only be made by non-signers, so find who is not currently a signer and get
+            // their stash stash_account
+            let (non_signer_stash_account, position) = {
+                let stash_accounts = vec![
+                    sr25519::Pair::from_string("//Alice//stash", None).unwrap(),
+                    sr25519::Pair::from_string("//Bob//stash", None).unwrap(),
+                    sr25519::Pair::from_string("//Charlie//stash", None).unwrap(),
+                    sr25519::Pair::from_string("//Dave//stash", None).unwrap(),
+                ];
+                // Get current signers
+                let signer_query = entropy::storage().staking_extension().signers();
+                let signer_stash_accounts =
+                    query_chain(&api, &rpc, signer_query, None).await.unwrap().unwrap();
 
-    // Make an encryption key backup - without this we are unable to backup the encrypted db as it
-    // expects to find the associated details
-    let storage_path: PathBuf =
-        format!(".entropy/testing/test_db_validator{}", position + 1).into();
-    // For testing we use TSS account ID as the db encryption key
-    let key = TSS_ACCOUNTS[position].0;
+                let position = stash_accounts
+                    .iter()
+                    .position(|s| !signer_stash_accounts.contains(&SubxtAccountId32(s.public().0)))
+                    .unwrap();
+                let stash_account = stash_accounts[position].clone();
+                (stash_account, position)
+            };
 
-    let validator_name = match position {
-        0 => ValidatorName::Alice,
-        2 => ValidatorName::Alice,
-        3 => ValidatorName::Alice,
-        4 => ValidatorName::Alice,
-        _ => panic!("Unexpected position"),
-    };
-    let mnemonic = development_mnemonic(&Some(validator_name));
-    let (tss_signer, _static_secret) =
-        get_signer_and_x25519_secret_from_mnemonic(&mnemonic.to_string()).unwrap();
+            // Make an encryption key backup - without this we are unable to backup the encrypted db as it
+            // expects to find the associated details
+            let storage_path: PathBuf =
+                format!(".entropy/testing/test_db_validator{}", position + 1).into();
+            // For testing we use TSS account ID as the db encryption key
+            let key = TSS_ACCOUNTS[position].0;
 
-    make_key_backup(&api, &rpc, key, tss_signer.signer(), storage_path.clone()).await.unwrap();
+            let validator_name = match position {
+                0 => ValidatorName::Alice,
+                1 => ValidatorName::Bob,
+                2 => ValidatorName::Charlie,
+                3 => ValidatorName::Dave,
+                _ => panic!("Unexpected position"),
+            };
+            let mnemonic = development_mnemonic(&Some(validator_name));
+            let (tss_signer, _static_secret) =
+                get_signer_and_x25519_secret_from_mnemonic(&mnemonic.to_string()).unwrap();
 
-    // Get a db dump
-    let _db_dump = request_backup_encrypted_db(&api, &rpc, non_signer_stash_account).await.unwrap();
+            make_key_backup(&api, &rpc, key, tss_signer.signer(), storage_path.clone())
+                .await
+                .unwrap();
+
+            // Get a db dump
+            let db_dump = request_backup_encrypted_db(&api, &rpc, non_signer_stash_account.clone())
+                .await
+                .unwrap();
+
+            let port = 3001 + position;
+            (db_dump, non_signer_stash_account, port)
+        });
+
+    tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+        // Start chain node
+        let force_authoring = true;
+        let context =
+            test_node_process_testing_state(ChainSpecType::IntegrationJumpStarted, force_authoring)
+                .await;
+        let api = get_api(&context[0].ws_url).await.unwrap();
+        let rpc = get_rpc(&context[0].ws_url).await.unwrap();
+
+        // Start TSS node eve - who is not in the staking pallet chainspec
+        let (axum, _kv, _id) =
+            create_clients("validator5".to_string(), vec![], vec![], &Some(ValidatorName::Eve))
+                .await;
+
+        // We need to use the ip and port associated with the original TSS node
+        let tcp_socket = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
+            .await
+            .expect("Unable to bind to given server address.");
+        tokio::spawn(async move {
+            axum::serve(tcp_socket, axum).await.unwrap();
+        });
+
+        // Attempt to recover
+        request_recover_encrypted_db(&api, &rpc, stash_account, db_dump).await.unwrap();
+    });
 }

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -53,7 +53,7 @@ use subxt::{
     backend::legacy::LegacyRpcMethods, ext::sp_core::sr25519, tx::PairSigner,
     utils::AccountId32 as SubxtAccountId32, Config, OnlineClient,
 };
-use tokio::sync::OnceCell;
+use tokio::sync::{mpsc, OnceCell};
 
 /// A shared reference to the logger used for tests.
 ///
@@ -77,7 +77,10 @@ pub async fn setup_client() -> KvManager {
         setup_kv_store(&Some(ValidatorName::Alice), Some(storage_path.clone())).await.unwrap();
 
     let _ = setup_latest_block_number(&kv_store).await;
-    let app_state = AppState::new(configuration, kv_store.clone(), sr25519_pair, x25519_secret);
+
+    let (shutdown_tx, _shutdown_rx) = mpsc::channel::<()>(1);
+    let app_state =
+        AppState::new(configuration, kv_store.clone(), sr25519_pair, x25519_secret, shutdown_tx);
 
     // Mock making the pre-requisite checks by setting the application state to ready
     app_state.make_ready();
@@ -109,7 +112,9 @@ pub async fn create_clients(
         setup_kv_store(validator_name, Some(path.into())).await.unwrap();
 
     let _ = setup_latest_block_number(&kv_store).await;
-    let app_state = AppState::new(configuration, kv_store.clone(), sr25519_pair, x25519_secret);
+    let (shutdown_tx, _shutdown_rx) = mpsc::channel::<()>(1);
+    let app_state =
+        AppState::new(configuration, kv_store.clone(), sr25519_pair, x25519_secret, shutdown_tx);
 
     let _ = setup_latest_block_number(&kv_store).await;
 

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -123,8 +123,13 @@ pub async fn create_clients(
         let _ = kv_store.clone().kv().put(reservation, value).await;
     }
 
-    // Mock making the pre-requisite checks by setting the application state to ready
-    app_state.make_ready().unwrap();
+    if validator_name == &Some(ValidatorName::Eve) {
+        // This is special behaviour needed for the encrypted_db_backup_test
+        app_state.connected_to_chain_node().unwrap();
+    } else {
+        // Mock making the pre-requisite checks by setting the application state to ready
+        app_state.make_ready().unwrap();
+    }
 
     let account_id = app_state.subxt_account_id();
 

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -158,6 +158,7 @@
 //! - [kvdb](entropy_kvdb) - Encrypted key-value database for storing key-shares and other data, build using
 //!     [sled](https://docs.rs/sled)
 #![doc(html_logo_url = "https://entropy.xyz/assets/logo_02.png")]
+use backup_provider::version_upgrade::api::{backup_encrypted_db, recover_encrypted_db};
 pub use entropy_client::chain_api;
 pub(crate) mod attestation;
 pub(crate) mod backup_provider;
@@ -313,6 +314,8 @@ pub fn app(app_state: AppState) -> Router {
         .route("/backup_encryption_key", post(backup_encryption_key))
         .route("/recover_encryption_key", post(recover_encryption_key))
         .route("/backup_provider_quote_nonce", post(quote_nonce))
+        .route("/backup_encrypted_db", post(backup_encrypted_db))
+        .route("/recover_encrypted_db", post(recover_encrypted_db))
         .route("/healthz", get(healthz))
         .route("/version", get(get_version))
         .route("/hashes", get(hashes))

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -14,10 +14,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 use crate::{node_info::errors::GetInfoError, AppState};
 use axum::{extract::State, Json};
-use entropy_shared::{types::HashingAlgorithm, X25519PublicKey};
-use serde::{Deserialize, Serialize};
+pub use entropy_client::TssPublicKeys;
+use entropy_shared::types::HashingAlgorithm;
 use strum::IntoEnumIterator;
-use subxt::utils::AccountId32;
 
 /// Returns the version and commit data
 #[tracing::instrument]
@@ -30,17 +29,6 @@ pub async fn version() -> String {
 pub async fn hashes() -> Json<Vec<HashingAlgorithm>> {
     let hashing_algos = HashingAlgorithm::iter().collect::<Vec<_>>();
     Json(hashing_algos)
-}
-
-/// Public signing and encryption keys associated with a TS server
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct TssPublicKeys {
-    /// Indicates that all prerequisite checks have passed
-    pub ready: bool,
-    /// The TSS account ID
-    pub tss_account: AccountId32,
-    /// The public encryption key
-    pub x25519_public_key: X25519PublicKey,
 }
 
 /// Returns the TS server's public keys and HTTP endpoint


### PR DESCRIPTION
This relates to, https://github.com/entropyxyz/entropy-core/issues/1247 and is described in this comment:  https://github.com/entropyxyz/entropy-core/issues/1247#issuecomment-2603935848

This provides HTTP endpoints which allow us to export the key-value store as a raw encrypted key-value pair dump, and import it again on a new version of entropy-tss.

The workflow will be something like:

- Do GET `/backup_encrypted_db` to get a payload containing the encrypted db, as well as details of the 'key provider'.
- Stop the VM.
- Start a new VM with the new version of `entropy-tss`
- Do POST `/backup_encrypted_db` giving the payload from step 1 in the request body, which would put the db / key provider files back.  This route can only be used when the node is in a 'not yet ready' state.

Currently based off https://github.com/entropyxyz/entropy-core/pull/1249

Following core sync call - it seems like we maybe don't want or need this feature.