### PR TITLE
Fix for release v0.4.0

### DIFF
--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -12,6 +12,8 @@ runs:
       shell: bash
     - name: Add Rust components
       run: |
+        rustup install 1.86.0
+        rustup default 1.86.0
         rustup target add wasm32-unknown-unknown
         rustup component add rust-src
       shell: bash

--- a/.github/workflows/build-and-run-node-test.yaml
+++ b/.github/workflows/build-and-run-node-test.yaml
@@ -10,16 +10,20 @@ jobs:
       run_tests: ${{ steps.filter.outputs.changes_detected }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Check for relevant changes
         id: filter
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^(node/|crates/|pallets/|runtime/)"; then
-            echo "changes_detected=true" >> $GITHUB_ENV
+          ## If this is the first commit on a branch, then the default behaviour of github.event.before is to show the previous ref as
+          ## repeated zeroes, as the previous ref is null
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^(node/|crates/|pallets/|runtime/)"; then
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
           else
-            echo "changes_detected=false" >> $GITHUB_ENV
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
           fi
-      - name: Set output
-        run: echo "changes_detected=${{ env.changes_detected }}" >> $GITHUB_OUTPUT
 
   node-test:
     needs: code-paths-changed

--- a/.github/workflows/lint-and-check-licenses.yaml
+++ b/.github/workflows/lint-and-check-licenses.yaml
@@ -14,6 +14,7 @@ jobs:
         run: |
           curl -LsSf https://github.com/tamasfe/taplo/releases/download/0.8.0/taplo-full-linux-x86_64.gz | gunzip -N -d - > ${CARGO_HOME:-~/.cargo}/bin/taplo && chmod +x ${CARGO_HOME:-~/.cargo}/bin/taplo
           rustup component add rustfmt
+          rustup component add clippy
           cargo fmt --check
           taplo fmt --check
           cargo clippy -- -D warnings

--- a/.github/workflows/lint-and-check-licenses.yaml
+++ b/.github/workflows/lint-and-check-licenses.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Format and lint
         run: |
           curl -LsSf https://github.com/tamasfe/taplo/releases/download/0.8.0/taplo-full-linux-x86_64.gz | gunzip -N -d - > ${CARGO_HOME:-~/.cargo}/bin/taplo && chmod +x ${CARGO_HOME:-~/.cargo}/bin/taplo
+          rustup component add rustfmt
           cargo fmt --check
           taplo fmt --check
           cargo clippy -- -D warnings

--- a/crates/kvdb/src/encrypted_sled/tests.rs
+++ b/crates/kvdb/src/encrypted_sled/tests.rs
@@ -16,10 +16,10 @@
 use serial_test::serial;
 
 use super::kv::EncryptedDb;
-use crate::{clean_tests, encrypted_sled::Db, get_db_path};
+use crate::{clean_tests, encrypted_sled::Db, get_db_path, BuildType};
 
 fn setup_db(key: [u8; 32]) -> Db {
-    EncryptedDb::open(get_db_path(true), key).unwrap()
+    EncryptedDb::open(get_db_path(BuildType::Test), key).unwrap()
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_encrypted_sled() {
 #[serial]
 fn test_use_existing_key() {
     let db = setup_db([1; 32]);
-    let db_path = get_db_path(true);
+    let db_path = get_db_path(BuildType::Test);
     drop(db);
     // open existing db
     assert!(EncryptedDb::open(db_path, [1; 32]).is_ok());
@@ -80,7 +80,7 @@ fn test_use_existing_key() {
 #[serial]
 fn test_key() {
     let db = setup_db([1; 32]);
-    let db_path = get_db_path(true);
+    let db_path = get_db_path(BuildType::Test);
 
     drop(db);
 

--- a/crates/threshold-signature-server/src/backup_provider/api.rs
+++ b/crates/threshold-signature-server/src/backup_provider/api.rs
@@ -52,24 +52,41 @@ pub async fn request_backup_encryption_key(
         &backup_provider_details.provider.x25519_public_key,
         &[],
     )?;
+    let signed_message = serde_json::to_string(&signed_message)?;
 
-    // Make the request
-    let client = reqwest::Client::new();
-    let response = client
-        .post(format!(
-            "http://{}/v1/backup_encryption_key",
-            backup_provider_details.provider.ip_address
-        ))
-        .header("Content-Type", "application/json")
-        .body(serde_json::to_string(&signed_message)?)
-        .send()
-        .await?;
+    let try_backup_encryption_key = || async {
+        tracing::info!("Requesting encryption key from backup provider");
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!(
+                "http://{}/v1/backup_encryption_key",
+                backup_provider_details.provider.ip_address
+            ))
+            .header("Content-Type", "application/json")
+            .body(signed_message.clone())
+            .send()
+            .await
+            .map_err(|err| backoff::Error::Transient { err: err.to_string(), retry_after: None })?;
 
-    let status = response.status();
-    if status != reqwest::StatusCode::OK {
-        let text = response.text().await?;
-        return Err(BackupProviderError::BadProviderResponse(status, text));
-    }
+        let status = response.status();
+        if status != reqwest::StatusCode::OK {
+            let text = response.text().await.map_err(|err| backoff::Error::Transient {
+                err: err.to_string(),
+                retry_after: None,
+            })?;
+            return Err(backoff::Error::Transient { err: text, retry_after: None });
+        }
+
+        Ok(())
+    };
+
+    // Use the default maximum elapsed time of 15 minutes.
+    let backoff = backoff::ExponentialBackoff::default();
+
+    backoff::future::retry(backoff, try_backup_encryption_key)
+        .await
+        .map_err(BackupProviderError::FailedToMakeBackup)?;
+
     Ok(())
 }
 
@@ -134,7 +151,7 @@ pub async fn request_recover_encryption_key(
     // Use the default maximum elapsed time of 15 minutes.
     let backoff = backoff::ExponentialBackoff::default();
 
-    let response_bytes: Vec<u8> = backoff::future::retry(backoff.clone(), get_encryption_key)
+    let response_bytes: Vec<u8> = backoff::future::retry(backoff, get_encryption_key)
         .await
         .map_err(BackupProviderError::FailedToRetrieveKey)?;
 
@@ -407,7 +424,7 @@ async fn request_quote_nonce(
     // Use the default maximum elapsed time of 15 minutes.
     let backoff = backoff::ExponentialBackoff::default();
 
-    let response_bytes: Vec<u8> = backoff::future::retry(backoff.clone(), get_quote_nonce)
+    let response_bytes: Vec<u8> = backoff::future::retry(backoff, get_quote_nonce)
         .await
         .map_err(BackupProviderError::FailedToRetrieveNonce)?;
 

--- a/crates/threshold-signature-server/src/backup_provider/errors.rs
+++ b/crates/threshold-signature-server/src/backup_provider/errors.rs
@@ -40,8 +40,8 @@ pub enum BackupProviderError {
     Attestation(#[from] crate::attestation::errors::AttestationErr),
     #[error("Generic Substrate error: {0}")]
     GenericSubstrate(#[from] subxt::error::Error),
-    #[error("Bad response from backup provider: {0} {1}")]
-    BadProviderResponse(reqwest::StatusCode, String),
+    #[error("Backup provider was unreachable or failed to make backup: {0}")]
+    FailedToMakeBackup(String),
     #[error("Provider responded with a key which is not 32 bytes")]
     BadKeyLength,
     #[error("Substrate: {0}")]

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! # Server
 //!
-//! The Threshold Server which stores key shares and participates in the signing protocol.
+//! The Threshold Signature Server which stores key shares and participates in the signing protocol.
 //!
 //! ## Overview
 //!

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! # Threshold Server
+//! # Threshold Signature Server
 //!
 //! The Threshold Signature Server which stores key shares and participates in the signing protocol.
 //!

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -123,10 +123,10 @@
 //!   in a [crate::validation::SignedMessage].
 //!
 //! - [`/ws`](crate::signing_client::api::ws_handler()) - Websocket server for signing and DKG protocol
-//!     messages. This is opened by other threshold servers when the signing procotol is initiated.
+//!   messages. This is opened by other threshold servers when the signing procotol is initiated.
 //!
 //! - [`/validator/sync_kvdb`](crate::validator::api::sync_kvdb()) - POST - Called by another
-//!     threshold server when joining to get the key-shares from a member of their sub-group.
+//!   threshold server when joining to get the key-shares from a member of their sub-group.
 //!
 //!   Takes a list of users account IDs for which shares are requested, wrapped in a
 //!   [crate::validation::SignedMessage].
@@ -156,7 +156,7 @@
 //!
 //! - Axum server - Includes global state and mutex locked IPs
 //! - [kvdb](entropy_kvdb) - Encrypted key-value database for storing key-shares and other data, build using
-//!     [sled](https://docs.rs/sled)
+//!   [sled](https://docs.rs/sled)
 #![doc(html_logo_url = "https://entropy.xyz/assets/logo_02.png")]
 pub use entropy_client::chain_api;
 pub(crate) mod attestation;

--- a/crates/threshold-signature-server/src/lib.rs
+++ b/crates/threshold-signature-server/src/lib.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-//! # Server
+//! # Threshold Server
 //!
 //! The Threshold Signature Server which stores key shares and participates in the signing protocol.
 //!

--- a/node/cli/src/chain_spec/dev.rs
+++ b/node/cli/src/chain_spec/dev.rs
@@ -261,7 +261,7 @@ pub fn development_genesis_config(
         "elections": ElectionsConfig {
             members: endowed_accounts
                 .iter()
-                .take((num_endowed_accounts + 1) / 2)
+                .take(num_endowed_accounts.div_ceil(2))
                 .cloned()
                 .map(|member| (member, STASH))
                 .collect(),
@@ -269,7 +269,7 @@ pub fn development_genesis_config(
         "technicalCommittee": TechnicalCommitteeConfig  {
             members: endowed_accounts
                 .iter()
-                .take((num_endowed_accounts + 1) / 2)
+                .take(num_endowed_accounts.div_ceil(2))
                 .cloned()
                 .collect(),
             phantom: Default::default(),

--- a/node/cli/src/chain_spec/integration_tests.rs
+++ b/node/cli/src/chain_spec/integration_tests.rs
@@ -234,7 +234,7 @@ pub fn integration_tests_genesis_config(
         "elections": ElectionsConfig {
             members: endowed_accounts
                 .iter()
-                .take((num_endowed_accounts + 1) / 2)
+                .take(num_endowed_accounts.div_ceil(2))
                 .cloned()
                 .map(|member| (member, STASH))
                 .collect(),
@@ -242,7 +242,7 @@ pub fn integration_tests_genesis_config(
         "technicalCommittee": TechnicalCommitteeConfig {
             members: endowed_accounts
                 .iter()
-                .take((num_endowed_accounts + 1) / 2)
+                .take(num_endowed_accounts.div_ceil(2))
                 .cloned()
                 .collect(),
             phantom: Default::default(),

--- a/node/cli/src/chain_spec/testnet.rs
+++ b/node/cli/src/chain_spec/testnet.rs
@@ -208,7 +208,7 @@ pub fn testnet_local_initial_tss_servers(
 /// However, this can be done by:
 /// - First, spinning up the machines you expect to be running at genesis
 /// - Then, running each TSS server with the `--setup-only` flag to get the `TssAccountId` and
-///     `TssX25519PublicKey`
+///   `TssX25519PublicKey`
 /// - Finally, writing all that information back here, and generating the chainspec from that.
 ///
 /// Note that if the KVDB of the TSS is deleted at any point during this process you will end up

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -431,7 +431,7 @@ pub fn new_full_base(
 
     (with_startup_data)(&block_import, &babe_link);
 
-    if let sc_service::config::Role::Authority { .. } = &role {
+    if let sc_service::config::Role::Authority = &role {
         let proposer = sc_basic_authorship::ProposerFactory::new(
             task_manager.spawn_handle(),
             client.clone(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel="stable"
+channel = "1.86.0"
 targets=["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel="1.86.0"
 targets=["wasm32-unknown-unknown"]


### PR DESCRIPTION
This cherry-picks commit `1634692c`, adding the fix from PR https://github.com/entropyxyz/entropy-core/pull/1385 to release v0.4.0-rc1

I tried releasing directly from that commit and had issues, even though the changed in-between are mostly just minor version bumps from dependabot - but to be sure i want to check CI passes here before releasing on this branch.

To get CI to run i also needed this: https://github.com/entropyxyz/entropy-core/pull/1410 so i cherry picked that as well.