### PR TITLE
Github actions workflow for building CVM image on release

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -76,15 +76,14 @@ jobs:
         env:
           ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}
         run: |
-          echo "Using artifact url: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}"
           make image-base
-          find . -name 'core-image-minimal-tdx-gcp'
+          echo "Using artifact url: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: images
-          path: /home/runner/work/yocto-build/yocto-build/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
+          path: /home/runner/work/entropy-core/entropy-core/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
           if-no-files-found: error
 
   release:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -18,7 +18,7 @@ jobs:
 
   git-ref-basename:
     uses: ./.github/workflows/git-ref-basename.yaml
-  
+
   test-e2e-reshare:
     runs-on: core-build-runner
     steps:
@@ -55,6 +55,34 @@ jobs:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_CI_TOKEN: ${{ secrets.DOCKER_HUB_CI_TOKEN }}
       CI_MACHINE_USER_TOKEN: ${{ secrets.CI_MACHINE_USER_TOKEN }}
+
+  build-entropy-tss-cvm-image:
+    name: Build confidential virtual machine image for entropy-tss
+    needs:
+      - build-entropy-tss
+    runs-on: core-build-runner
+    steps:
+      - name: Check out the yocto-build repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'entropyxyz/yocto-build'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+            version: latest
+
+      - name: Build
+        env:
+          ENTROPY_TSS_BINARY_URI: ${{need.build-entropy-tss.outputs.artifact-url}}
+        run: |
+          make image-base
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: images
+          path: ~/work/yocto-build/yocto-build/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
 
   release:
     name: Publish new release

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -48,8 +48,6 @@ jobs:
     uses: ./.github/workflows/container-build-and-push.yaml
     needs:
       - git-ref-basename
-    outputs:
-      artifact_url: foobar
     with:
       docker_build_arg_package: entropy-tss
       git_ref_basename: ${{ needs.git-ref-basename.outputs.git_ref_basename }}
@@ -76,7 +74,7 @@ jobs:
 
       - name: Build
         env:
-          ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.outputs.artifact-url}}
+          ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}
         run: |
           make image-base
 

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build
         env:
-          ENTROPY_TSS_BINARY_URI: ${{need.build-entropy-tss.outputs.artifact-url}}
+          ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.outputs.artifact-url}}
         run: |
           make image-base
 

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -48,6 +48,8 @@ jobs:
     uses: ./.github/workflows/container-build-and-push.yaml
     needs:
       - git-ref-basename
+    outputs:
+      artifact_url: foobar
     with:
       docker_build_arg_package: entropy-tss
       git_ref_basename: ${{ needs.git-ref-basename.outputs.git_ref_basename }}
@@ -82,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: images
-          path: ~/work/yocto-build/yocto-build/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
+          path: /home/runner/work/yocto-build/yocto-build/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
 
   release:
     name: Publish new release

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -76,13 +76,16 @@ jobs:
         env:
           ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}
         run: |
+          echo "Using artifact url: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}"
           make image-base
+          find . -name 'core-image-minimal-tdx-gcp'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: images
           path: /home/runner/work/yocto-build/yocto-build/reproducible-build/artifacts-base/core-image-minimal-tdx-gcp.rootfs.wic.tar.gz
+          if-no-files-found: error
 
   release:
     name: Publish new release

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -74,10 +74,10 @@ jobs:
 
       - name: Build
         env:
-          ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}
+          ENTROPY_TSS_BINARY_URI: ${{needs.build-entropy-tss.outputs.artifact_url}}
         run: |
           make image-base
-          echo "Using artifact url: ${{needs.build-entropy-tss.jobs.build.outputs.artifact-url}}"
+          echo "Using artifact url: ${{needs.build-entropy-tss.outputs.artifact_url}}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/container-build-and-push.yaml
+++ b/.github/workflows/container-build-and-push.yaml
@@ -31,6 +31,10 @@ on:
       CI_MACHINE_USER_TOKEN:
         description: Fine-grained GitHub Personal Access Token specific for CI.
         required: true
+    outputs:
+      artifact_url:
+        description: Url of the uploaded binary
+        value: ${{ jobs.build.outputs.artifact_url }}
 
 jobs:
   build:

--- a/.github/workflows/container-build-and-push.yaml
+++ b/.github/workflows/container-build-and-push.yaml
@@ -36,6 +36,8 @@ jobs:
   build:
     name: Build and upload ${{ inputs.docker_build_arg_package }} binary
     runs-on: core-build-runner
+    outputs:
+        artifact_url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
     steps:
       - uses: actions/checkout@v4
       # Occasionally our builds will run out of free hard disk space.
@@ -112,6 +114,7 @@ jobs:
               > ${{ runner.temp }}/artifacts/${{ inputs.docker_build_arg_package }}-chain-spec-${{ inputs.git_ref_basename }}-${{ github.sha }}.json
       - name: Upload ${{ inputs.docker_build_arg_package }} binary artifact
         uses: actions/upload-artifact@v4
+        id: artifact-upload-step
         with:
           name: ${{ inputs.docker_build_arg_package}}_${{ inputs.git_ref_basename }}
           path: ${{ runner.temp }}/artifacts/${{ inputs.docker_build_arg_package }}*


### PR DESCRIPTION
This builds a confidential virtual machine image containing the entropy-tss binary when a release is made.

Eventually the binary could be built reproducibly from within yocto or guix - see: https://github.com/entropyxyz/meta-entropy-tss/issues/2

But for now, entropy-tss is built in a docker container with our usual release workflow, and the binary bundled into the image.

Pairs with: https://github.com/entropyxyz/yocto-build/pull/6