### PR TITLE
Revert "Bump parity-scale-codec from 3.7.2 to 3.7.4 in the patch-dependencies group"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7795,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "b91c2d9a6a6004e205b7e881856fb1a0f5022d382acc2c01b52185f7b6f65997"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -7812,14 +7812,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -31,7 +31,7 @@ reqwest           ={ version="0.12.12", features=["json", "stream"], optional=tr
 base64            ={ version="0.22.0", optional=true }
 synedrion         ={ version="0.2.0", optional=true }
 hex               ={ version="0.4.3", optional=true }
-parity-scale-codec={ version="3.7.4", default-features=false, optional=true }
+parity-scale-codec={ version="3.7.2", default-features=false, optional=true }
 
 # Only for the browser
 js-sys={ version="0.3.74", optional=true }

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -24,4 +24,4 @@ entropy-shared    ={ version="0.3.0", path="../shared" }
 serde_json        ="1.0.138"
 serde             ={ version="1.0.217", features=["derive"] }
 reqwest           ="0.12.12"
-parity-scale-codec={ version="3.7.4", default-features=false }
+parity-scale-codec={ version="3.7.2", default-features=false }

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -13,7 +13,7 @@ subxt             ="0.35.3"
 sp-keyring        ="34.0.0"
 project-root      ="0.2.2"
 sp-core           ={ version="31.0.0", default-features=false }
-parity-scale-codec="3.7.4"
+parity-scale-codec="3.7.2"
 lazy_static       ="1.5.0"
 hex-literal       ="0.4.1"
 tokio             ={ version="1.43", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -36,7 +36,7 @@ axum   ={ version="0.8.2", features=["ws"] }
 
 # Substrate
 subxt             ="0.35.3"
-parity-scale-codec="3.7.4"
+parity-scale-codec="3.7.2"
 sp-core           ={ version="31.0.0", default-features=false }
 sp-keyring        ="34.0.0"
 


### PR DESCRIPTION
Reverts entropyxyz/entropy-core#1286 which was automatically merged despite breaking CI.

This is a short term proposal to get CI to pass on master again for now.

Long term i think we should be able to re-open that PR and fix the issue with having duplicate indexes.