### PR TITLE
Fix staking it_deletes_when_no_bond_left test

### DIFF
--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -371,7 +371,7 @@ fn it_deletes_when_no_bond_left() {
 
         assert_ok!(FrameStaking::bond(
             RuntimeOrigin::signed(2),
-            100u64,
+            90u64,
             pallet_staking::RewardDestination::Account(1),
         ));
 
@@ -389,15 +389,11 @@ fn it_deletes_when_no_bond_left() {
         assert_eq!(tss_account, 3);
         assert_eq!(Staking::threshold_to_stash(3).unwrap(), 2);
 
-        let mut lock = Balances::locks(&2);
-        assert_eq!(lock[0].amount, 100);
-        assert_eq!(lock.len(), 1);
+        let mut free_balance = Balances::free_balance(&2);
+        assert_eq!(free_balance, 10);
 
         assert_ok!(FrameStaking::unbond(RuntimeOrigin::signed(2), 50u64,));
 
-        lock = Balances::locks(&2);
-        assert_eq!(lock[0].amount, 100);
-        assert_eq!(lock.len(), 1);
         println!(":{:?}", FrameStaking::ledger(1.into()));
         MockSessionManager::new_session(0);
 
@@ -413,9 +409,8 @@ fn it_deletes_when_no_bond_left() {
             amount: 50,
         }));
 
-        lock = Balances::locks(&2);
-        assert_eq!(lock[0].amount, 50);
-        assert_eq!(lock.len(), 1);
+        free_balance = Balances::free_balance(&2);
+        assert_eq!(free_balance, 60);
 
         let ServerInfo { tss_account, endpoint, .. } = Staking::threshold_server(2).unwrap();
         assert_eq!(endpoint, vec![20]);
@@ -428,8 +423,8 @@ fn it_deletes_when_no_bond_left() {
         // make sure node info removed event happens
         System::assert_last_event(RuntimeEvent::Staking(crate::Event::NodeInfoRemoved(2)));
 
-        lock = Balances::locks(&2);
-        assert_eq!(lock.len(), 0);
+        free_balance = Balances::free_balance(&2);
+        assert_eq!(free_balance, 100);
         assert_eq!(Staking::threshold_server(2), None);
         assert_eq!(Staking::threshold_to_stash(3), None);
 


### PR DESCRIPTION
This test is failing with the new update (weird it wasn't picked up in the CI, anyways instead of dealing with locks we check free balance now