### PR TITLE
Ignore another failing integration test

### DIFF
--- a/crates/threshold-signature-server/tests/jumpstart_register_sign.rs
+++ b/crates/threshold-signature-server/tests/jumpstart_register_sign.rs
@@ -35,6 +35,9 @@ use sp_keyring::AccountKeyring;
 use subxt::utils::AccountId32;
 use synedrion::k256::ecdsa::VerifyingKey;
 
+// FIXME (#1119): This fails intermittently and needs to be addressed. For now we ignore it since
+// it's producing false negatives on our CI runs.
+#[ignore]
 #[tokio::test]
 #[serial]
 async fn integration_test_register_sign() {


### PR DESCRIPTION
This is a follow up to #1274 - looks like there are more failing tests
than I originally thought.
