### PR TITLE
Deterministic alice bootnode for testing

### DIFF
--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -51,11 +51,19 @@ where
         force_authoring: bool,
         bootnode: Option<String>,
         threshold_url: Option<String>,
+        node_key: Option<String>,
     ) -> TestNodeProcessBuilder
     where
         S: AsRef<OsStr> + Clone,
     {
-        TestNodeProcessBuilder::new(program, chain_type, force_authoring, bootnode, threshold_url)
+        TestNodeProcessBuilder::new(
+            program,
+            chain_type,
+            force_authoring,
+            bootnode,
+            threshold_url,
+            node_key,
+        )
     }
 
     /// Attempt to kill the running substrate process.
@@ -84,6 +92,7 @@ pub struct TestNodeProcessBuilder {
     force_authoring: bool,
     bootnode: Option<String>,
     tss_server_endpoint: Option<String>,
+    node_key: Option<String>,
 }
 
 impl TestNodeProcessBuilder {
@@ -93,6 +102,7 @@ impl TestNodeProcessBuilder {
         force_authoring: bool,
         bootnode: Option<String>,
         tss_server_endpoint: Option<String>,
+        node_key: Option<String>,
     ) -> TestNodeProcessBuilder
     where
         P: AsRef<OsStr>,
@@ -105,6 +115,7 @@ impl TestNodeProcessBuilder {
             force_authoring,
             bootnode,
             tss_server_endpoint,
+            node_key,
         }
     }
 
@@ -137,10 +148,14 @@ impl TestNodeProcessBuilder {
         if let Some(authority) = self.authority {
             let authority = format!("{authority:?}");
             let arg = format!("--{}", authority.as_str().to_lowercase());
-            if authority.as_str().to_lowercase() == "alice" {
-                cmd.arg("--node-key=0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
-            }
             cmd.arg(arg);
+        }
+
+        if let Some(node_key) = &self.node_key {
+            let arg = format!("--node-key={}", node_key.as_str());
+            cmd.arg(arg);
+        } else {
+            cmd.arg("--unsafe-force-node-key-generation");
         }
 
         if let Some(bootnode) = &self.bootnode {

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -137,6 +137,9 @@ impl TestNodeProcessBuilder {
         if let Some(authority) = self.authority {
             let authority = format!("{authority:?}");
             let arg = format!("--{}", authority.as_str().to_lowercase());
+            if authority.as_str().to_lowercase() == "alice" {
+                cmd.arg("--node-key=0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
+            }
             cmd.arg(arg);
         }
 

--- a/crates/testing-utils/src/node_proc.rs
+++ b/crates/testing-utils/src/node_proc.rs
@@ -140,7 +140,6 @@ impl TestNodeProcessBuilder {
     {
         let mut cmd = process::Command::new(&self.node_path);
         cmd.env("RUST_LOG", "error").arg(&self.chain_type).arg("--tmp");
-        cmd.arg("--unsafe-force-node-key-generation");
         cmd.arg("--public-addr=/ip4/0.0.0.0/tcp/30333");
         if self.force_authoring {
             cmd.arg("--force-authoring");

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -119,7 +119,7 @@ pub async fn test_node_process_testing_state(
     force_authoring: bool,
 ) -> Vec<TestNodeProcess<EntropyConfig>> {
     let alice_bootnode = Some(
-        "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWM7EoKJfwgzAR1nAVmYRuuFq2f3GpJPLrdfhQaRsKjn38"
+        "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWMrQiZJKkbkZrb7NfkF3u2cu1i5js3tuC3LTYYHfoVbyE"
             .to_string(),
     );
     let result =

--- a/crates/testing-utils/src/substrate_context.rs
+++ b/crates/testing-utils/src/substrate_context.rs
@@ -74,6 +74,7 @@ pub async fn test_node_process_with(
         force_authoring,
         bootnode,
         tss_server_endpoint,
+        None,
     )
     .with_authority(key)
     .scan_for_open_ports()
@@ -87,15 +88,22 @@ pub async fn test_node(
     chain_type: String,
     force_authoring: bool,
     bootnode: Option<String>,
+    node_key: Option<String>,
 ) -> TestNodeProcess<EntropyConfig> {
     let path = get_path();
     let path = path.to_str().expect("Path should've been checked to be valid earlier.");
 
-    let proc =
-        TestNodeProcess::<EntropyConfig>::build(path, chain_type, force_authoring, bootnode, None)
-            .with_authority(key)
-            .spawn::<EntropyConfig>()
-            .await;
+    let proc = TestNodeProcess::<EntropyConfig>::build(
+        path,
+        chain_type,
+        force_authoring,
+        bootnode,
+        None,
+        node_key,
+    )
+    .with_authority(key)
+    .spawn::<EntropyConfig>()
+    .await;
     proc.unwrap()
 }
 
@@ -104,11 +112,11 @@ pub async fn test_node_process() -> TestNodeProcess<EntropyConfig> {
 }
 
 pub async fn test_node_process_stationary() -> TestNodeProcess<EntropyConfig> {
-    test_node(Keyring::Alice, "--dev".to_string(), false, None).await
+    test_node(Keyring::Alice, "--dev".to_string(), false, None, None).await
 }
 
 pub async fn test_node_process_stationary_local() -> TestNodeProcess<EntropyConfig> {
-    test_node(Keyring::Alice, "--chain=testnet-local".to_string(), false, None).await
+    test_node(Keyring::Alice, "--chain=testnet-local".to_string(), false, None, None).await
 }
 
 /// Tests chain with test state in chain config.
@@ -118,13 +126,21 @@ pub async fn test_node_process_testing_state(
     chain_spec_type: ChainSpecType,
     force_authoring: bool,
 ) -> Vec<TestNodeProcess<EntropyConfig>> {
+    // boot node is generated with node key for determinisim
     let alice_bootnode = Some(
         "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWMrQiZJKkbkZrb7NfkF3u2cu1i5js3tuC3LTYYHfoVbyE"
             .to_string(),
     );
-    let result =
-        test_node(Keyring::Alice, format!("--chain={}", chain_spec_type), force_authoring, None)
-            .await;
+    let alice_node_key =
+        Some("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d".to_string());
+    let result = test_node(
+        Keyring::Alice,
+        format!("--chain={}", chain_spec_type),
+        force_authoring,
+        None,
+        alice_node_key,
+    )
+    .await;
     let result_bob = test_node_process_with(
         Keyring::Bob,
         format!("--chain={}", chain_spec_type),

--- a/crates/threshold-signature-server/src/user/tests.rs
+++ b/crates/threshold-signature-server/src/user/tests.rs
@@ -2203,7 +2203,7 @@ async fn test_validate_jump_start_fail_repeated() {
         submit_transaction_with_pair(&api, &rpc, &alice.pair(), &jump_start_request, None)
             .await
             .unwrap();
-    let result_event =
+    let _result_event =
         in_block.find_first::<entropy::registry::events::StartedNetworkJumpStart>().unwrap();
     // manipulates cache to get to repeated data error
     app_state.cache.write_to_block_numbers(BlockNumberFields::NewUser, block_number).unwrap();


### PR DESCRIPTION
Idk why but my nodes were not able to find themselves, not sure how it happened and why not on CI, however now I create alice's node key deterministically so it is hardcoded in our tests and nodes can find each other, this fixes the issue and in general makes this more stable