### PR TITLE
Revert "Bump the patch-dependencies group with 6 updates"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.32",
+ "zerocopy",
 ]
 
 [[package]]
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "approx"
@@ -374,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ dependencies = [
  "getrandom 0.2.15",
  "instant",
  "pin-project-lite 0.2.14",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -847,7 +847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -2489,7 +2489,7 @@ dependencies = [
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "project-root",
- "rand 0.8.5",
+ "rand",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-chain-spec 28.0.0",
@@ -2555,7 +2555,7 @@ dependencies = [
  "js-sys",
  "num",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "reqwest",
  "serde",
@@ -2594,7 +2594,7 @@ dependencies = [
  "chacha20poly1305 0.9.1",
  "entropy-protocol",
  "hex",
- "rand 0.8.5",
+ "rand",
  "rpassword",
  "scrypt",
  "serde",
@@ -2814,7 +2814,7 @@ dependencies = [
  "lazy_static",
  "parity-scale-codec",
  "project-root",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "sp-core 31.0.0",
  "sp-keyring 34.0.0",
@@ -2859,7 +2859,7 @@ dependencies = [
  "num",
  "parity-scale-codec",
  "project-root",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "reqwest",
  "reqwest-eventsource",
@@ -3025,7 +3025,7 @@ dependencies = [
  "k256",
  "num_enum",
  "open-fastrlp",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "serde_json",
@@ -3211,7 +3211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3349,7 +3349,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "sc-block-builder 0.34.0",
  "sc-cli 0.37.0",
@@ -3970,7 +3970,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
 ]
 
@@ -4087,7 +4087,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "spinning_top",
 ]
@@ -4980,7 +4980,7 @@ dependencies = [
  "hyper 0.14.28",
  "jsonrpsee-types 0.20.3",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -5005,7 +5005,7 @@ dependencies = [
  "jsonrpsee-types 0.22.4",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -5331,7 +5331,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "rw-stream-sink",
  "smallvec",
  "thiserror 1.0.68",
@@ -5387,7 +5387,7 @@ dependencies = [
  "multiaddr",
  "multihash 0.17.0",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "thiserror 1.0.68",
  "zeroize",
@@ -5412,7 +5412,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "smallvec",
  "thiserror 1.0.68",
@@ -5434,7 +5434,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.10",
  "tokio",
@@ -5470,7 +5470,7 @@ dependencies = [
  "log",
  "once_cell",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -5492,7 +5492,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "void",
 ]
 
@@ -5512,7 +5512,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "quinn-proto",
- "rand 0.8.5",
+ "rand",
  "rustls 0.20.9",
  "thiserror 1.0.68",
  "tokio",
@@ -5530,7 +5530,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.5",
+ "rand",
  "smallvec",
 ]
 
@@ -5549,7 +5549,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "tokio",
  "void",
@@ -5685,7 +5685,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -6092,7 +6092,7 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.6.1",
@@ -6315,7 +6315,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -6505,7 +6505,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -6985,7 +6985,7 @@ dependencies = [
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sp-arithmetic 24.0.0",
  "sp-core 29.0.0",
@@ -7394,7 +7394,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sp-core 29.0.0",
  "sp-io 31.0.0",
@@ -7459,7 +7459,7 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "sp-runtime 32.0.0",
  "sp-session 28.0.0",
  "sp-std 14.0.0",
@@ -7534,7 +7534,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "scale-info",
@@ -7767,7 +7767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -7788,7 +7788,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -8469,7 +8469,7 @@ dependencies = [
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.3",
@@ -8645,7 +8645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.9",
@@ -8683,17 +8683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.1",
- "zerocopy 0.8.20",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8711,16 +8700,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.1",
 ]
 
 [[package]]
@@ -8742,23 +8721,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
-dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.20",
-]
-
-[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -9455,7 +9424,7 @@ dependencies = [
  "parity-scale-codec",
  "prost 0.12.4",
  "prost-build",
- "rand 0.8.5",
+ "rand",
  "sc-client-api 29.0.0",
  "sc-network 0.35.0",
  "sp-api 27.0.0",
@@ -9606,7 +9575,7 @@ dependencies = [
  "log",
  "names",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rpassword",
  "sc-client-api 29.0.0",
@@ -9648,7 +9617,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rpassword",
  "sc-client-api 32.0.0",
@@ -9926,7 +9895,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-block-builder 0.34.0",
  "sc-chain-spec 28.0.0",
  "sc-client-api 29.0.0",
@@ -10272,7 +10241,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-client-api 29.0.0",
  "sc-network-common 0.34.0",
  "sc-utils 15.0.0",
@@ -10316,7 +10285,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "partial_sort",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-client-api 32.0.0",
  "sc-network-common 0.37.0",
  "sc-utils 17.0.0",
@@ -10611,7 +10580,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-client-api 29.0.0",
  "sc-network 0.35.0",
  "sc-network-common 0.34.0",
@@ -10825,7 +10794,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec 31.0.0",
  "sc-client-api 32.0.0",
  "sc-rpc 33.0.0",
@@ -10859,7 +10828,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec 28.0.0",
  "sc-client-api 29.0.0",
  "sc-client-db 0.36.0",
@@ -10923,7 +10892,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec 31.0.0",
  "sc-client-api 32.0.0",
  "sc-client-db 0.39.0",
@@ -11040,7 +11009,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "regex",
  "sc-telemetry 16.0.0",
@@ -11062,7 +11031,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "regex",
  "sc-telemetry 18.0.0",
@@ -11086,7 +11055,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-utils 15.0.0",
  "serde",
  "serde_json",
@@ -11106,7 +11075,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-utils 17.0.0",
  "serde",
  "serde_json",
@@ -11690,9 +11659,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -11719,9 +11688,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11741,9 +11710,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -12051,7 +12020,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "pin-project",
  "poly1305 0.8.0",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "ruzstd",
  "schnorrkel",
@@ -12094,7 +12063,7 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -12161,7 +12130,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1",
 ]
 
@@ -12579,7 +12548,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
@@ -12626,7 +12595,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
@@ -12673,7 +12642,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
@@ -13117,7 +13086,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -13142,7 +13111,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -13167,7 +13136,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -13336,7 +13305,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core 29.0.0",
  "sp-externalities 0.26.0",
@@ -13358,7 +13327,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core 31.0.0",
  "sp-externalities 0.27.0",
@@ -13380,7 +13349,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core 32.0.0",
  "sp-externalities 0.28.0",
@@ -13402,7 +13371,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sha2 0.10.8",
  "sp-api 27.0.0",
@@ -13428,7 +13397,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sha2 0.10.8",
  "sp-api 30.0.0",
@@ -13597,7 +13566,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core 29.0.0",
@@ -13622,7 +13591,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core 31.0.0",
@@ -13647,7 +13616,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core 32.0.0",
@@ -14612,7 +14581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -14662,9 +14631,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
 dependencies = [
  "futures-util",
  "log",
@@ -15035,7 +15004,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.10",
  "thiserror 1.0.68",
@@ -15116,16 +15085,17 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
 dependencies = [
+ "byteorder",
  "bytes",
  "data-encoding",
  "http 1.1.0",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand",
  "sha1",
  "thiserror 2.0.11",
  "utf-8",
@@ -15139,7 +15109,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -15348,7 +15318,7 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -16084,7 +16054,7 @@ dependencies = [
  "memfd",
  "memoffset 0.8.0",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.36.17",
  "wasmtime-asm-macros 8.0.1",
  "wasmtime-environ 8.0.1",
@@ -16109,7 +16079,7 @@ dependencies = [
  "memfd",
  "memoffset 0.9.1",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.38.40",
  "sptr",
  "wasm-encoder 0.31.1",
@@ -16878,7 +16848,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -16903,16 +16873,7 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive 0.7.32",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
-dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -16920,17 +16881,6 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -19,7 +19,7 @@ futures       ="0.3"
 sp-core       ={ version="31.0.0", default-features=false, features=["full_crypto", "serde"] }
 tracing       ="0.1.41"
 rand          ={ version="0.8", default-features=false }
-anyhow        ="1.0.96"
+anyhow        ="1.0.95"
 
 # Present when "full-client" feature is active
 blake2            ={ version="0.10.4", optional=true }
@@ -31,7 +31,7 @@ reqwest           ={ version="0.12.12", features=["json", "stream"], optional=tr
 base64            ={ version="0.22.0", optional=true }
 synedrion         ={ version="0.2.0", optional=true }
 hex               ={ version="0.4.3", optional=true }
-parity-scale-codec={ version="3.7.4", default-features=false, optional=true }
+parity-scale-codec={ version="3.7.2", default-features=false, optional=true }
 
 # Only for the browser
 js-sys={ version="0.3.74", optional=true }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -35,7 +35,7 @@ num                ="0.4.3"
 
 # Used only with the `server` feature to implement the WsConnection trait
 axum             ={ version="0.8.2", features=["ws"], optional=true }
-tokio-tungstenite={ version="0.26.2", optional=true }
+tokio-tungstenite={ version="0.26.1", optional=true }
 
 # Used only with the `wasm` feature
 gloo-net            ={ version="0.6.0", default-features=false, features=["websocket"], optional=true }
@@ -49,7 +49,7 @@ schnorrkel          ={ version="0.11.4", default-features=false, features=["std"
 [dev-dependencies]
 serial_test="3.2.0"
 sp-keyring ="34.0.0"
-anyhow     ="1.0.96"
+anyhow     ="1.0.95"
 num_cpus   ="1.16.0"
 
 [features]

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -14,14 +14,14 @@ clap              ={ version="4.5.30", features=["derive"] }
 colored           ="3.0.0"
 subxt             ="0.35.3"
 sp-core           ="31.0.0"
-anyhow            ="1.0.96"
+anyhow            ="1.0.95"
 tokio             ={ version="1.43", features=["macros", "rt-multi-thread", "io-util", "process"] }
 hex               ="0.4.3"
 bincode           ="1.3.3"
 x25519-dalek      ="2.0.1"
 sp-runtime        ={ version="32.0.0", default-features=false }
 entropy-shared    ={ version="0.3.0", path="../shared" }
-serde_json        ="1.0.139"
-serde             ={ version="1.0.218", features=["derive"] }
+serde_json        ="1.0.138"
+serde             ={ version="1.0.217", features=["derive"] }
 reqwest           ="0.12.12"
-parity-scale-codec={ version="3.7.4", default-features=false }
+parity-scale-codec={ version="3.7.2", default-features=false }

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -13,7 +13,7 @@ subxt             ="0.35.3"
 sp-keyring        ="34.0.0"
 project-root      ="0.2.2"
 sp-core           ={ version="31.0.0", default-features=false }
-parity-scale-codec="3.7.4"
+parity-scale-codec="3.7.2"
 lazy_static       ="1.5.0"
 hex-literal       ="0.4.1"
 tokio             ={ version="1.43", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -13,7 +13,7 @@ edition    ='2021'
 serde              ={ version="1.0", default-features=false, features=["derive"] }
 serde_json         ="1.0"
 thiserror          ="2.0.11"
-anyhow             ="1.0.96"
+anyhow             ="1.0.95"
 blake2             ="0.10.4"
 x25519-dalek       ={ version="2.0.1", features=["static_secrets"] }
 rand_core          ="0.6.4"
@@ -36,7 +36,7 @@ axum   ={ version="0.8.2", features=["ws"] }
 
 # Substrate
 subxt             ="0.35.3"
-parity-scale-codec="3.7.4"
+parity-scale-codec="3.7.2"
 sp-core           ={ version="31.0.0", default-features=false }
 sp-keyring        ="34.0.0"
 
@@ -58,7 +58,7 @@ tracing-bunyan-formatter="0.3.10"
 uuid                    ={ version="1.13.2", features=["v4"] }
 
 # Misc
-tokio-tungstenite="0.26.2"
+tokio-tungstenite="0.26.1"
 bincode          ="1.3.3"
 bip32            ={ version="0.5.3" }
 bip39            ={ version="2.1.0", features=["zeroize"] }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -29,8 +29,8 @@ lazy_static     ={ version="1.5.0", features=["spin_no_std"] }
 log             ="0.4.25"
 pallet-im-online={ version="28.0.0" }
 rand            ="0.8.5"
-serde           ={ version="1.0.218", features=["derive"] }
-serde_json      ='1.0.139'
+serde           ={ version="1.0.217", features=["derive"] }
+serde_json      ='1.0.138'
 
 # Substrate Client
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -15,7 +15,7 @@ targets=['x86_64-unknown-linux-gnu']
 codec      ={ package="parity-scale-codec", version="3.6.3", default-features=false, features=["derive"] }
 scale-info ={ version="2.11", default-features=false, features=["derive"] }
 log        ={ version="0.4.25", default-features=false }
-serde      ={ version="1.0.218", default-features=false }
+serde      ={ version="1.0.217", default-features=false }
 rand_chacha={ version="0.3", default-features=false }
 
 frame-benchmarking={ version="29.0.0", default-features=false, optional=true }


### PR DESCRIPTION
Reverts entropyxyz/entropy-core#1308 

This is starting to drive me insane.  If we don't find a solution to https://github.com/entropyxyz/entropy-core/issues/1302 soon, i propose we remove https://github.com/entropyxyz/entropy-core/blob/eaa13f8c70bcd7e31112bdbe9ce8f5e64ad70b42/.github/workflows/dependabot-auto-merge.yml until we figure out how to put in a clause that CI must pass.