### PR TITLE
Propagate key-value db command handler errors

### DIFF
--- a/crates/kvdb/src/kv_manager/kv.rs
+++ b/crates/kvdb/src/kv_manager/kv.rs
@@ -185,14 +185,7 @@ fn handle_response<T>(
 ) where
     T: Debug,
 {
-    match kv_resp {
-        Ok(_) => {
-            let response = resp.send(kv_resp);
-            match response {
-                Ok(_) => {},
-                Err(err) => tracing::warn!("Receiver to dropped with: {:?}", err),
-            }
-        },
-        Err(err) => tracing::error!("Failed to handle database query with: {:?}", err),
-    }
+    if let Err(err) = resp.send(kv_resp) {
+        tracing::warn!("KVDB response channel receiver to dropped with: {:?}", err);
+    };
 }


### PR DESCRIPTION
Relates to https://github.com/entropyxyz/entropy-core/issues/1260

This makes it so that errors from the key-value store command handler are sent through the response channel so they can be propagated to the caller of the public methods.

Without this, whichever database error occurs, the caller will always see `Recv Error: channel closed`.