### PR TITLE
FIx test_node_process_stationary_local

### DIFF
--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -43,21 +43,20 @@ jobs:
       - name: Install dependencies
         if: needs.code-paths-changed.outputs.run_tests == 'true'
         uses: ./.github/actions/install-dependencies/
-      - name: Build entropy-protocol nodejs package
-        if: needs.code-paths-changed.outputs.run_tests == 'true'
-        run: |
-          cd crates/protocol
-          make build-nodejs-testing
-          cd nodejs-test
-          yarn
-          cd ../../..
+      # - name: Build entropy-protocol nodejs package
+      #   if: needs.code-paths-changed.outputs.run_tests == 'true'
+      #   run: |
+      #     cd crates/protocol
+      #     make build-nodejs-testing
+      #     cd nodejs-test
+      #     yarn
+      #     cd ../../..
       - name: Run `cargo build && cargo test`
         if: needs.code-paths-changed.outputs.run_tests == 'true'
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
           cargo test --all-targets --release
-          yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm
       - name: Skip tests when no code changes have been made
         if: needs.code-paths-changed.outputs.run_tests == 'false'

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -43,20 +43,21 @@ jobs:
       - name: Install dependencies
         if: needs.code-paths-changed.outputs.run_tests == 'true'
         uses: ./.github/actions/install-dependencies/
-      # - name: Build entropy-protocol nodejs package
-      #   if: needs.code-paths-changed.outputs.run_tests == 'true'
-      #   run: |
-      #     cd crates/protocol
-      #     make build-nodejs-testing
-      #     cd nodejs-test
-      #     yarn
-      #     cd ../../..
+      - name: Build entropy-protocol nodejs package
+        if: needs.code-paths-changed.outputs.run_tests == 'true'
+        run: |
+          cd crates/protocol
+          make build-nodejs-testing
+          cd nodejs-test
+          yarn
+          cd ../../..
       - name: Run `cargo build && cargo test`
         if: needs.code-paths-changed.outputs.run_tests == 'true'
         run: |
           pushd node
           cargo build --all-targets --release -j $(nproc)
           cargo test --all-targets --release
+          yarn --cwd ../crates/protocol/nodejs-test test
           cargo test -p entropy-tss --release --features=test_helpers -F wasm_test test_wasm
       - name: Skip tests when no code changes have been made
         if: needs.code-paths-changed.outputs.run_tests == 'false'

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -111,7 +111,7 @@ pub async fn test_node_process_stationary_local() -> TestNodeProcess<EntropyConf
     test_node(AccountKeyring::Alice, "--chain=testnet".to_string(), false, None).await
 }
 
-/// Tests chain with test state in chain config
+/// Tests chain with test state in chain config.
 ///
 /// Allowing `force_authoring` will produce blocks.
 pub async fn test_node_process_testing_state(

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -107,6 +107,10 @@ pub async fn test_node_process_stationary() -> TestNodeProcess<EntropyConfig> {
     test_node(AccountKeyring::Alice, "--dev".to_string(), false, None).await
 }
 
+pub async fn test_node_process_stationary_local() -> TestNodeProcess<EntropyConfig> {
+    test_node(AccountKeyring::Alice, "--chain=testnet".to_string(), false, None).await
+}
+
 /// Tests chain with test state in chain config
 ///
 /// Allowing `force_authoring` will produce blocks.

--- a/crates/threshold-signature-server/src/signing_client/tests.rs
+++ b/crates/threshold-signature-server/src/signing_client/tests.rs
@@ -25,7 +25,7 @@ use entropy_shared::{
 };
 use entropy_testing_utils::{
     constants::{TSS_ACCOUNTS, X25519_PUBLIC_KEYS},
-    substrate_context::{test_context_stationary, test_node_process_testing_state},
+    substrate_context::{test_node_process_stationary_local, test_node_process_testing_state},
     ChainSpecType,
 };
 use futures::future::join_all;
@@ -149,9 +149,9 @@ async fn test_proactive_refresh_validation_fail() {
     clean_tests();
 
     let dave = AccountKeyring::Dave;
-    let cxt = test_context_stationary().await;
-    let api = get_api(&cxt.node_proc.ws_url).await.unwrap();
-    let rpc = get_rpc(&cxt.node_proc.ws_url).await.unwrap();
+    let cxt = test_node_process_stationary_local().await;
+    let api = get_api(&cxt.ws_url).await.unwrap();
+    let rpc = get_rpc(&cxt.ws_url).await.unwrap();
     let app_state = setup_client().await;
 
     let block_number = rpc.chain_get_header(None).await.unwrap().unwrap().number;


### PR DESCRIPTION
@ameba23 Found a race condition in this test here https://github.com/entropyxyz/entropy-core/actions/runs/14791179943/job/41528489582

The issue is the ```.staking_extension().proactive_refresh()``` gets cleared at the end of each block. It gets set at block 0 with default so it has a result. Then when it gets cleared it causes an error. This is good behaviour normally, as this only will get fired once by the chain, but bad for this test

I set it to a chain that won't produce blocks so the test doesn't have to race to make this call