### PR TITLE
Validate jumpstart mutex handling

### DIFF
--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -128,7 +128,7 @@ impl TestNodeProcessBuilder {
         R: Config,
     {
         let mut cmd = process::Command::new(&self.node_path);
-        cmd.env("RUST_LOG", "error").arg(&self.chain_type).arg("--tmp");
+        cmd.env("RUST_LOG", "info").arg(&self.chain_type).arg("--tmp");
         if self.force_authoring {
             cmd.arg("--force-authoring");
         }

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -128,7 +128,7 @@ impl TestNodeProcessBuilder {
         R: Config,
     {
         let mut cmd = process::Command::new(&self.node_path);
-        cmd.env("RUST_LOG", "info").arg(&self.chain_type).arg("--tmp");
+        cmd.env("RUST_LOG", "error").arg(&self.chain_type).arg("--tmp");
         if self.force_authoring {
             cmd.arg("--force-authoring");
         }

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -459,7 +459,6 @@ pub async fn generate_network_key(
     }
 
     validate_jump_start(&data, &api, &rpc, &app_state.cache).await?;
-    dbg!("passed validate lfg");
     let app_state = app_state.clone();
     setup_dkg(api, &rpc, data, app_state).await?;
 

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -459,6 +459,7 @@ pub async fn generate_network_key(
     }
 
     validate_jump_start(&data, &api, &rpc, &app_state.cache).await?;
+
     let app_state = app_state.clone();
     setup_dkg(api, &rpc, data, app_state).await?;
 

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -547,6 +547,8 @@ pub async fn validate_jump_start(
         .await?
         .ok_or_else(|| UserErr::OptionUnwrapError("Failed to get block number".to_string()))?
         .number;
+    dbg!(latest_block_number.saturating_sub(1));
+    dbg!(chain_data.block_number);
 
     // we subtract 1 as the message info is coming from the previous block
     if latest_block_number.saturating_sub(1) != chain_data.block_number {
@@ -554,12 +556,12 @@ pub async fn validate_jump_start(
     }
 
     // Check that the on-chain selected validators match those from the HTTP request
-    let verifying_data_query = entropy::storage().registry().jumpstart_dkg(chain_data.block_number);
-    let verifying_data = query_chain(api, rpc, verifying_data_query, None).await?.unwrap();
-    let verifying_data: Vec<_> = verifying_data.into_iter().map(|v| v.0).collect();
-    if verifying_data != chain_data.validators_info {
-        return Err(UserErr::InvalidData);
-    }
+    // let verifying_data_query = entropy::storage().registry().jumpstart_dkg(chain_data.block_number);
+    // let verifying_data = query_chain(api, rpc, verifying_data_query, None).await?.unwrap();
+    // let verifying_data: Vec<_> = verifying_data.into_iter().map(|v| v.0).collect();
+    // if verifying_data != chain_data.validators_info {
+    //     return Err(UserErr::InvalidData);
+    // }
     let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
     cache.write_to_block_numbers(BlockNumberFields::NewUser, chain_data.block_number)?;
     dbg!(last_block_number_recorded);

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -459,7 +459,7 @@ pub async fn generate_network_key(
     }
 
     validate_jump_start(&data, &api, &rpc, &app_state.cache).await?;
-
+    dbg!("passed validate lfg");
     let app_state = app_state.clone();
     setup_dkg(api, &rpc, data, app_state).await?;
 
@@ -543,7 +543,8 @@ pub async fn validate_jump_start(
     cache: &Cache,
 ) -> Result<(), UserErr> {
     let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
-
+    dbg!(last_block_number_recorded);
+    dbg!(chain_data.block_number);
     if last_block_number_recorded >= chain_data.block_number {
         return Err(UserErr::RepeatedData);
     }

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -542,13 +542,6 @@ pub async fn validate_jump_start(
     rpc: &LegacyRpcMethods<EntropyConfig>,
     cache: &Cache,
 ) -> Result<(), UserErr> {
-    let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
-    dbg!(last_block_number_recorded);
-    dbg!(chain_data.block_number);
-    if last_block_number_recorded >= chain_data.block_number {
-        return Err(UserErr::RepeatedData);
-    }
-
     let latest_block_number = rpc
         .chain_get_header(None)
         .await?
@@ -567,8 +560,13 @@ pub async fn validate_jump_start(
     if verifying_data != chain_data.validators_info {
         return Err(UserErr::InvalidData);
     }
-
+    let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
     cache.write_to_block_numbers(BlockNumberFields::NewUser, chain_data.block_number)?;
+    dbg!(last_block_number_recorded);
+    dbg!(chain_data.block_number);
+    if last_block_number_recorded >= chain_data.block_number {
+        return Err(UserErr::RepeatedData);
+    }
 
     Ok(())
 }

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -547,8 +547,6 @@ pub async fn validate_jump_start(
         .await?
         .ok_or_else(|| UserErr::OptionUnwrapError("Failed to get block number".to_string()))?
         .number;
-    dbg!(latest_block_number.saturating_sub(1));
-    dbg!(chain_data.block_number);
 
     // we subtract 1 as the message info is coming from the previous block
     if latest_block_number.saturating_sub(1) != chain_data.block_number {
@@ -567,8 +565,7 @@ pub async fn validate_jump_start(
 
     let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
     cache.write_to_block_numbers(BlockNumberFields::NewUser, chain_data.block_number)?;
-    dbg!(last_block_number_recorded);
-    dbg!(chain_data.block_number);
+
     if last_block_number_recorded >= chain_data.block_number {
         return Err(UserErr::RepeatedData);
     }

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -556,12 +556,15 @@ pub async fn validate_jump_start(
     }
 
     // Check that the on-chain selected validators match those from the HTTP request
-    // let verifying_data_query = entropy::storage().registry().jumpstart_dkg(chain_data.block_number);
-    // let verifying_data = query_chain(api, rpc, verifying_data_query, None).await?.unwrap();
-    // let verifying_data: Vec<_> = verifying_data.into_iter().map(|v| v.0).collect();
-    // if verifying_data != chain_data.validators_info {
-    //     return Err(UserErr::InvalidData);
-    // }
+    let verifying_data_query = entropy::storage().registry().jumpstart_dkg(chain_data.block_number);
+    let verifying_data = query_chain(api, rpc, verifying_data_query, None)
+        .await?
+        .ok_or_else(|| UserErr::ChainFetch("Error getting jumpstart data"))?;
+    let verifying_data: Vec<_> = verifying_data.into_iter().map(|v| v.0).collect();
+    if verifying_data != chain_data.validators_info {
+        return Err(UserErr::InvalidData);
+    }
+
     let last_block_number_recorded = cache.read_from_block_numbers(&BlockNumberFields::NewUser)?;
     cache.write_to_block_numbers(BlockNumberFields::NewUser, chain_data.block_number)?;
     dbg!(last_block_number_recorded);

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -1950,11 +1950,7 @@ async fn test_validate_jump_start_fail() {
         tss_account: dave.to_account_id().encode(),
     };
 
-    let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number + 1;
-    let mut ocw_message =
-        OcwMessageDkg { validators_info: vec![validators_info.clone()], block_number };
-
-    let storage_address_dkg_data = entropy::storage().registry().jumpstart_dkg(block_number);
+    let storage_address_dkg_data = entropy::storage().registry().jumpstart_dkg(2);
     let value_dkg_info = vec![validators_info.clone()];
     // Add DKG
     let call = RuntimeCall::System(SystemsCall::set_storage {
@@ -1962,6 +1958,12 @@ async fn test_validate_jump_start_fail() {
     });
 
     call_set_storage(&api, &rpc, call).await;
+    
+    run_to_block(&rpc, 3).await;
+
+    let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number - 1;
+    let mut ocw_message =
+        OcwMessageDkg { validators_info: vec![validators_info.clone()], block_number };
 
     // manipulates cache to get to repeated data error
     app_state.cache.write_to_block_numbers(BlockNumberFields::NewUser, block_number).unwrap();

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -29,8 +29,8 @@ use entropy_protocol::{
     KeyShareWithAuxInfo, SessionId, SigningSessionInfo, ValidatorInfo,
 };
 use entropy_shared::{
-    HashingAlgorithm, OcwMessageDkg, ValidatorInfo as SharedValidatorInfo, DAVE_VERIFYING_KEY,
-    DEFAULT_VERIFYING_KEY_NOT_REGISTERED, DEVICE_KEY_HASH, NETWORK_PARENT_KEY,
+    HashingAlgorithm, OcwMessageDkg, DAVE_VERIFYING_KEY, DEFAULT_VERIFYING_KEY_NOT_REGISTERED,
+    DEVICE_KEY_HASH, NETWORK_PARENT_KEY,
 };
 use entropy_testing_utils::{
     chain_api::{
@@ -73,7 +73,6 @@ use crate::{
     chain_api::{
         entropy, entropy::runtime_types::bounded_collections::bounded_vec::BoundedVec,
         entropy::runtime_types::entropy_runtime::RuntimeCall,
-        entropy::runtime_types::frame_system::pallet::Call as SystemsCall,
         entropy::runtime_types::pallet_balances::pallet::Call as BalancesCall,
         entropy::runtime_types::pallet_registry::pallet::ProgramInstance, get_api, get_rpc,
         EntropyConfig,
@@ -87,8 +86,8 @@ use crate::{
         signing::Hasher,
         substrate::{get_oracle_data, get_signers_from_chain, query_chain, submit_transaction},
         tests::{
-            call_set_storage, do_jump_start, get_port, initialize_test_logger, run_to_block,
-            setup_client, spawn_testing_validators, store_program_and_register, unsafe_get,
+            do_jump_start, get_port, initialize_test_logger, run_to_block, setup_client,
+            spawn_testing_validators, store_program_and_register, unsafe_get,
         },
         user::compute_hash,
         validator::get_signer_and_x25519_secret_from_mnemonic,
@@ -1938,7 +1937,6 @@ async fn test_validate_jump_start_fail_repeated() {
     initialize_test_logger().await;
     clean_tests();
 
-    let dave = AccountKeyring::Dave;
     let alice = AccountKeyring::Alice;
 
     let cxt = &test_node_process_testing_state(ChainSpecType::Integration, false).await[0];
@@ -1952,32 +1950,24 @@ async fn test_validate_jump_start_fail_repeated() {
     let app_state =
         AppState::new(configuration.clone(), kv_store.clone(), sr25519_pair, x25519_secret);
 
-    let validators_info = SharedValidatorInfo {
-        x25519_public_key: X25519_PUBLIC_KEYS[0],
-        ip_address: vec![80, 80],
-        tss_account: dave.to_account_id().encode(),
-    };
-
     let jump_start_request = entropy::tx().registry().jump_start_network();
-    let result =
+    let block_number = 2;
+
+    run_to_block(&rpc, block_number - 1).await;
+    let _result =
         submit_transaction_with_pair(&api, &rpc, &alice.pair(), &jump_start_request, None)
             .await
             .unwrap();
-
-    let block_number = 2; //rpc.chain_get_header(None).await.unwrap().unwrap().number - 1;
-    let mut ocw_message =
-        OcwMessageDkg { validators_info: vec![validators_info.clone()], block_number };
     // manipulates cache to get to repeated data error
     app_state.cache.write_to_block_numbers(BlockNumberFields::NewUser, block_number).unwrap();
-    run_to_block(&rpc, 3).await;
+    run_to_block(&rpc, block_number + 1).await;
 
-    let jump_start_progress_query = entropy::storage().registry().jumpstart_dkg(2);
+    let jump_start_progress_query = entropy::storage().registry().jumpstart_dkg(block_number);
     let jump_start_progress =
         query_chain(&api, &rpc, jump_start_progress_query, None).await.unwrap().unwrap();
     let validators_info: Vec<_> = jump_start_progress.into_iter().map(|v| v.0).collect();
 
-    let mut ocw_message =
-        OcwMessageDkg { validators_info, block_number };
+    let mut ocw_message = OcwMessageDkg { validators_info, block_number };
     let err_stale_data = validate_jump_start(&ocw_message, &api, &rpc, &app_state.cache)
         .await
         .map_err(|e| e.to_string());


### PR DESCRIPTION
Very similar issue to #1331 logs support that
```
2025-03-07 16:44:26 💤 Idle (3 peers), best: #8 (0xa2ba…e4f2), finalized #6 (0x5b43…2649), ⬇ 3.2kiB/s ⬆ 3.3kiB/s    
2025-03-07 16:44:28 💤 Idle (3 peers), best: #8 (0xa2ba…e4f2), finalized #6 (0x5b43…2649), ⬇ 3.1kiB/s ⬆ 2.9kiB/s    
2025-03-07 16:44:29 💤 Idle (3 peers), best: #8 (0xa2ba…e4f2), finalized #6 (0x5b43…2649), ⬇ 3.3kiB/s ⬆ 3.5kiB/s    
2025-03-07 16:44:30 🙌 Starting consensus session on top of parent 0xa2ba17533aea7f7348f5f006324c06e49a5acf3bbc89aec8c452743eb626e4f2    
2025-03-07 16:44:30 🎁 Prepared block for proposing at 9 (1 ms) [hash: 0xcda6715ca3ac23f70b9bb6f413c3e50a69338a71037fcf51fd192be9c36b2808; parent_hash: 0xa2ba…e4f2; extrinsics (2): [0x5cf4…bf52, 0x3f2f…1b5d]    
2025-03-07 16:44:30 🔖 Pre-sealed block for proposal at 9. Hash now 0x997b39632928d7c68242600a6ae7a9611b88ff91168a31e7f570bbc0b77bde18, previously 0xcda6715ca3ac23f70b9bb6f413c3e50a69338a71037fcf51fd192be9c36b2808.    
2025-03-07 16:44:30 ✨ Imported #9 (0x997b…de18)    
2025-03-07 16:44:30 ✨ Imported #9 (0x997b…de18)    
2025-03-07 16:44:30 ✨ Imported #9 (0x997b…de18)    
2025-03-07 16:44:30 ✨ Imported #9 (0x997b…de18)    
2025-03-07 16:44:30 💤 Idle (3 peers), best: #9 (0x997b…de18), finalized #6 (0x5b43…2649), ⬇ 2.9kiB/s ⬆ 3.1kiB/s    
test user::tests::test_jumpstart_network has been running for over 60 seconds
2025-03-07 16:44:31 💤 Idle (3 peers), best: #9 (0x997b…de18), finalized #7 (0x3213…8b2f), ⬇ 3.0kiB/s ⬆ 2.8kiB/s    
2025-03-07 16:44:33 💤 Idle (3 peers), best: #9 (0x997b…de18), finalized #7 (0x3213…8b2f), ⬇ 3.4kiB/s ⬆ 3.2kiB/s    
2025-03-07 16:44:34 💤 Idle (3 peers), best: #9 (0x997b…de18), finalized #7 (0x3213…8b2f), ⬇ 2.8kiB/s ⬆ 2.9kiB/s    
2025-03-07 16:44:35 💤 Idle (3 peers), best: #9 (0x997b…de18), finalized #7 (0x3213…8b2f), ⬇ 3.2kiB/s ⬆ 3.1kiB/s    
  2025-03-07T21:44:36.005162Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 5221d3a9-8e9d-4d0c-9c18-65e4a025d724, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.005639Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 09423cb4-e151-49fa-a9ef-4e7ee6f4b9a4, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.006318Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 80694ddd-440d-4cb9-96a3-b6006bd506b7, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.006719Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 4494163f-b936-4099-afb2-bb47b52f5e76, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.007110Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 20d23871-daef-4daf-a0c4-568e1295deea, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.007132Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: adc6768f-c9f4-45f8-8daf-bff7e3adb699, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.007525Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: c22e3f6c-f426-433d-b6af-f70908c80981, uri: /generate_network_key, method: POST

[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
  2025-03-07T21:44:36.023061Z  WARN entropy_tss::user::api: The account AccountId32([148, 97, 64, 211, 213, 221, 185, 128, 199, 79, 250, 27, 182, 67, 83, 181, 82, 61, 45, 119, 205, 243, 220, 97, 127, 214, 61, 233, 211, 182, 99, 56]) is not in the registration group for block_number 9
    at crates/threshold-signature-server/src/user/api.rs:452
    in entropy_tss::user::api::generate_network_key with block_number: 9
    in entropy_tss::http-request with uuid: 09423cb4-e151-49fa-a9ef-4e7ee6f4b9a4, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.023314Z  INFO tower_http::trace::on_response: finished processing request, latency: 17 ms, status: 421
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 09423cb4-e151-49fa-a9ef-4e7ee6f4b9a4, uri: /generate_network_key, method: POST

[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
[crates/threshold-signature-server/src/user/api.rs:546:5] last_block_number_recorded = 0
[crates/threshold-signature-server/src/user/api.rs:547:5] chain_data.block_number = 9
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
2025-03-07 16:44:36 ✨ Imported #10 (0xb129…2417)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 ♻️  Reorg on #10,0xb129…2417 to #10,0xc08f…fb4d, common ancestor #9,0x997b…de18    
2025-03-07 16:44:36 ✨ Imported #10 (0xc08f…fb4d)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
[crates/threshold-signature-server/src/user/api.rs:462:5] "passed validate lfg" = "passed validate lfg"
  2025-03-07T21:44:36.024685Z ERROR entropy_tss::user::errors: "Oneshot timeout error: channel closed"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: adc6768f-c9f4-45f8-8daf-bff7e3adb699, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.024696Z  INFO tower_http::trace::on_response: finished processing request, latency: 17 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: adc6768f-c9f4-45f8-8daf-bff7e3adb699, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.024701Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 17 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: adc6768f-c9f4-45f8-8daf-bff7e3adb699, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.024758Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 097ddb71-6c5e-4b2e-9751-009c30d6aa13, uri: /ws, method: GET

  2025-03-07T21:44:36.024812Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 097ddb71-6c5e-4b2e-9751-009c30d6aa13, uri: /ws, method: GET

  2025-03-07T21:44:36.025167Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: a2e547b7-81f3-40a2-a45e-cff1946e4139, uri: /ws, method: GET

  2025-03-07T21:44:36.025186Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: a2e547b7-81f3-40a2-a45e-cff1946e4139, uri: /ws, method: GET

  2025-03-07T21:44:36.025203Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 61784c7c-b492-4513-b0c4-f59d3904aba3, uri: /ws, method: GET

  2025-03-07T21:44:36.025212Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 61784c7c-b492-4513-b0c4-f59d3904aba3, uri: /ws, method: GET

  2025-03-07T21:44:36.025228Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 40a35414-dc58-430b-9448-509d29d0d9a1, uri: /ws, method: GET

  2025-03-07T21:44:36.025269Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 40a35414-dc58-430b-9448-509d29d0d9a1, uri: /ws, method: GET

  2025-03-07T21:44:36.025295Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: ae7932e4-b7d5-4a60-8f82-81f5c834dffa, uri: /ws, method: GET

  2025-03-07T21:44:36.025304Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: ae7932e4-b7d5-4a60-8f82-81f5c834dffa, uri: /ws, method: GET

  2025-03-07T21:44:36.025349Z  INFO tower_http::trace::on_request: started processing request
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_request.rs:80
    in entropy_tss::http-request with uuid: 016ce194-d4dd-49a3-84b4-703d176a9088, uri: /ws, method: GET

  2025-03-07T21:44:36.025358Z  INFO tower_http::trace::on_response: finished processing request, latency: 0 ms, status: 101
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 016ce194-d4dd-49a3-84b4-703d176a9088, uri: /ws, method: GET

  2025-03-07T21:44:36.026707Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 2cbc68e8bf0fbc1c28c282d1263fc9d29267dc12a1044fb730e8b65abc37524c (5D5Mw6Wb...), signature: 707c3b31d791183352908de7845be23370a85e9d468014891ea9841772f989603b47b51996703614353a655ef5c27f884b969041e504fc95b48a6ac7baef1881, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.027414Z ERROR entropy_tss::user::errors: "Oneshot timeout error: channel closed"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: 20d23871-daef-4daf-a0c4-568e1295deea, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.027418Z  INFO tower_http::trace::on_response: finished processing request, latency: 20 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 20d23871-daef-4daf-a0c4-568e1295deea, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.027422Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 20 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: 20d23871-daef-4daf-a0c4-568e1295deea, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.027478Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 2cbc68e8bf0fbc1c28c282d1263fc9d29267dc12a1044fb730e8b65abc37524c (5D5Mw6Wb...), signature: cc11f7f3a09427f842e112fde169893cbb25f5ce3ced9ac85f7a3418dae835169e3568c36bcadb4dd03f66cb3f9a30db5365651605c5d105ac052136aa16ef80, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.027541Z  WARN entropy_tss::signing_client::api: Websocket connection closed unexpectedly BadSubscribeMessage
    at crates/threshold-signature-server/src/signing_client/api.rs:139

  2025-03-07T21:44:36.027593Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 306bdb49cbbe7104e3621abab3c9d31698b159f48dafe567abb7ea5d872ed329 (5DACCJgQ...), signature: 54381d80b4a4f0403a1454eb18618ef7d4754684f0509f584262b98c411ffc1b4f8a28a357493a7a049152efe9955697b83935807bf2061a4f04f013b9fe2d82, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.027687Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 306bdb49cbbe7104e3621abab3c9d31698b159f48dafe567abb7ea5d872ed329 (5DACCJgQ...), signature: b006b3b6ac9a384fb546488e954196b7aa4aae8e4cd5a1fb338428c2252b35191f2e86d0f279888d171bf38e702240f85f059c6a918c630c5661354f86448c89, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.027735Z  WARN entropy_tss::signing_client::protocol_transport: Cannot find associated listener - waiting
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:208

  2025-03-07T21:44:36.027978Z ERROR entropy_tss::user::errors: "Oneshot timeout error: channel closed"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: 80694ddd-440d-4cb9-96a3-b6006bd506b7, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.027984Z  INFO tower_http::trace::on_response: finished processing request, latency: 21 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 80694ddd-440d-4cb9-96a3-b6006bd506b7, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.027988Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 21 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: 80694ddd-440d-4cb9-96a3-b6006bd506b7, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.028104Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 306bdb49cbbe7104e3621abab3c9d31698b159f48dafe567abb7ea5d872ed329 (5DACCJgQ...), signature: 98b236b5299bd1935fbfb55268e97c54a49858c4b120ae4d6d89302aad95c8134f397bbf4968b10feb6be65b9e730ec7567d2e7aa2a0c389f748fb56afcf408d, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.028171Z  WARN entropy_tss::signing_client::protocol_transport: Cannot find associated listener - waiting
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:208

  2025-03-07T21:44:36.028230Z  INFO entropy_tss::signing_client::protocol_transport: Got ws connection, with message: SubscribeMessage { session_id: Dkg { block_number: 9 }, public_key: 306bdb49cbbe7104e3621abab3c9d31698b159f48dafe567abb7ea5d872ed329 (5DACCJgQ...), signature: 40092da40647b253facc9708912a1fbece7cd6acbc19439b05478740c357d04a4b673788f05b292199df23b12ef3d3096c917ed4535ad0bb0a0a521d510c858f, version: 1 }
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:195

  2025-03-07T21:44:36.028283Z  WARN entropy_tss::signing_client::protocol_transport: Cannot find associated listener - waiting
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:208

  2025-03-07T21:44:36.028581Z ERROR entropy_tss::user::errors: "Signing/DKG protocol error: Subscribe message rejected: Decryption(\"Public key does not match any of those expected for this protocol session\") by TSS Account `5CJZDDk6kLPHYKk9CQyoJBsjquU9ASXG79FJDMKJbhy1aLVf`"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: 4494163f-b936-4099-afb2-bb47b52f5e76, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.028591Z  INFO tower_http::trace::on_response: finished processing request, latency: 21 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 4494163f-b936-4099-afb2-bb47b52f5e76, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.028596Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 21 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: 4494163f-b936-4099-afb2-bb47b52f5e76, uri: /generate_network_key, method: POST

  2025-03-07T21:44:36.028712Z  WARN entropy_tss::signing_client::protocol_transport: EncryptedConnection("Websocket error: Connection error: WebSocket protocol error: Connection reset without closing handshake")
    at crates/threshold-signature-server/src/signing_client/protocol_transport.rs:131

2025-03-07 16:44:36 🙌 Starting consensus session on top of parent 0x997b39632928d7c68242600a6ae7a9611b88ff91168a31e7f570bbc0b77bde18    
2025-03-07 16:44:36 🎁 Prepared block for proposing at 10 (0 ms) [hash: 0x5886d57a13dee8aafe8c2d6eb0997c1c4967c9cdbb614941647472baf49ae02f; parent_hash: 0x997b…de18; extrinsics (1): [0x3c34…76ee]    
2025-03-07 16:44:36 🔖 Pre-sealed block for proposal at 10. Hash now 0xc08fbc83172ca602571efe23161e0af0110adad4b40f672b6bb70254c6f2fb4d, previously 0x5886d57a13dee8aafe8c2d6eb0997c1c4967c9cdbb614941647472baf49ae02f.    
2025-03-07 16:44:36 ✨ Imported #10 (0xc08f…fb4d)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 ✨ Imported #10 (0xb129…2417)    
2025-03-07 16:44:36 Unexpected status code: 421 []    
2025-03-07 16:44:36 ✨ Imported #10 (0xb129…2417)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 ♻️  Reorg on #10,0xb129…2417 to #10,0xc08f…fb4d, common ancestor #9,0x997b…de18    
2025-03-07 16:44:36 ✨ Imported #10 (0xc08f…fb4d)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 Unexpected status code: 500 [79, 110, 101, 115, 104, 111, 116, 32, 116, 105, 109, 101, 111, 117, 116, 32, 101, 114, 114, 111, 114, 58, 32, 99, 104, 97, 110, 110, 101, 108, 32, 99, 108, 111, 115, 101, 100]    
2025-03-07 16:44:36 Unexpected status code: 500 [79, 110, 101, 115, 104, 111, 116, 32, 116, 105, 109, 101, 111, 117, 116, 32, 101, 114, 114, 111, 114, 58, 32, 99, 104, 97, 110, 110, 101, 108, 32, 99, 108, 111, 115, 101, 100]    
2025-03-07 16:44:36 🙌 Starting consensus session on top of parent 0x997b39632928d7c68242600a6ae7a9611b88ff91168a31e7f570bbc0b77bde18    
2025-03-07 16:44:36 🎁 Prepared block for proposing at 10 (0 ms) [hash: 0xd3417f7ac9df99307fa8671cb81be0037a6ab16258f9e94d4e0604f18ec759ff; parent_hash: 0x997b…de18; extrinsics (1): [0xa252…1bb0]    
2025-03-07 16:44:36 🔖 Pre-sealed block for proposal at 10. Hash now 0xb1297f2282de7e2ebff1e62754fdbc88bfc9abec3bc81e4613a5db19d92e2417, previously 0xd3417f7ac9df99307fa8671cb81be0037a6ab16258f9e94d4e0604f18ec759ff.    
2025-03-07 16:44:36 ✨ Imported #10 (0xb129…2417)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 ♻️  Reorg on #10,0xb129…2417 to #10,0xc08f…fb4d, common ancestor #9,0x997b…de18    
2025-03-07 16:44:36 ✨ Imported #10 (0xc08f…fb4d)    
2025-03-07 16:44:36 propagation::post::validators_info: [ValidatorInfo { x25519_public_key: [8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49], tss_account: [48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41] }, ValidatorInfo { x25519_public_key: [196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50], tss_account: [44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76] }, ValidatorInfo { x25519_public_key: [165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71], ip_address: [49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52], tss_account: [10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2] }]    
2025-03-07 16:44:36 propagation::post::req_body: [[9, 0, 0, 0, 12, 8, 22, 19, 230, 107, 217, 249, 190, 14, 142, 155, 252, 156, 229, 120, 11, 180, 35, 83, 245, 222, 11, 153, 201, 162, 29, 153, 13, 123, 126, 128, 32, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 49, 128, 48, 107, 219, 73, 203, 190, 113, 4, 227, 98, 26, 186, 179, 201, 211, 22, 152, 177, 89, 244, 141, 175, 229, 103, 171, 183, 234, 93, 135, 46, 211, 41, 196, 53, 98, 10, 160, 169, 139, 48, 194, 230, 69, 64, 165, 48, 133, 110, 38, 64, 184, 113, 255, 201, 253, 212, 217, 21, 252, 57, 253, 78, 0, 56, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 50, 128, 44, 188, 104, 232, 191, 15, 188, 28, 40, 194, 130, 209, 38, 63, 201, 210, 146, 103, 220, 18, 161, 4, 79, 183, 48, 232, 182, 90, 188, 55, 82, 76, 165, 202, 97, 104, 222, 190, 168, 183, 231, 63, 209, 233, 19, 185, 187, 200, 10, 29, 102, 240, 39, 50, 140, 15, 124, 112, 94, 121, 44, 182, 40, 71, 56, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 51, 48, 48, 52, 128, 10, 144, 84, 239, 107, 107, 138, 208, 221, 44, 137, 137, 91, 37, 21, 88, 63, 47, 191, 30, 220, 237, 104, 231, 50, 138, 228, 86, 216, 107, 148, 2]]    
2025-03-07 16:44:36 Unexpected status code: 500 [79, 110, 101, 115, 104, 111, 116, 32, 116, 105, 109, 101, 111, 117, 116, 32, 101, 114, 114, 111, 114, 58, 32, 99, 104, 97, 110, 110, 101, 108, 32, 99, 108, 111, 115, 101, 100]    
2025-03-07 16:44:36 Unexpected status code: 500 [83, 105, 103, 110, 105, 110, 103, 47, 68, 75, 71, 32, 112, 114, 111, 116, 111, 99, 111, 108, 32, 101, 114, 114, 111, 114, 58, 32, 83, 117, 98, 115, 99, 114, 105, 98, 101, 32, 109, 101, 115, 115, 97, 103, 101, 32, 114, 101, 106, 101, 99, 116, 101, 100, 58, 32, 68, 101, 99, 114, 121, 112, 116, 105, 111, 110, 40, 34, 80, 117, 98, 108, 105, 99, 32, 107, 101, 121, 32, 100, 111, 101, 115, 32, 110, 111, 116, 32, 109, 97, 116, 99, 104, 32, 97, 110, 121, 32, 111, 102, 32, 116, 104, 111, 115, 101, 32, 101, 120, 112, 101, 99, 116, 101, 100, 32, 102, 111, 114, 32, 116, 104, 105, 115, 32, 112, 114, 111, 116, 111, 99, 111, 108, 32, 115, 101, 115, 115, 105, 111, 110, 34, 41, 32, 98, 121, 32, 84, 83, 83, 32, 65, 99, 99, 111, 117, 110, 116, 32, 96, 53, 67, 74, 90, 68, 68, 107, 54, 107, 76, 80, 72, 89, 75, 107, 57, 67, 81, 121, 111, 74, 66, 115, 106, 113, 117, 85, 57, 65, 83, 88, 71, 55, 57, 70, 74, 68, 77, 75, 74, 98, 104, 121, 49, 97, 76, 86, 102, 96]    
2025-03-07 16:44:36 💤 Idle (3 peers), best: #10 (0xc08f…fb4d), finalized #7 (0x3213…8b2f), ⬇ 3.5kiB/s ⬆ 3.3kiB/s    
2025-03-07 16:44:38 💤 Idle (3 peers), best: #10 (0xc08f…fb4d), finalized #8 (0xa2ba…e4f2), ⬇ 3.4kiB/s ⬆ 3.2kiB/s    
2025-03-07 16:44:38 💤 Idle (3 peers), best: #10 (0xc08f…fb4d), finalized #8 (0xa2ba…e4f2), ⬇ 4.4kiB/s ⬆ 4.1kiB/s    
2025-03-07 16:44:40 💤 Idle (3 peers), best: #10 (0xc08f…fb4d), finalized #8 (0xa2ba…e4f2), ⬇ 3.3kiB/s ⬆ 3.7kiB/s    
2025-03-07 16:44:41 💤 Idle (3 peers), best: #10 (0xc08f…fb4d), finalized #8 (0xa2ba…e4f2), ⬇ 3.3kiB/s ⬆ 3.3kiB/s    
2025-03-07 16:44:42 🙌 Starting consensus session on top of parent 0xc08fbc83172ca602571efe23161e0af0110adad4b40f672b6bb70254c6f2fb4d    
2025-03-07 16:44:42 🎁 Prepared block for proposing at 11 (1 ms) [hash: 0x249aca8241c210bee37209712154c5dcb4fc27424f8473c524d65c7437429eb7; parent_hash: 0xc08f…fb4d; extrinsics (1): [0xac57…9836]    
2025-03-07 16:44:42 🔖 Pre-sealed block for proposal at 11. Hash now 0x073b1f73659600ffcc3a763f262b41e4d804455c81a3ba7aff83555e3dd6524e, previously 0x249aca8241c210bee37209712154c5dcb4fc27424f8473c524d65c7437429eb7.    
2025-03-07 16:44:42 ✨ Imported #11 (0x073b…524e)    
2025-03-07 16:44:42 ✨ Imported #11 (0x073b…524e)    
2025-03-07 16:44:42 ✨ Imported #11 (0x073b…524e)    
2025-03-07 16:44:42 ✨ Imported #11 (0x073b…524e)    
2025-03-07 16:44:43 💤 Idle (3 peers), best: #11 (0x073b…524e), finalized #9 (0x997b…de18), ⬇ 3.3kiB/s ⬆ 3.7kiB/s    
2025-03-07 16:44:43 💤 Idle (3 peers), best: #11 (0x073b…524e), finalized #9 (0x997b…de18), ⬇ 3.2kiB/s ⬆ 3.1kiB/s    
2025-03-07 16:44:45 💤 Idle (3 peers), best: #11 (0x073b…524e), finalized #9 (0x997b…de18), ⬇ 4.1kiB/s ⬆ 3.6kiB/s    
  2025-03-07T21:44:46.024691Z  WARN entropy_tss::signing_client::api: Websocket connection closed unexpectedly BadSubscribeMessage
    at crates/threshold-signature-server/src/signing_client/api.rs:139

  2025-03-07T21:44:46.024936Z  WARN entropy_tss::signing_client::api: Websocket connection closed unexpectedly BadSubscribeMessage
    at crates/threshold-signature-server/src/signing_client/api.rs:139

  2025-03-07T21:44:46.025025Z  WARN entropy_tss::signing_client::api: Websocket connection closed unexpectedly BadSubscribeMessage
    at crates/threshold-signature-server/src/signing_client/api.rs:139

  2025-03-07T21:44:46.027021Z ERROR entropy_tss::user::errors: "Signing/DKG protocol error: Subscribe message rejected: NoListener(\"no listener\") by TSS Account `5CJZDDk6kLPHYKk9CQyoJBsjquU9ASXG79FJDMKJbhy1aLVf`"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: c22e3f6c-f426-433d-b6af-f70908c80981, uri: /generate_network_key, method: POST

  2025-03-07T21:44:46.027110Z  INFO tower_http::trace::on_response: finished processing request, latency: 10025 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: c22e3f6c-f426-433d-b6af-f70908c80981, uri: /generate_network_key, method: POST

  2025-03-07T21:44:46.027142Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 10025 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: c22e3f6c-f426-433d-b6af-f70908c80981, uri: /generate_network_key, method: POST

  2025-03-07T21:44:46.028935Z ERROR entropy_tss::user::errors: "Signing/DKG protocol error: Subscribe message rejected: NoListener(\"no listener\") by TSS Account `5D5Mw6WbWwYf1SH9NUeVVHmf9SJSHJ9KictU3DsEQ1ti6eUb`"
    at crates/threshold-signature-server/src/user/errors.rs:200
    in entropy_tss::http-request with uuid: 5221d3a9-8e9d-4d0c-9c18-65e4a025d724, uri: /generate_network_key, method: POST

  2025-03-07T21:44:46.028960Z  INFO tower_http::trace::on_response: finished processing request, latency: 10029 ms, status: 500
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_response.rs:114
    in entropy_tss::http-request with uuid: 5221d3a9-8e9d-4d0c-9c18-65e4a025d724, uri: /generate_network_key, method: POST

  2025-03-07T21:44:46.028969Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 10029 ms
    at /Users/jesse/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93
    in entropy_tss::http-request with uuid: 5221d3a9-8e9d-4d0c-9c18-65e4a025d724, uri: /generate_network_key, method: POST

2025-03-07 16:44:46 Unexpected status code: 500 [83, 105, 103, 110, 105, 110, 103, 47, 68, 75, 71, 32, 112, 114, 111, 116, 111, 99, 111, 108, 32, 101, 114, 114, 111, 114, 58, 32, 83, 117, 98, 115, 99, 114, 105, 98, 101, 32, 109, 101, 115, 115, 97, 103, 101, 32, 114, 101, 106, 101, 99, 116, 101, 100, 58, 32, 78, 111, 76, 105, 115, 116, 101, 110, 101, 114, 40, 34, 110, 111, 32, 108, 105, 115, 116, 101, 110, 101, 114, 34, 41, 32, 98, 121, 32, 84, 83, 83, 32, 65, 99, 99, 111, 117, 110, 116, 32, 96, 53, 67, 74, 90, 68, 68, 107, 54, 107, 76, 80, 72, 89, 75, 107, 57, 67, 81, 121, 111, 74, 66, 115, 106, 113, 117, 85, 57, 65, 83, 88, 71, 55, 57, 70, 74, 68, 77, 75, 74, 98, 104, 121, 49, 97, 76, 86, 102, 96]    
2025-03-07 16:44:46 Unexpected status code: 500 [83, 105, 103, 110, 105, 110, 103, 47, 68, 75, 71, 32, 112, 114, 111, 116, 111, 99, 111, 108, 32, 101, 114, 114, 111, 114, 58, 32, 83, 117, 98, 115, 99, 114, 105, 98, 101, 32, 109, 101, 115, 115, 97, 103, 101, 32, 114, 101, 106, 101, 99, 116, 101, 100, 58, 32, 78, 111, 76, 105, 115, 116, 101, 110, 101, 114, 40, 34, 110, 111, 32, 108, 105, 115, 116, 101, 110, 101, 114, 34, 41, 32, 98, 121, 32, 84, 83, 83, 32, 65, 99, 99, 111, 117, 110, 116, 32, 96, 53, 68, 53, 77, 119, 54, 87, 98, 87, 119, 89, 102, 49, 83, 72, 57, 78, 85, 101, 86, 86, 72, 109, 102, 57, 83, 74, 83, 72, 74, 57, 75, 105, 99, 116, 85, 51, 68, 115, 69, 81, 49, 116, 105, 54, 101, 85, 98, 96]    
2025-03-07 16:44:46 💤 Idle (3 peers), best: #11 (0x073b…524e), finalized #9 (0x997b…de18), ⬇ 3.6kiB/s ⬆ 3.9kiB/s    
```