### PR TITLE
Fix enum variant name for production build details

### DIFF
--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -53,10 +53,12 @@ impl BuildDetails {
 
     #[cfg(feature = "production")]
     fn new() -> Self {
-        BuildDetails::Production(match crate::attestation::api::get_measurement_value() {
-            Ok(value) => hex::encode(value),
-            Err(error) => format!("Failed to get measurement value {:?}", error),
-        })
+        BuildDetails::ProductionWithMeasurementValue(
+            match crate::attestation::api::get_measurement_value() {
+                Ok(value) => hex::encode(value),
+                Err(error) => format!("Failed to get measurement value {:?}", error),
+            },
+        )
     }
 }
 


### PR DESCRIPTION
This is a small fix needed to compile `entropy-tss` in with the `production` feature enabled.

Ideally problems like this should be picked up in CI - we should probably be running `cargo check --features=production`.

 