### PR TITLE
Add endowed accounts - at compile time

### DIFF
--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -101,7 +101,9 @@ pallet-staking-extension={ version="0.4.0-rc.3", path="../../pallets/staking" }
 project-root="0.2.2"
 
 [build-dependencies]
-clap={ version="4.5.35", optional=true }
+clap      ={ version="4.5.35", optional=true }
+serde     ={ version="1.0.219", features=["derive"] }
+serde_json='1.0.140'
 
 pallet-balances             ={ version="29.0.0" }
 substrate-build-script-utils={ version="11.0.0" }

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::{env, fs, path::Path};
 use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
@@ -21,16 +22,18 @@ fn main() {
     rerun_if_git_head_changed();
 
     // Read testnet endowed accounts from file at compile time
-    let testnet_accounts_file = "data/testnet/testnet-accounts.json";
+    let testnet_accounts_file = "../../data/testnet/testnet-accounts.json";
     let json_str = fs::read_to_string(testnet_accounts_file)
-        .expect(format!("Failed to read {testnet_accounts_file}"));
+        .unwrap_or_else(|e| panic!("Failed to read {testnet_accounts_file}: {e}"));
     let accounts_json: Vec<serde_json::Value> = serde_json::from_str(&json_str)
-        .expect(format!("Failed to parse {testnet_accounts_file} as JSON"));
+        .unwrap_or_else(|e| panic!("Failed to parse {testnet_accounts_file} as JSON: {e}"));
 
     let num_accounts = accounts_json.len();
 
-    let accounts: Vec<&str> =
-        accounts_json.into_iter().map(|account| json["address"].as_str().unwrap()).collect();
+    let accounts: Vec<String> = accounts_json
+        .into_iter()
+        .map(|account| account["address"].as_str().unwrap().to_string())
+        .collect();
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("endowed_testnet_accounts.rs");
@@ -39,7 +42,7 @@ fn main() {
         &dest_path,
         format!(
             r#"
-            pub static ENDOWED_TESTNET_ACCOUNTS: [&str, {num_accounts}] = {accounts:?};
+            pub static ENDOWED_TESTNET_ACCOUNTS: [&str; {num_accounts}] = {accounts:?};
             "#
         ),
     )

--- a/node/cli/src/chain_spec/testnet.rs
+++ b/node/cli/src/chain_spec/testnet.rs
@@ -13,9 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::chain_spec::{
-    get_account_id_from_seed, provisioning_certification_key, ChainSpec, MeasurementValues,
-    MEASUREMENT_VALUE_MOCK_QUOTE,
+use crate::{
+    chain_spec::{
+        get_account_id_from_seed, provisioning_certification_key, ChainSpec, MeasurementValues,
+        MEASUREMENT_VALUE_MOCK_QUOTE,
+    },
+    endowed_accounts::endowed_accounts_testnet,
 };
 
 use entropy_runtime::{
@@ -445,6 +448,7 @@ pub fn testnet_genesis_config(
         "balances": BalancesConfig {
             balances: endowed_accounts
                         .iter()
+                        .chain(endowed_accounts_testnet().iter())
                         .cloned()
                         .map(|x| (x, ENDOWMENT))
                         .unique()

--- a/node/cli/src/endowed_accounts.rs
+++ b/node/cli/src/endowed_accounts.rs
@@ -19,6 +19,8 @@ use entropy_runtime::AccountId;
 use serde::{Deserialize, Serialize};
 use sp_core::sr25519;
 
+include!(concat!(env!("OUT_DIR"), "/endowed_testnet_accounts.rs"));
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddressStruct {
     address: String,
@@ -49,4 +51,15 @@ pub fn endowed_accounts_dev() -> Vec<AccountId> {
         crate::chain_spec::tss_account_id::CHARLIE.clone(),
         crate::chain_spec::tss_account_id::DAVE.clone(),
     ]
+}
+
+pub fn endowed_accounts_testnet() -> Vec<AccountId> {
+    ENDOWED_TESTNET_ACCOUNTS
+        .iter()
+        .map(|account_id| {
+            AccountId::from_string(account_id).unwrap_or_else(|_| {
+                panic!("failed to convert a testnet_address address: {:?}", address)
+            })
+        })
+        .collect()
 }

--- a/node/cli/src/endowed_accounts.rs
+++ b/node/cli/src/endowed_accounts.rs
@@ -18,6 +18,7 @@ use crate::chain_spec::get_account_id_from_seed;
 use entropy_runtime::AccountId;
 use serde::{Deserialize, Serialize};
 use sp_core::sr25519;
+use std::str::FromStr;
 
 include!(concat!(env!("OUT_DIR"), "/endowed_testnet_accounts.rs"));
 
@@ -57,8 +58,8 @@ pub fn endowed_accounts_testnet() -> Vec<AccountId> {
     ENDOWED_TESTNET_ACCOUNTS
         .iter()
         .map(|account_id| {
-            AccountId::from_string(account_id).unwrap_or_else(|_| {
-                panic!("failed to convert a testnet_address address: {:?}", address)
+            AccountId::from_str(account_id).unwrap_or_else(|_| {
+                panic!("Failed to convert an endowed account ID: {:?}", account_id)
             })
         })
         .collect()


### PR DESCRIPTION
In https://github.com/entropyxyz/entropy-core/pull/1424 i removed adding the endowed testnet accounts to the testnet chainspec.

Maybe we do actually want this - see this conversation: 

https://github.com/entropyxyz/ansible-collection-entropy/pull/42#issuecomment-2938767929

In this PR i add them back in, but at compile time, not runtime, meaning the JSON file does not need to exist on the server where entropy runs - they are hard-coded into the binary.  This prevents potential issues where each server has a different version of the file and ends up with a different chainspec.