### PR TITLE
Release in production mode unless 'non-TDX' is specified in release tag

### DIFF
--- a/.github/workflows/container-build-and-push.yaml
+++ b/.github/workflows/container-build-and-push.yaml
@@ -70,13 +70,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_CI_TOKEN }}
-      - name: Determine if this is a production release
+      - name: Determine if this is release is non-TDX or production
         id: check-production
         run: |
-          if [[ ${{ github.ref_name }} == *production* ]]; then
-            echo "PRODUCTION=true" >> $GITHUB_ENV
-          else
+          if [[ ${{ github.ref_name }} == *non-TDX* ]]; then
             echo "PRODUCTION=false" >> $GITHUB_ENV
+          else
+            echo "PRODUCTION=true" >> $GITHUB_ENV
           fi
       - name: Build and push ${{ inputs.docker_build_arg_package }} container image
         id: docker-build

--- a/.github/workflows/container-build-and-push.yaml
+++ b/.github/workflows/container-build-and-push.yaml
@@ -70,6 +70,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_CI_TOKEN }}
+      - name: Determine if this is a production release
+        id: check-production
+        run: |
+          if [[ "$TAG_NAME" == *production* ]]; then
+            echo "PRODUCTION=true" >> $GITHUB_ENV
+          else
+            echo "PRODUCTION=false" >> $GITHUB_ENV
+          fi
       - name: Build and push ${{ inputs.docker_build_arg_package }} container image
         id: docker-build
         uses: docker/build-push-action@v6
@@ -77,6 +85,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PACKAGE=${{ inputs.docker_build_arg_package }}
+            PRODUCTION=${{ env.PRODUCTION }}
           secrets: |
             credentials=${{ secrets.CI_MACHINE_USER_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container-build-and-push.yaml
+++ b/.github/workflows/container-build-and-push.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Determine if this is a production release
         id: check-production
         run: |
-          if [[ "$TAG_NAME" == *production* ]]; then
+          if [[ ${{ github.ref_name }} == *production* ]]; then
             echo "PRODUCTION=true" >> $GITHUB_ENV
           else
             echo "PRODUCTION=false" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ runtime
   certificate chain.
 - In [#1305](https://github.com/entropyxyz/entropy-core/pull/1305) the output of the entropy-tss
   `/version` HTTP route was changed to include additional build details.
+- In [#1349](https://github.com/entropyxyz/entropy-core/pull/1349) the release pipeline was changed
+  to make mock TDX quotes opt-in. That is, if you want the released build to work on non-TDX
+  hardware for testing, you must specify `non-TDX` in the release tag.
 
 ### Added
 - In [#1128](https://github.com/entropyxyz/entropy-core/pull/1128) an `/info` route was added to `entropy-tss`

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -64,6 +64,9 @@ tagged as the final release.
 - [ ] Ensure **all** CI checks on `master` pass
 - [ ] Create a Git tag From the squashed release PR commit on `master`
     - Make sure to follow [release tag naming conventions](https://github.com/entropyxyz/meta/wiki/Release-management)
+    - If this release is intended to be used in test network which does not involve TDX hardware,
+      the release tag must specify `non-TDX`, eg 'test/release/vX.Y.Z-rc.1+non-TDX'. This will
+      ensure that the TSS node generates mock TDX quotes and the chain node will consider them valid.
     - `git tag release/vX.Y.Z-rc.1` - meaning release candidate number 1. If all goes well this can
       later by tagged as `release/vX.Y.Z`
     - Nice to have: sign the tag with an offline GPG key (`git tag -s ...`)


### PR DESCRIPTION
This makes it possible to build entropy with the `production` feature flag in the release pipeline if the release tag contains the string 'production'.

An alternative would be to make production mode default and 'mock' need to be specified.  But i think this is fine for now.