### PR TITLE
Include Provisioning Certification Key (PCK) in the entropy-tss `/info` HTTP route output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ runtime
 - In [#1349](https://github.com/entropyxyz/entropy-core/pull/1349) the release pipeline was changed
   to make mock TDX quotes opt-in. That is, if you want the released build to work on non-TDX
   hardware for testing, you must specify `non-TDX` in the release tag.
+- In [#1357](https://github.com/entropyxyz/entropy-core/pull/1357) the output of the entropy-tss
+  `/info` HTTP route was changed to include the provisioning certification key.
 
 ### Added
 - In [#1128](https://github.com/entropyxyz/entropy-core/pull/1128) an `/info` route was added to `entropy-tss`
@@ -73,6 +75,7 @@ runtime
 - Allow different versions for programs ([#1250](https://github.com/entropyxyz/entropy-core/pull/1250))
 - Attestation quote verification should check both run-time and build-time measurement values ([#1303](https://github.com/entropyxyz/entropy-core/pull/1303))
 - `/version` HTTP route gives measurement value on production builds ([#1305](https://github.com/entropyxyz/entropy-core/pull/1305))
+- Include Provisioning Certification Key (PCK) in the entropy-tss `/info` HTTP route output ([#1357](https://github.com/entropyxyz/entropy-core/pull/1357))
 
 ### Fixed
 

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -121,7 +121,7 @@ pub fn get_pck(
 ) -> Result<BoundedVecEncodedVerifyingKey, AttestationErr> {
     let quote_raw = configfs_tsm::create_quote([0; 64])
         .map_err(|e| AttestationErr::QuoteGeneration(format!("{:?}", e)))?;
-    let quote = Quote::from_bytes(&quote_raw).unwrap();
+    let quote = Quote::from_bytes(&quote_raw)?;
     let pck = quote.verify().map_err(|e| {
         AttestationErr::QuoteGeneration(format!("Could not get PCK from quote {:?}", e))
     })?;

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -30,7 +30,7 @@ use axum::{
 use entropy_client::user::request_attestation;
 use entropy_shared::{
     attestation::{compute_quote_measurement, QuoteContext, QuoteInputData, VerifyQuoteError},
-    OcwMessageAttestationRequest,
+    BoundedVecEncodedVerifyingKey, OcwMessageAttestationRequest,
 };
 use parity_scale_codec::Decode;
 use serde::Deserialize;
@@ -186,6 +186,44 @@ pub fn get_measurement_value() -> Result<[u8; 32], AttestationErr> {
         .map_err(|e| AttestationErr::QuoteGeneration(format!("{:?}", e)))?;
     let quote = Quote::from_bytes(&quote_raw)?;
     Ok(compute_quote_measurement(&quote))
+}
+
+/// Get our Provisioning Certification Key (PCK)
+/// This generates a quote and gets the public key from it
+#[cfg(feature = "production")]
+pub fn get_pck(
+    _tss_account: SubxtAccountId32,
+) -> Result<BoundedVecEncodedVerifyingKey, AttestationErr> {
+    let quote_raw = configfs_tsm::create_quote([0; 64])
+        .map_err(|e| AttestationErr::QuoteGeneration(format!("{:?}", e)))?;
+    let quote = Quote::from_bytes(&quote_raw).unwrap();
+    let pck = quote.verify().map_err(|e| {
+        AttestationErr::QuoteGeneration(format!("Could not get PCK from quote {:?}", e))
+    })?;
+
+    let pck =
+        BoundedVecEncodedVerifyingKey::try_from(tdx_quote::encode_verifying_key(&pck)?.to_vec())
+            .map_err(|_| AttestationErr::BadVerifyingKeyLength)?;
+    Ok(pck)
+}
+
+/// Get our Provisioning Certification Key (PCK)
+/// In mock mode, this is derived from the TSS account ID
+#[cfg(not(feature = "production"))]
+pub fn get_pck(
+    tss_account: SubxtAccountId32,
+) -> Result<BoundedVecEncodedVerifyingKey, AttestationErr> {
+    use rand::{rngs::StdRng, SeedableRng};
+
+    // This is generated deterministically from TSS account id
+    let mut pck_seeder = StdRng::from_seed(tss_account.0);
+    let pck = tdx_quote::SigningKey::random(&mut pck_seeder);
+
+    let pck = BoundedVecEncodedVerifyingKey::try_from(
+        tdx_quote::encode_verifying_key(pck.verifying_key())?.to_vec(),
+    )
+    .map_err(|_| AttestationErr::BadVerifyingKeyLength)?;
+    Ok(pck)
 }
 
 /// Querystring for the GET `/attest` endpoint

--- a/crates/threshold-signature-server/src/attestation/api.rs
+++ b/crates/threshold-signature-server/src/attestation/api.rs
@@ -26,7 +26,7 @@ use axum::{
 use entropy_client::user::request_attestation;
 use entropy_shared::{
     attestation::{compute_quote_measurement, QuoteContext, QuoteInputData, VerifyQuoteError},
-    BoundedVecEncodedVerifyingKey, OcwMessageAttestationRequest,
+    BoundedVecEncodedVerifyingKey,
 };
 use serde::Deserialize;
 use subxt::{backend::legacy::LegacyRpcMethods, OnlineClient};

--- a/crates/threshold-signature-server/src/attestation/errors.rs
+++ b/crates/threshold-signature-server/src/attestation/errors.rs
@@ -40,9 +40,10 @@ pub enum AttestationErr {
     #[cfg(feature = "production")]
     #[error("Quote generation: {0}")]
     QuoteGeneration(String),
-    #[cfg(not(feature = "production"))]
     #[error("Cannot encode verifying key: {0}")]
     EncodeVerifyingKey(#[from] tdx_quote::VerifyingKeyError),
+    #[error("Verifying key is not 33 bytes long")]
+    BadVerifyingKeyLength,
     #[error("Data is repeated")]
     RepeatedData,
     #[error("Kv error: {0}")]

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -12,9 +12,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-use crate::{node_info::errors::GetInfoError, AppState};
+use crate::{attestation::api::get_pck, node_info::errors::GetInfoError, AppState};
 use axum::{extract::State, Json};
-use entropy_shared::{types::HashingAlgorithm, X25519PublicKey};
+use entropy_shared::{types::HashingAlgorithm, BoundedVecEncodedVerifyingKey, X25519PublicKey};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use subxt::utils::AccountId32;
@@ -84,6 +84,8 @@ pub struct TssPublicKeys {
     pub tss_account: AccountId32,
     /// The public encryption key
     pub x25519_public_key: X25519PublicKey,
+    /// The Provisioning Certification Key used in TDX quotes
+    pub provisioning_certification_key: BoundedVecEncodedVerifyingKey,
 }
 
 /// Returns the TS server's public keys and HTTP endpoint
@@ -93,5 +95,6 @@ pub async fn info(State(app_state): State<AppState>) -> Result<Json<TssPublicKey
         ready: app_state.cache.is_ready(),
         x25519_public_key: app_state.x25519_public_key(),
         tss_account: app_state.subxt_account_id(),
+        provisioning_certification_key: get_pck(app_state.subxt_account_id()).unwrap(),
     }))
 }

--- a/crates/threshold-signature-server/src/node_info/api.rs
+++ b/crates/threshold-signature-server/src/node_info/api.rs
@@ -95,6 +95,6 @@ pub async fn info(State(app_state): State<AppState>) -> Result<Json<TssPublicKey
         ready: app_state.cache.is_ready(),
         x25519_public_key: app_state.x25519_public_key(),
         tss_account: app_state.subxt_account_id(),
-        provisioning_certification_key: get_pck(app_state.subxt_account_id()).unwrap(),
+        provisioning_certification_key: get_pck(app_state.subxt_account_id())?,
     }))
 }

--- a/crates/threshold-signature-server/src/node_info/errors.rs
+++ b/crates/threshold-signature-server/src/node_info/errors.rs
@@ -23,6 +23,8 @@ use thiserror::Error;
 pub enum GetInfoError {
     #[error("Could not get public keys: {0}")]
     User(#[from] crate::user::errors::UserErr),
+    #[error("Could not get Provisioning Certification Key: {0}")]
+    Attestation(#[from] crate::attestation::errors::AttestationErr),
 }
 
 impl IntoResponse for GetInfoError {

--- a/crates/threshold-signature-server/src/node_info/tests.rs
+++ b/crates/threshold-signature-server/src/node_info/tests.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    attestation::api::get_pck,
     helpers::tests::{initialize_test_logger, setup_client},
     node_info::api::{BuildDetails, TssPublicKeys, VersionDetails},
 };
@@ -82,6 +83,7 @@ async fn info_test() {
             tss_account: TSS_ACCOUNTS[0].clone(),
             x25519_public_key: X25519_PUBLIC_KEYS[0],
             ready: true,
+            provisioning_certification_key: get_pck(TSS_ACCOUNTS[0].clone()).unwrap(),
         }
     );
     clean_tests();


### PR DESCRIPTION
Closes https://github.com/entropyxyz/entropy-core/issues/1354

Example output of `/info` on this branch:

```json
{"ready":false,"tss_account":"5Dy7r8pTEoJJDGRrebQvFyWWfKCpTJiXxz7NxbKeh8zXE7Vk","x25519_public_key":[40,170,149,217,225,231,193,134,157,146,161,94,118,146,134,201,179,206,106,186,35,6,93,138,104,203,205,68,208,90,255,7],"provisioning_certification_key":[2,35,153,56,144,219,98,192,9,186,39,114,167,154,75,24,93,39,159,234,180,105,135,89,110,203,179,93,192,164,177,214,78]}
```