### PR TITLE
Change `entropy-tss` storage location for TDX production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ runtime
 - Attestation quote verification should check both run-time and build-time measurement values ([#1303](https://github.com/entropyxyz/entropy-core/pull/1303))
 - `/version` HTTP route gives measurement value on production builds ([#1305](https://github.com/entropyxyz/entropy-core/pull/1305))
 - Include Provisioning Certification Key (PCK) in the entropy-tss `/info` HTTP route output ([#1357](https://github.com/entropyxyz/entropy-core/pull/1357))
+- Change entropy-tss storage location for TDX production builds ([#1361](https://github.com/entropyxyz/entropy-core/pull/1361))
 
 ### Fixed
 

--- a/crates/kvdb/src/kv_manager/tests.rs
+++ b/crates/kvdb/src/kv_manager/tests.rs
@@ -31,11 +31,11 @@ use super::{
 use crate::{
     clean_tests,
     encrypted_sled::{Db, Result},
-    get_db_path,
+    get_db_path, BuildType,
 };
 
 pub fn open_with_test_key() -> Result<Db> {
-    Db::open(get_db_path(true), [1; 32])
+    Db::open(get_db_path(BuildType::Test), [1; 32])
 }
 
 #[test]

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -18,7 +18,7 @@ pub mod encrypted_sled;
 pub mod kv_manager;
 use std::{fs, path::PathBuf};
 
-/// The intended environment entropy-tss is build for
+/// The intended environment entropy-tss is built for
 #[derive(PartialEq)]
 pub enum BuildType {
     /// Automated tests

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -18,10 +18,21 @@ pub mod encrypted_sled;
 pub mod kv_manager;
 use std::{fs, path::PathBuf};
 
-pub fn get_db_path(testing: bool) -> String {
-    let mut root: PathBuf = std::env::current_dir().expect("could not get home directory");
+#[derive(PartialEq)]
+pub enum BuildType {
+    Test,
+    ProductionNoTdx,
+    ProductionTdx,
+}
+
+pub fn get_db_path(build_type: BuildType) -> String {
+    let mut root: PathBuf = if build_type == BuildType::ProductionTdx {
+        "/persist".into()
+    } else {
+        std::env::current_dir().expect("could not get home directory")
+    };
     root.push(".entropy");
-    if testing {
+    if build_type == BuildType::Test {
         root.push("testing");
     } else {
         root.push("production");
@@ -34,7 +45,7 @@ pub fn get_db_path(testing: bool) -> String {
 }
 
 pub fn clean_tests() {
-    let db_path = get_db_path(true);
+    let db_path = get_db_path(BuildType::Test);
     if fs::metadata(db_path.clone()).is_ok() {
         let _result = std::fs::remove_dir_all(db_path);
     }

--- a/crates/kvdb/src/lib.rs
+++ b/crates/kvdb/src/lib.rs
@@ -18,13 +18,18 @@ pub mod encrypted_sled;
 pub mod kv_manager;
 use std::{fs, path::PathBuf};
 
+/// The intended environment entropy-tss is build for
 #[derive(PartialEq)]
 pub enum BuildType {
+    /// Automated tests
     Test,
+    /// A production-like test deployment without TDX
     ProductionNoTdx,
+    /// A production deployment with TDX
     ProductionTdx,
 }
 
+/// Build the path used to store the key-value database
 pub fn get_db_path(build_type: BuildType) -> String {
     let mut root: PathBuf = if build_type == BuildType::ProductionTdx {
         "/persist".into()

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use clap::Parser;
 use entropy_client::substrate::SubstrateError;
-use entropy_kvdb::kv_manager::KvManager;
+use entropy_kvdb::{get_db_path, kv_manager::KvManager, BuildType};
 use rand::RngCore;
 use rand_core::OsRng;
 use serde::Deserialize;
@@ -161,10 +161,16 @@ pub async fn setup_kv_store(
 /// different test accounts when testing
 pub fn build_db_path(validator_name: &Option<ValidatorName>) -> PathBuf {
     if cfg!(test) {
-        return PathBuf::from(entropy_kvdb::get_db_path(true));
+        return PathBuf::from(get_db_path(BuildType::Test));
     }
 
-    let mut root: PathBuf = PathBuf::from(entropy_kvdb::get_db_path(false));
+    let build_type = if cfg!(feature = "production") {
+        BuildType::ProductionTdx
+    } else {
+        BuildType::ProductionNoTdx
+    };
+
+    let mut root: PathBuf = PathBuf::from(get_db_path(build_type));
     // Alice has no extra subdirectory
     if validator_name == &Some(ValidatorName::Bob) {
         root.push("bob");

--- a/crates/threshold-signature-server/src/helpers/tests.rs
+++ b/crates/threshold-signature-server/src/helpers/tests.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 use axum::{routing::IntoMakeService, Router};
 use entropy_client::substrate::query_chain;
-use entropy_kvdb::{get_db_path, kv_manager::KvManager};
+use entropy_kvdb::{get_db_path, kv_manager::KvManager, BuildType};
 use entropy_protocol::PartyId;
 #[cfg(test)]
 use entropy_shared::EncodedVerifyingKey;
@@ -72,7 +72,7 @@ pub async fn initialize_test_logger() {
 pub async fn setup_client() -> AppState {
     let configuration = Configuration::new(DEFAULT_ENDPOINT.to_string());
 
-    let storage_path: PathBuf = get_db_path(true).into();
+    let storage_path: PathBuf = get_db_path(BuildType::Test).into();
     let (kv_store, sr25519_pair, x25519_secret, _should_backup) =
         setup_kv_store(&Some(ValidatorName::Alice), Some(storage_path.clone())).await.unwrap();
 


### PR DESCRIPTION
This relates to this issue: https://github.com/entropyxyz/entropy-core/issues/1197

This changes the directory where `entropy-tss` stores its key-value store but only for TDX production builds.  The base directory for these builds is now `/persist` rather than the working directory where the binary is run.

This pairs with https://github.com/entropyxyz/meta-entropy-tss/pull/5 which mounts a persistent filesystem to the path `/persist` (the rest of the filesystem is in-memory only).

Rather than fix this issue complete by setting the storage directory to something conventional, i am trying to minimize the amount of breaking changes to our current setup since we are talking about doing another non-TDX deployment soon.