### PR TITLE
Build devnet chainspec script takes a chainspec given as an argument

### DIFF
--- a/scripts/build-devnet-chainspec.sh
+++ b/scripts/build-devnet-chainspec.sh
@@ -1,2 +1,3 @@
 # This script is meant to be run once before launching the devnet to build the inital chain spec
-./target/release/entropy build-spec --disable-default-bootnode --raw --chain=devnet > chains/devnet.json
+CHAINSPEC=${1:-"devnet"}
+ENTROPY_TESTNET_TSS_IP=0.0.0.0:3001 ./target/release/entropy build-spec --disable-default-bootnode --raw --chain=$CHAINSPEC > chains/${CHAINSPEC}.json


### PR DESCRIPTION
This is a tiny, non-breaking change to `./scripts/build-devnet-chainspec.sh` script, which makes it take a chainspec type given as a command line argument, defaulting to `devnet` if none is given.

This is so the script can be used with the `tdx-testnet` chainspec.

For discussion of why we would use this, see https://github.com/entropyxyz/entropy-core/pull/1366#discussion_r2006618363