### PR TITLE
Repeatedly attempt to retrieve TSS db backup and on failure start fresh 

### DIFF
--- a/crates/threshold-signature-server/src/backup_provider/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/api.rs
@@ -82,6 +82,7 @@ pub async fn request_recover_encryption_key(
     let response_key = PublicKey::from(&response_secret_key).to_bytes();
 
     let quote_nonce = request_quote_nonce(&response_secret_key, &backup_provider_details).await?;
+    tracing::info!("Successfully retrieved quote nonce from backup provider");
 
     // Quote input contains: key_provider_details.tss_account, and response_key
     let quote = create_quote(
@@ -321,7 +322,9 @@ pub async fn quote_nonce(
     State(app_state): State<AppState>,
     Json(response_key): Json<X25519PublicKey>,
 ) -> Result<Json<EncryptedSignedMessage>, BackupProviderError> {
+    tracing::info!("Got request for quote nonce");
     if !app_state.cache.is_ready() {
+        tracing::info!("Cannot provide quote nonce as not yet ready");
         return Err(BackupProviderError::NotReady);
     }
 
@@ -352,6 +355,7 @@ async fn request_quote_nonce(
     let response_key = serde_json::to_string(&response_key)?;
 
     let get_quote_nonce = || async {
+        tracing::info!("Requesting quote nonce");
         let client = reqwest::Client::new();
         let response = client
             .post(format!(

--- a/crates/threshold-signature-server/src/backup_provider/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/errors.rs
@@ -70,6 +70,8 @@ pub enum BackupProviderError {
     NotConnectedToChain,
     #[error("Application State Error: {0}")]
     AppStateError(#[from] crate::helpers::app_state::AppStateError),
+    #[error("Failed to retrieve nonce from backup provider during recovery: {0}")]
+    FailedToRetrieveNonce(String),
 }
 
 impl IntoResponse for BackupProviderError {

--- a/crates/threshold-signature-server/src/backup_provider/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/errors.rs
@@ -72,6 +72,8 @@ pub enum BackupProviderError {
     AppStateError(#[from] crate::helpers::app_state::AppStateError),
     #[error("Failed to retrieve nonce from backup provider during recovery: {0}")]
     FailedToRetrieveNonce(String),
+    #[error("Failed to retrieve encryption key from backup provider during recovery: {0}")]
+    FailedToRetrieveKey(String),
 }
 
 impl IntoResponse for BackupProviderError {

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -105,7 +105,9 @@ pub async fn setup_kv_store(
     // Check for existing database with backup details
     if let Ok(key_provider_details) = get_key_provider_details(storage_path.clone()) {
         // Retrieve encryption key from another TSS node
+        tracing::info!("Existing database found - recovering encryption key...");
         let key = request_recover_encryption_key(key_provider_details).await?;
+        tracing::info!("Key recovered successfully");
 
         // Open existing db with recovered key
         let kv_manager = KvManager::new(storage_path, key)?;
@@ -126,6 +128,7 @@ pub async fn setup_kv_store(
         let pair = sr25519::Pair::from_seed(&sr25519_seed);
         Ok((kv_manager, pair, x25519_secret.into(), None))
     } else {
+        tracing::info!("No existing database found - generating fresh keys...");
         // Generate TSS account (or use ValidatorName to get a test account)
         let (pair, seed, x25519_secret, encryption_key) = if cfg!(test) || validator_name.is_some()
         {


### PR DESCRIPTION
Closes https://github.com/entropyxyz/entropy-core/issues/1379

When requesting both the nonce and the encryption key, we use the `backoff` crate to repeatedly send requests to the backup provider (another TSS node) for 15 mins. This is for the event that they themselves are still getting setup.

On failure, we copy the current db directory to `<directory name>-backup-<timestamp>` and start fresh.