### PR TITLE
Ignore failing jumpstart and reshare tests

### DIFF
--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -1054,6 +1054,9 @@ async fn test_program_with_config() {
     clean_tests();
 }
 
+// FIXME (#1119): This fails intermittently and needs to be addressed. For now we ignore it since
+// it's producing false negatives on our CI runs.
+#[ignore]
 #[tokio::test]
 #[serial]
 async fn test_jumpstart_network() {

--- a/crates/threshold-signature-server/src/validator/tests.rs
+++ b/crates/threshold-signature-server/src/validator/tests.rs
@@ -55,6 +55,9 @@ use std::collections::HashSet;
 use subxt::utils::AccountId32;
 use synedrion::k256::ecdsa::VerifyingKey;
 
+// FIXME (#1273): This fails intermittently and needs to be addressed. For now we ignore it since
+// it's producing false negatives on our CI runs.
+#[ignore]
 #[tokio::test]
 #[serial]
 async fn test_reshare_basic() {

--- a/crates/threshold-signature-server/tests/sign_eth_tx.rs
+++ b/crates/threshold-signature-server/tests/sign_eth_tx.rs
@@ -44,6 +44,9 @@ use synedrion::k256::ecdsa::VerifyingKey;
 
 const GOERLI_CHAIN_ID: u64 = 5;
 
+// FIXME (#1119): This fails intermittently and needs to be addressed. For now we ignore it since
+// it's producing false negatives on our CI runs.
+#[ignore]
 #[tokio::test]
 #[serial]
 async fn integration_test_sign_eth_tx() {


### PR DESCRIPTION
There have been two tests which have been randomly failing for the last month or two
(see #1119 and #1273).

This has caused problems with other CI jobs which would've otherwise passed but now fail
because of one of these two tests. I hate to ignore tests, but until they can run more
reliably we shouldn't have them running as part of the CI.

@JesseAbram can you take some time in the next couple of days to get these sorted out 🙏
