### PR TITLE
Fix `entropy-protocol` compilation on wasm

### DIFF
--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -14,7 +14,7 @@ entropy-shared     ={ version="0.4.0-rc.1", path="../shared", default-features=f
 synedrion          ="0.2.0"
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.38.0", default-features=false }
-sp-core            ={ version="34.0.0", default-features=false, features=["full_crypto", "serde"] }
+sp-core            ={ version="34.0.0", default-features=false, features=["full_crypto", "serde", "std"] }
 tokio              ={ version="1.44", features=["sync", "rt", "macros"] }
 x25519-dalek       ={ version="2.0.1", features=["static_secrets"] }
 futures            ="0.3"

--- a/crates/protocol/js-README.md
+++ b/crates/protocol/js-README.md
@@ -31,7 +31,7 @@ NodeJS you must have the dependency [`ws`](https://www.npmjs.com/package/ws) as 
 Object.assign(global, { WebSocket: require('ws') })
 ```
 
-This is tested in CI with `ws` version `^8.14.2`.
+This is tested in CI with `ws` version `^8.14.2`
 
 ## `Hpke`
 


### PR DESCRIPTION
`entropy-protcol` currently will not compile for wasm. This PR fixes it.

Example of this failing: https://github.com/entropyxyz/entropy-core/actions/runs/14794865619/job/41539621619?pr=1414