### PR TITLE
Tiny fix to command in release checklist

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -45,7 +45,7 @@ tagged as the final release.
       `entropyxyz/entropy:local-vX.Y.Z-rc.1`
     - Build the images and spin up the network using `docker compose up`
     - Jumpstart the network using:
-        - `cargo run -p entropy-test-cli -- jumpstart-network`
+        - `cargo run -p entropy-test-cli -- jumpstart-network -m //One`
     - Register an account using:
         - `cargo run -p entropy-test-cli -- register ./crates/testing-utils/template_barebones.wasm -m //One`
     - Request a signature using:


### PR DESCRIPTION
This is a small fix to the commands giving in the release checklist for testing the network with docker-compose.

Without this small change i get:

```
Error: A mnemonic must be given either by the command line option or DEPLOYER_MNEMONIC environment variable
```

when using the given CLI command to jumpstart the network.