### PR TITLE
Bump package versions to `v0.4.0-rc.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "entropy"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "clap",
  "entropy-runtime",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-client"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-create-test-keyshares"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-kvdb",
  "entropy-shared",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-kvdb"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "bincode 1.3.3",
  "chacha20poly1305 0.9.1",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-protocol"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-runtime"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-shared"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "blake2 0.10.6",
  "hex-literal",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-test-cli"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-testing-utils"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "axum",
  "entropy-kvdb",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "entropy-tss"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-attestation"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7238,7 +7238,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-oracle"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-programs"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-propagation"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7377,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-registry"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "bip32",
  "entropy-shared",
@@ -7472,7 +7472,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-slashing"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7522,7 +7522,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-extension"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "entropy-shared",
  "frame-benchmarking",
@@ -7626,7 +7626,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-pause"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support 29.0.2",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-client"
-version    ="0.4.0-rc.1"
+version    ="0.4.0-rc.3"
 edition    ="2021"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -11,7 +11,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 [dependencies]
 sha3          ="0.10.8"
 serde         ={ version="1.0", default-features=false, features=["derive"] }
-entropy-shared={ version="0.4.0-rc.1", path="../shared", default-features=false }
+entropy-shared={ version="0.4.0-rc.3", path="../shared", default-features=false }
 subxt         ={ version="0.35.3", default-features=false, features=["jsonrpsee"] }
 num           ="0.4.3"
 thiserror     ="2.0.12"
@@ -26,7 +26,7 @@ blake2            ={ version="0.10.4", optional=true }
 rand_core         ={ version="0.6.4", optional=true }
 serde_json        ={ version="1.0", optional=true }
 x25519-dalek      ={ version="2.0.1", features=["static_secrets"], optional=true }
-entropy-protocol  ={ version="0.4.0-rc.1", path="../protocol", optional=true, default-features=false }
+entropy-protocol  ={ version="0.4.0-rc.3", path="../protocol", optional=true, default-features=false }
 reqwest           ={ version="0.12.12", features=["json", "stream"], optional=true }
 base64            ={ version="0.22.0", optional=true }
 synedrion         ={ version="0.2.0", optional=true }

--- a/crates/kvdb/Cargo.toml
+++ b/crates/kvdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-kvdb"
 description="Encrypted key-value database for the Entropy Theshold Signing Server"
-version    ="0.4.0-rc.1"
+version    ="0.4.0-rc.3"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -32,7 +32,7 @@ tracing={ version="0.1", default-features=false }
 # Misc
 sled            ="0.34.7"
 bincode         ="1.3.3"
-entropy-protocol={ version="0.4.0-rc.1", path="../protocol" }
+entropy-protocol={ version="0.4.0-rc.3", path="../protocol" }
 
 [dev-dependencies]
 serial_test="3.2.0"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy-protocol'
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 description="Entropy Signing and DKG protocol execution and transport logic"
 homepage   ='https://entropy.xyz/'
@@ -10,7 +10,7 @@ edition    ='2021'
 
 [dependencies]
 async-trait        ="0.1.88"
-entropy-shared     ={ version="0.4.0-rc.1", path="../shared", default-features=false }
+entropy-shared     ={ version="0.4.0-rc.3", path="../shared", default-features=false }
 synedrion          ="0.2.0"
 serde              ={ version="1.0", features=["derive"], default-features=false }
 subxt              ={ version="0.35.3", default-features=false }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-shared"
 description="Shared types used by the Entropy chain node and Entropy Threshold Signing Server"
-version    ="0.4.0-rc.1"
+version    ="0.4.0-rc.3"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'

--- a/crates/test-cli/Cargo.toml
+++ b/crates/test-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-test-cli"
 description="Simple command line interface client for testing Entropy"
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -9,7 +9,7 @@ repository ='https://github.com/entropyxyz/entropy-core'
 edition    ='2021'
 
 [dependencies]
-entropy-client    ={ version="0.4.0-rc.1", path="../client" }
+entropy-client    ={ version="0.4.0-rc.3", path="../client" }
 clap              ={ version="4.5.35", features=["derive"] }
 colored           ="3.0.0"
 subxt             ="0.35.3"
@@ -20,7 +20,7 @@ hex               ="0.4.3"
 bincode           ="1.3.3"
 x25519-dalek      ="2.0.1"
 sp-runtime        ={ version="32.0.0", default-features=false }
-entropy-shared    ={ version="0.4.0-rc.1", path="../shared" }
+entropy-shared    ={ version="0.4.0-rc.3", path="../shared" }
 serde_json        ="1.0.140"
 serde             ={ version="1.0.219", features=["derive"] }
 reqwest           ="0.12.12"

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-testing-utils"
 description="Utilities for testing the Entropy Threshold Signature Server"
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -18,12 +18,12 @@ lazy_static="1.5.0"
 hex-literal="1.0.0"
 tokio={ version="1.44", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
 axum={ version="0.8.3" }
-entropy-shared={ version="0.4.0-rc.1", path="../shared" }
-entropy-kvdb={ version="0.4.0-rc.1", path="../kvdb", default-features=false }
-entropy-tss={ version="0.4.0-rc.1", path="../threshold-signature-server", features=[
+entropy-shared={ version="0.4.0-rc.3", path="../shared" }
+entropy-kvdb={ version="0.4.0-rc.3", path="../kvdb", default-features=false }
+entropy-tss={ version="0.4.0-rc.3", path="../threshold-signature-server", features=[
   "test_helpers",
 ] }
-entropy-protocol={ version="0.4.0-rc.1", path="../protocol" }
+entropy-protocol={ version="0.4.0-rc.3", path="../protocol" }
 synedrion="0.2.0"
 hex="0.4.3"
 rand_core="0.6.4"

--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ="entropy-tss"
-version    ="0.4.0-rc.1"
+version    ="0.4.0-rc.3"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 description='Entropy threshold signature scheme (TSS) server'
@@ -41,10 +41,10 @@ sp-core           ={ version="31.0.0", default-features=false }
 sp-keyring        ="34.0.0"
 
 # Entropy
-entropy-shared={ version="0.4.0-rc.1", path="../shared" }
-entropy-kvdb={ version="0.4.0-rc.1", path="../kvdb", default-features=false }
-entropy-protocol={ version="0.4.0-rc.1", path="../protocol", features=["server"] }
-entropy-client={ version="0.4.0-rc.1", path="../client", default-features=false, features=[
+entropy-shared={ version="0.4.0-rc.3", path="../shared" }
+entropy-kvdb={ version="0.4.0-rc.3", path="../kvdb", default-features=false }
+entropy-protocol={ version="0.4.0-rc.3", path="../protocol", features=["server"] }
+entropy-client={ version="0.4.0-rc.3", path="../client", default-features=false, features=[
   "native",
 ] }
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       ='entropy'
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 description="Entropy substrate node"
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
@@ -90,12 +90,12 @@ pallet-transaction-payment    ={ version="29.0.0" }
 pallet-transaction-payment-rpc={ version="31.0.0" }
 
 # Entropy Dependencies
-entropy-runtime={ version="0.4.0-rc.1", path="../../runtime" }
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-runtime={ version="0.4.0-rc.3", path="../../runtime" }
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-registry={ version="0.4.0-rc.1", path="../../pallets/registry" }
-pallet-staking-extension={ version="0.4.0-rc.1", path="../../pallets/staking" }
+pallet-registry={ version="0.4.0-rc.3", path="../../pallets/registry" }
+pallet-staking-extension={ version="0.4.0-rc.3", path="../../pallets/staking" }
 project-root="0.2.2"
 
 [build-dependencies]

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-attestation"
-version   ="0.4.0-rc.1"
+version   ="0.4.0-rc.3"
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -23,11 +23,11 @@ sp-std            ={ version="14.0.0", default-features=false }
 pallet-session    ={ version="29.0.0", default-features=false, optional=true }
 rand_chacha       ={ version="0.3", default-features=false }
 
-pallet-parameters={ version="0.4.0-rc.1", path="../parameters", default-features=false }
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", features=[
+pallet-parameters={ version="0.4.0-rc.3", path="../parameters", default-features=false }
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-pallet-staking-extension={ version="0.4.0-rc.1", path="../staking", default-features=false }
+pallet-staking-extension={ version="0.4.0-rc.3", path="../staking", default-features=false }
 tdx-quote="0.0.3"
 
 [dev-dependencies]
@@ -42,7 +42,7 @@ pallet-staking-reward-curve    ={ version="11.0.0" }
 tdx-quote                      ={ version="0.0.3", features=["mock"] }
 rand_core                      ="0.6.4"
 
-pallet-slashing={ version="0.4.0-rc.1", path="../slashing", default-features=false }
+pallet-slashing={ version="0.4.0-rc.3", path="../slashing", default-features=false }
 
 [features]
 default=['std']

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-oracle"
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/parameters/Cargo.toml
+++ b/pallets/parameters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-parameters"
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -19,7 +19,7 @@ sp-runtime        ={ version="32.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 pallet-session    ={ version="29.0.0", default-features=false }
 
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 

--- a/pallets/programs/Cargo.toml
+++ b/pallets/programs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-programs'
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -23,7 +23,7 @@ sp-io             ={ version="31.0.0", default-features=false }
 sp-runtime        ={ version="32.0.0", default-features=false }
 sp-staking        ={ version="27.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
-pallet-oracle     ={ version='0.4.0-rc.1', path='../oracle', default-features=false }
+pallet-oracle     ={ version='0.4.0-rc.3', path='../oracle', default-features=false }
 
 [dev-dependencies]
 pallet-balances={ version="29.0.0" }

--- a/pallets/propagation/Cargo.toml
+++ b/pallets/propagation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-propagation'
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -26,13 +26,13 @@ sp-io                ={ version="31.0.0", default-features=false }
 sp-runtime           ={ version="32.0.0", default-features=false }
 sp-staking           ={ version="27.0.0", default-features=false }
 
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
-pallet-attestation={ version="0.4.0-rc.1", path="../attestation", default-features=false }
-pallet-programs={ version="0.4.0-rc.1", path="../programs", default-features=false }
-pallet-registry={ version="0.4.0-rc.1", path="../registry", default-features=false }
-pallet-staking-extension={ version="0.4.0-rc.1", path="../staking", default-features=false }
+pallet-attestation={ version="0.4.0-rc.3", path="../attestation", default-features=false }
+pallet-programs={ version="0.4.0-rc.3", path="../programs", default-features=false }
+pallet-registry={ version="0.4.0-rc.3", path="../registry", default-features=false }
+pallet-staking-extension={ version="0.4.0-rc.3", path="../staking", default-features=false }
 
 [dev-dependencies]
 parking_lot="0.12.3"
@@ -47,9 +47,9 @@ pallet-staking-reward-curve    ={ version="11.0.0" }
 pallet-timestamp               ={ version="28.0.0", default-features=false }
 sp-keystore                    ={ version="0.35.0" }
 sp-npos-elections              ={ version="27.0.0", default-features=false }
-pallet-parameters              ={ version="0.4.0-rc.1", path="../parameters", default-features=false }
-pallet-oracle                  ={ version='0.4.0-rc.1', path='../oracle', default-features=false }
-pallet-slashing                ={ version="0.4.0-rc.1", path="../slashing", default-features=false }
+pallet-parameters              ={ version="0.4.0-rc.3", path="../parameters", default-features=false }
+pallet-oracle                  ={ version='0.4.0-rc.3', path='../oracle', default-features=false }
+pallet-slashing                ={ version="0.4.0-rc.3", path="../slashing", default-features=false }
 
 [features]
 default=['std']

--- a/pallets/registry/Cargo.toml
+++ b/pallets/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-registry'
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -29,12 +29,12 @@ sp-core           ={ version="29.0.0", default-features=false }
 sp-runtime        ={ version="32.0.0", default-features=false }
 sp-std            ={ version="14.0.0", default-features=false }
 
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", features=[
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
-pallet-programs={ version="0.4.0-rc.1", path="../programs", default-features=false }
-pallet-staking-extension={ version="0.4.0-rc.1", path="../staking", default-features=false }
-pallet-parameters={ version="0.4.0-rc.1", path="../parameters", default-features=false }
+pallet-programs={ version="0.4.0-rc.3", path="../programs", default-features=false }
+pallet-staking-extension={ version="0.4.0-rc.3", path="../staking", default-features=false }
+pallet-parameters={ version="0.4.0-rc.3", path="../parameters", default-features=false }
 
 [dev-dependencies]
 frame-election-provider-support={ version="29.0.0", default-features=false }
@@ -45,8 +45,8 @@ pallet-timestamp               ={ version="28.0.0", default-features=false }
 sp-io                          ={ version="31.0.0", default-features=false }
 sp-npos-elections              ={ version="27.0.0", default-features=false }
 sp-staking                     ={ version="27.0.0", default-features=false }
-pallet-oracle                  ={ version='0.4.0-rc.1', path='../oracle', default-features=false }
-pallet-slashing                ={ version="0.4.0-rc.1", path="../slashing", default-features=false }
+pallet-oracle                  ={ version='0.4.0-rc.3', path='../oracle', default-features=false }
+pallet-slashing                ={ version="0.4.0-rc.3", path="../slashing", default-features=false }
 
 [features]
 

--- a/pallets/slashing/Cargo.toml
+++ b/pallets/slashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-slashing'
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ='pallet-staking-extension'
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -30,9 +30,9 @@ sp-std            ={ version="14.0.0", default-features=false }
 sp-consensus-babe ={ version="0.33.0", default-features=false }
 rand              ={ version="0.8.5", default-features=false, features=["alloc"] }
 
-pallet-parameters={ version="0.4.0-rc.1", path="../parameters", default-features=false }
-pallet-slashing={ version="0.4.0-rc.1", path="../slashing", default-features=false }
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared", features=[
+pallet-parameters={ version="0.4.0-rc.3", path="../parameters", default-features=false }
+pallet-slashing={ version="0.4.0-rc.3", path="../slashing", default-features=false }
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared", features=[
   "wasm-no-std",
 ], default-features=false }
 tdx-quote={ version="0.0.3", features=["mock"], optional=true }

--- a/pallets/transaction-pause/Cargo.toml
+++ b/pallets/transaction-pause/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name      ="pallet-transaction-pause"
-version   ='0.4.0-rc.1'
+version   ='0.4.0-rc.3'
 authors   =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage  ='https://entropy.xyz/'
 license   ='AGPL-3.0-or-later'
@@ -22,11 +22,11 @@ sp-std            ={ version="14.0.0", default-features=false }
 smallvec="1.14.0"
 
 pallet-balances={ version="29.0.0" }
-pallet-oracle  ={ version='0.4.0-rc.1', path='../oracle', default-features=false }
+pallet-oracle  ={ version='0.4.0-rc.3', path='../oracle', default-features=false }
 sp-core        ={ version="29.0.0" }
 sp-io          ={ version="31.0.0" }
 
-pallet-programs={ version="0.4.0-rc.1", default-features=false, path="../programs" }
+pallet-programs={ version="0.4.0-rc.3", default-features=false, path="../programs" }
 
 [features]
 default=["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ='entropy-runtime'
 description="The substrate runtime for the Entropy chain node"
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -95,17 +95,17 @@ pallet-utility                               ={ version="29.0.0", default-featur
 pallet-vesting                               ={ version="29.0.0", default-features=false }
 
 # Entropy Pallets
-pallet-programs         ={ version='0.4.0-rc.1', path='../pallets/programs', default-features=false }
-pallet-propagation      ={ version='0.4.0-rc.1', path='../pallets/propagation', default-features=false }
-pallet-registry         ={ version='0.4.0-rc.1', path='../pallets/registry', default-features=false }
-pallet-slashing         ={ version='0.4.0-rc.1', path='../pallets/slashing', default-features=false }
-pallet-staking-extension={ version='0.4.0-rc.1', path='../pallets/staking', default-features=false }
-pallet-transaction-pause={ version='0.4.0-rc.1', path='../pallets/transaction-pause', default-features=false }
-pallet-parameters       ={ version='0.4.0-rc.1', path='../pallets/parameters', default-features=false }
-pallet-attestation      ={ version='0.4.0-rc.1', path='../pallets/attestation', default-features=false }
-pallet-oracle           ={ version='0.4.0-rc.1', path='../pallets/oracle', default-features=false }
+pallet-programs         ={ version='0.4.0-rc.3', path='../pallets/programs', default-features=false }
+pallet-propagation      ={ version='0.4.0-rc.3', path='../pallets/propagation', default-features=false }
+pallet-registry         ={ version='0.4.0-rc.3', path='../pallets/registry', default-features=false }
+pallet-slashing         ={ version='0.4.0-rc.3', path='../pallets/slashing', default-features=false }
+pallet-staking-extension={ version='0.4.0-rc.3', path='../pallets/staking', default-features=false }
+pallet-transaction-pause={ version='0.4.0-rc.3', path='../pallets/transaction-pause', default-features=false }
+pallet-parameters       ={ version='0.4.0-rc.3', path='../pallets/parameters', default-features=false }
+pallet-attestation      ={ version='0.4.0-rc.3', path='../pallets/attestation', default-features=false }
+pallet-oracle           ={ version='0.4.0-rc.3', path='../pallets/oracle', default-features=false }
 
-entropy-shared={ version="0.4.0-rc.1", path="../crates/shared", default-features=false, features=[
+entropy-shared={ version="0.4.0-rc.3", path="../crates/shared", default-features=false, features=[
   "wasm-no-std",
 ] }
 

--- a/scripts/create-test-keyshares/Cargo.toml
+++ b/scripts/create-test-keyshares/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name       ="entropy-create-test-keyshares"
 description="Makes a set of keyshares for testing entropy-tss"
-version    ='0.4.0-rc.1'
+version    ='0.4.0-rc.3'
 authors    =['Entropy Cryptography <engineering@entropy.xyz>']
 homepage   ='https://entropy.xyz/'
 license    ='AGPL-3.0-or-later'
@@ -10,12 +10,12 @@ edition    ='2021'
 publish    =false
 
 [dependencies]
-entropy-testing-utils={ version="0.4.0-rc.1", path="../../crates/testing-utils" }
+entropy-testing-utils={ version="0.4.0-rc.3", path="../../crates/testing-utils" }
 tokio={ version="1.44", features=["macros", "fs", "rt-multi-thread", "io-util", "process"] }
-entropy-shared={ version="0.4.0-rc.1", path="../../crates/shared" }
-entropy-kvdb={ version="0.4.0-rc.1", path="../../crates/kvdb", default-features=false }
+entropy-shared={ version="0.4.0-rc.3", path="../../crates/shared" }
+entropy-kvdb={ version="0.4.0-rc.3", path="../../crates/kvdb", default-features=false }
 sp-core="31.0.0"
 synedrion="0.2.0"
-entropy-tss={ version="0.4.0-rc.1", path="../../crates/threshold-signature-server", features=[
+entropy-tss={ version="0.4.0-rc.3", path="../../crates/threshold-signature-server", features=[
   "test_helpers",
 ] }


### PR DESCRIPTION
Bumps these versions in preparation for a crates.io release.