### PR TITLE
Trivial doccomment change to trigger CI tests on master

### DIFF
--- a/crates/protocol/src/execute_protocol.rs
+++ b/crates/protocol/src/execute_protocol.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! A wrapper for the threshold signing library to handle sending and receiving messages.
+//! A wrapper for the threshold signing library to handle sending and receiving messages
 
 use futures::future::try_join_all;
 use num::bigint::BigUint;


### PR DESCRIPTION
Because of an issue with code checking which should now be fixed ( https://github.com/entropyxyz/entropy-core/pull/1410 ) - it is possible that some PRs have been merged despite not all tests passing.  

I am having issues with failing tests in another PR, which do not appear to be directly related to the changes i made.

To be sure whether thats the case, i made i trivial code change here to see what the status of tests on master are. 