### PR TITLE
Add no hash option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ runtime
 - Test CLI command to retrieve quote and change endpoint / TSS account in one command ([#1198](https://github.com/entropyxyz/entropy-core/pull/1198))
 - On-chain unresponsiveness reporting [(#1215)](https://github.com/entropyxyz/entropy-core/pull/1215)
 - Add cli options for adding validator [(#1242)](https://github.com/entropyxyz/entropy-core/pull/1242)
+- Add no hash option [(#1266)](https://github.com/entropyxyz/entropy-core/pull/1266)
 
 ### Changed
 - Use correct key rotation endpoint in OCW ([#1104](https://github.com/entropyxyz/entropy-core/pull/1104))

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -105,6 +105,7 @@ pub enum HashingAlgorithm {
     Sha3,
     Keccak,
     Blake2_256,
+    NoHash,
     Custom(usize),
 }
 

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -105,6 +105,7 @@ pub enum HashingAlgorithm {
     Sha3,
     Keccak,
     Blake2_256,
+    /// If you are trying to sign a hashed message you can use this, length requirement is 64 digits
     NoHash,
     Custom(usize),
 }

--- a/crates/shared/src/types.rs
+++ b/crates/shared/src/types.rs
@@ -105,8 +105,8 @@ pub enum HashingAlgorithm {
     Sha3,
     Keccak,
     Blake2_256,
-    /// If you are trying to sign a hashed message you can use this, length requirement is 64 digits
-    NoHash,
+    /// An algorithm which produces the same output as its input.
+    Identity,
     Custom(usize),
 }
 

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -157,7 +157,7 @@ pub async fn compute_hash(
             Ok(hash)
         },
         HashingAlgorithm::Blake2_256 => Ok(blake2_256(message)),
-        HashingAlgorithm::NoHash => Ok(message.try_into()?),
+        HashingAlgorithm::Identity => Ok(message.try_into()?),
         HashingAlgorithm::Custom(i) => {
             let program_info = get_program(api, rpc, &programs_data[*i].program_pointer).await?;
             evaluate_custom_hash(fuel, program_info, message)

--- a/crates/threshold-signature-server/src/helpers/user.rs
+++ b/crates/threshold-signature-server/src/helpers/user.rs
@@ -157,6 +157,7 @@ pub async fn compute_hash(
             Ok(hash)
         },
         HashingAlgorithm::Blake2_256 => Ok(blake2_256(message)),
+        HashingAlgorithm::NoHash => Ok(message.try_into()?),
         HashingAlgorithm::Custom(i) => {
             let program_info = get_program(api, rpc, &programs_data[*i].program_pointer).await?;
             evaluate_custom_hash(fuel, program_info, message)

--- a/crates/threshold-signature-server/src/node_info/tests.rs
+++ b/crates/threshold-signature-server/src/node_info/tests.rs
@@ -54,6 +54,7 @@ async fn hashes_test() {
             HashingAlgorithm::Sha3,
             HashingAlgorithm::Keccak,
             HashingAlgorithm::Blake2_256,
+            HashingAlgorithm::NoHash,
             HashingAlgorithm::Custom(0),
         ]
     );

--- a/crates/threshold-signature-server/src/node_info/tests.rs
+++ b/crates/threshold-signature-server/src/node_info/tests.rs
@@ -54,7 +54,7 @@ async fn hashes_test() {
             HashingAlgorithm::Sha3,
             HashingAlgorithm::Keccak,
             HashingAlgorithm::Blake2_256,
-            HashingAlgorithm::NoHash,
+            HashingAlgorithm::Identity,
             HashingAlgorithm::Custom(0),
         ]
     );

--- a/crates/threshold-signature-server/src/user/errors.rs
+++ b/crates/threshold-signature-server/src/user/errors.rs
@@ -179,6 +179,8 @@ pub enum UserErr {
     IncorrectSigner,
     #[error("Program Version not supported")]
     ProgramVersion,
+    #[error("Conversion Error: {0}")]
+    TryFromSlice(#[from] std::array::TryFromSliceError),
 }
 
 impl From<hkdf::InvalidLength> for UserErr {

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -957,14 +957,15 @@ async fn test_compute_hash() {
     let expected_hash = blake3::hash(PREIMAGE_SHOULD_SUCCEED).as_bytes().to_vec();
     assert_eq!(message_hash.to_vec(), expected_hash);
 
-    let no_hash = vec![0u8; 32];
-    let no_hash_too_long = vec![0u8; 33];
+    const EXPECTED_MAX_HASH_LENGTH: usize = 32;
+    let no_hash = vec![0u8; EXPECTED_MAX_HASH_LENGTH];
+    let no_hash_too_long = vec![0u8; EXPECTED_MAX_HASH_LENGTH + 1];
 
     // no hash
     let message_hash_no_hash = compute_hash(
         &api,
         &rpc,
-        &HashingAlgorithm::NoHash,
+        &HashingAlgorithm::Identity,
         10000000u64,
         &vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }],
         &no_hash,
@@ -978,14 +979,17 @@ async fn test_compute_hash() {
     let message_hash_no_hash_too_long = compute_hash(
         &api,
         &rpc,
-        &HashingAlgorithm::NoHash,
+        &HashingAlgorithm::Identity,
         10000000u64,
         &vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }],
         &no_hash_too_long,
     )
     .await;
 
-    assert!(message_hash_no_hash_too_long.is_err());
+    assert_eq!(
+        message_hash_no_hash_too_long.unwrap_err().to_string(),
+        "Conversion Error: could not convert slice to array".to_string()
+    );
 }
 
 #[tokio::test]

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -986,7 +986,6 @@ async fn test_compute_hash() {
     .await;
 
     assert!(message_hash_no_hash_too_long.is_err());
-
 }
 
 #[tokio::test]

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -956,6 +956,37 @@ async fn test_compute_hash() {
     // custom hash program uses blake 3 to hash
     let expected_hash = blake3::hash(PREIMAGE_SHOULD_SUCCEED).as_bytes().to_vec();
     assert_eq!(message_hash.to_vec(), expected_hash);
+
+    let no_hash = vec![0u8; 32];
+    let no_hash_too_long = vec![0u8; 33];
+
+    // no hash
+    let message_hash_no_hash = compute_hash(
+        &api,
+        &rpc,
+        &HashingAlgorithm::NoHash,
+        10000000u64,
+        &vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }],
+        &no_hash,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(message_hash_no_hash.to_vec(), no_hash);
+
+    // no hash too long error
+    let message_hash_no_hash_too_long = compute_hash(
+        &api,
+        &rpc,
+        &HashingAlgorithm::NoHash,
+        10000000u64,
+        &vec![ProgramInstance { program_pointer: program_hash, program_config: vec![] }],
+        &no_hash_too_long,
+    )
+    .await;
+
+    assert!(message_hash_no_hash_too_long.is_err());
+
 }
 
 #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,6 @@ exceptions=[
   { allow=["AGPL-3.0"], name="entropy-client" },
   { allow=["AGPL-3.0"], name="entropy-testing-utils" },
   { allow=["AGPL-3.0"], name="entropy-test-cli" },
-  { allow=["AGPL-3.0"], name="entropy-create-test-keyshares" },
 
   # Other Entropy crates
   { allow=["AGPL-3.0"], name="entropy-programs-core" },

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow=[
   "MIT",
   "MIT-0",
   "MPL-2.0",
+  "Zlib"
 ]
 
 # If true, ignores workspace crates that aren't published, or are only
@@ -33,7 +34,6 @@ exceptions=[
   { allow=["AGPL-3.0"], name="entropy-client" },
   { allow=["AGPL-3.0"], name="entropy-testing-utils" },
   { allow=["AGPL-3.0"], name="entropy-test-cli" },
-  { allow=["AGPL-3.0"], name="entropy-create-test-keyshares" },
 
   # Other Entropy crates
   { allow=["AGPL-3.0"], name="entropy-programs-core" },

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,7 @@ allow=[
   "MIT",
   "MIT-0",
   "MPL-2.0",
-  "Zlib"
+  "Zlib",
 ]
 
 # If true, ignores workspace crates that aren't published, or are only

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ exceptions=[
   { allow=["AGPL-3.0"], name="entropy-client" },
   { allow=["AGPL-3.0"], name="entropy-testing-utils" },
   { allow=["AGPL-3.0"], name="entropy-test-cli" },
+  { allow=["AGPL-3.0"], name="entropy-create-test-keyshares" },
 
   # Other Entropy crates
   { allow=["AGPL-3.0"], name="entropy-programs-core" },


### PR DESCRIPTION
Adds a no hash option. After talking with @rh0delta a possibility to send a hash to be signed is a good use case, can do this hackily with custom hash, but this should be an out of the box option