### PR TITLE
In Dockerfile allow installing a non-native rust toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         export RUST_PLATFORM=x86_64; \
     else \
         export RUST_PLATFORM=aarch64; \
-    fi; $HOME/.cargo/bin/rustup toolchain install "${RUST_STABLE_VERSION}-${RUST_PLATFORM}-unknown-linux-gnu" --profile minimal \
+    fi; $HOME/.cargo/bin/rustup toolchain install "${RUST_STABLE_VERSION}-${RUST_PLATFORM}-unknown-linux-gnu" \
+      --profile minimal --force-non-host \
     && $HOME/.cargo/bin/rustup component add rust-src rustfmt clippy \
     && $HOME/.cargo/bin/rustup target add wasm32-unknown-unknown
 


### PR DESCRIPTION
This is an alternative solution to https://github.com/entropyxyz/entropy-core/issues/1328

I personally see this as a dirty fix and see https://github.com/entropyxyz/entropy-core/pull/1329 as a better solution.  But if it turns out that #1329 doesn't work, we can use this.

Again, i don't know how to test this without pushing to Dockerhub.