### PR TITLE
Fix CI check for code changed (suggested by Zach)

### DIFF
--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -15,7 +15,11 @@ jobs:
       - name: Check for relevant changes
         id: filter
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^(node/|crates/|pallets/|runtime/)"; then
+          ## If this is the first commit on a branch, then the default behaviour of github.event.before is to show the previous ref as
+          ## repeated zeroes, as the previous ref is null
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "changes_detected=true" >> $GITHUB_ENV
+          elif git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^(node/|crates/|pallets/|runtime/)"; then
             echo "changes_detected=true" >> $GITHUB_ENV
           else
             echo "changes_detected=false" >> $GITHUB_ENV

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -18,14 +18,12 @@ jobs:
           ## If this is the first commit on a branch, then the default behaviour of github.event.before is to show the previous ref as
           ## repeated zeroes, as the previous ref is null
           if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-            echo "changes_detected=true" >> $GITHUB_ENV
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
           elif git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^(node/|crates/|pallets/|runtime/)"; then
-            echo "changes_detected=true" >> $GITHUB_ENV
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
           else
-            echo "changes_detected=false" >> $GITHUB_ENV
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
           fi
-      - name: Set output
-        run: echo "changes_detected=${{ env.changes_detected }}" >> $GITHUB_OUTPUT
 
   node-test:
     needs: code-paths-changed

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -10,6 +10,8 @@ jobs:
       run_tests: ${{ steps.filter.outputs.changes_detected }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Check for relevant changes
         id: filter
         run: |


### PR DESCRIPTION
In some cases tests were not being run despite code having been changed, due to an issue with the check as to whether code changes. Eg: https://github.com/entropyxyz/entropy-core/actions/runs/14751508488/job/41409844605?pr=1392

@cooldracula suggested this fix - making it so that all commit history is checked out, so `git diff` can find the commits we are referring to.