### PR TITLE
Dockerfile - Always install the native rust toolchain and add other platforms as a target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,12 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --no-modify-path --profile minimal \
       --default-toolchain none \
     && $HOME/.cargo/bin/rustup default "${RUST_STABLE_VERSION}" \
-    && if [ "amd64" = ${TARGETPLATFORM#"linux/"} ]; then \
-        export RUST_PLATFORM=x86_64; \
-    else \
-        export RUST_PLATFORM=aarch64; \
-    fi; $HOME/.cargo/bin/rustup toolchain install "${RUST_STABLE_VERSION}-${RUST_PLATFORM}-unknown-linux-gnu" --profile minimal \
+    && $HOME/.cargo/bin/rustup toolchain install "${RUST_STABLE_VERSION}-x86_64-unknown-linux-gnu" --profile minimal \
     && $HOME/.cargo/bin/rustup component add rust-src rustfmt clippy \
-    && $HOME/.cargo/bin/rustup target add wasm32-unknown-unknown
+    && $HOME/.cargo/bin/rustup target add wasm32-unknown-unknown \
+    && if [ "amd64" = ${TARGETPLATFORM#"linux/"} ]; then \
+      $HOME/.cargo/bin/rustup target add aarch64-unknown-linux-gnu; \
+    fi;
 
 # Now fetch and build our own source code. This is a somewhat involved
 # set of shell commands but the basic idea is that we are running the


### PR DESCRIPTION
This is a possible solution to https://github.com/entropyxyz/entropy-core/issues/1328

Rather than installing the rust toolchain of the target platform, we always install the x86 toolchain (since that is the platform we are building on), and when building for arm64 add that as a target using `cargo target add`.

If i have understood correctly we wont be able to see if this fixes the issue tagging a release on this branch, because the release pipeline pulls the build container image from Dockerhub. Im not sure how to test it without pushing these changes to Dockerhub.