### PR TITLE
Clippy lints for rust 1.88

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -537,7 +537,7 @@ pub async fn get_tdx_quote(
     quote_context: QuoteContext,
 ) -> Result<Vec<u8>, ClientError> {
     let response =
-        reqwest::get(format!("http://{}/v1/attest?context={}", tss_endpoint, quote_context))
+        reqwest::get(format!("http://{tss_endpoint}/v1/attest?context={quote_context}"))
             .await?;
     if response.status() != reqwest::StatusCode::OK {
         return Err(ClientError::QuoteGet(response.text().await?));

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -110,7 +110,7 @@ impl TryFrom<String> for PartyId {
         let bytes = hex::decode(s).map_err(|err| format!("{err}"))?;
         let len = bytes.len();
         let arr: [u8; 32] =
-            bytes.try_into().map_err(|_err| format!("Invalid party ID length: {}", len))?;
+            bytes.try_into().map_err(|_err| format!("Invalid party ID length: {len}"))?;
         let acc = arr.into();
         Ok(Self(acc))
     }
@@ -266,7 +266,7 @@ impl SessionId {
         let mut hasher = Blake2s256::new();
         hasher.update(bincode::serialize(self)?);
         if let Some(session) = sub_session {
-            hasher.update(format!("{:?}", session).as_bytes());
+            hasher.update(format!("{session:?}").as_bytes());
         }
         Ok(hasher.finalize().into())
     }

--- a/crates/test-cli/src/lib.rs
+++ b/crates/test-cli/src/lib.rs
@@ -293,7 +293,7 @@ pub async fn run_command(
             if cli.json {
                 Ok(serde_json::to_string_pretty(&verifying_key)?)
             } else {
-                Ok(format!("Verifying key: {},\n{:?}", verifying_key, registered_info))
+                Ok(format!("Verifying key: {verifying_key},\n{registered_info:?}"))
             }
         },
         CliCommand::Sign { signature_verifying_key, message, auxilary_data, mnemonic_option } => {
@@ -324,7 +324,7 @@ pub async fn run_command(
             if cli.json {
                 Ok(serde_json::to_string_pretty(&recoverable_signature)?)
             } else {
-                Ok(format!("Message signed: {:?}", recoverable_signature))
+                Ok(format!("Message signed: {recoverable_signature:?}"))
             }
         },
         CliCommand::StoreProgram {
@@ -520,7 +520,7 @@ pub async fn run_command(
 
             let result_event =
                 get_quote_and_change_endpoint(&api, &rpc, user_keypair, new_endpoint).await?;
-            cli.log(format!("Event result: {:?}", result_event));
+            cli.log(format!("Event result: {result_event:?}"));
 
             if cli.json {
                 Ok("{}".to_string())
@@ -548,7 +548,7 @@ pub async fn run_command(
                 new_x25519_public_key,
             )
             .await?;
-            cli.log(format!("Event result: {:?}", result_event));
+            cli.log(format!("Event result: {result_event:?}"));
 
             if cli.json {
                 Ok("{}".to_string())
@@ -580,7 +580,7 @@ pub async fn run_command(
             if cli.json {
                 Ok("{}".to_string())
             } else {
-                Ok(format!("Succesfully written quote to {}", output_filename))
+                Ok(format!("Succesfully written quote to {output_filename}"))
             }
         },
         CliCommand::BondAccount { amount, reward_destination, mnemonic_option } => {
@@ -590,7 +590,7 @@ pub async fn run_command(
 
             let result_event =
                 bond_account(&api, &rpc, signer, amount, reward_destination_account).await?;
-            cli.log(format!("Event result: {:?}", result_event));
+            cli.log(format!("Event result: {result_event:?}"));
 
             if cli.json {
                 Ok("{}".to_string())
@@ -633,7 +633,7 @@ pub async fn run_command(
             )
             .await?;
 
-            cli.log(format!("Event result: {:?}", result_event));
+            cli.log(format!("Event result: {result_event:?}"));
 
             if cli.json {
                 Ok("{}".to_string())

--- a/crates/test-cli/src/main.rs
+++ b/crates/test-cli/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
     match run_command(cli, None, None, None, None, None).await {
         Ok(output) => {
             if json_ouput {
-                println!("{}", output);
+                println!("{output}");
             } else {
                 println!("Success: {}", output.green());
                 println!("{}", format!("That took {:?}", now.elapsed()).yellow());

--- a/crates/threshold-signature-server/src/helpers/app_state.rs
+++ b/crates/threshold-signature-server/src/helpers/app_state.rs
@@ -280,8 +280,7 @@ impl Cache {
     ) -> Result<Vec<subxt::utils::AccountId32>, AppStateError> {
         self.listener_state.unsubscribed_peers(session_id).map_err(|_| {
             AppStateError::SessionError(format!(
-                "Unable to get unsubscribed peers for `SessionId` {:?}",
-                session_id,
+                "Unable to get unsubscribed peers for `SessionId` {session_id:?}",
             ))
         })
     }

--- a/crates/threshold-signature-server/src/helpers/launch.rs
+++ b/crates/threshold-signature-server/src/helpers/launch.rs
@@ -76,7 +76,7 @@ pub enum ValidatorName {
 
 impl std::fmt::Display for ValidatorName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", format!("{:?}", self).to_lowercase())
+        write!(f, "{}", format!("{self:?}").to_lowercase())
     }
 }
 

--- a/crates/threshold-signature-server/src/helpers/logger.rs
+++ b/crates/threshold-signature-server/src/helpers/logger.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for Logger {
             Logger::Pretty => "pretty",
             Logger::Json => "json",
         };
-        write!(f, "{}", logger)
+        write!(f, "{logger}")
     }
 }
 

--- a/crates/threshold-signature-server/src/helpers/validator.rs
+++ b/crates/threshold-signature-server/src/helpers/validator.rs
@@ -15,7 +15,6 @@
 
 //! Utilites relating to [crate::validator]
 use bip39::{Language, Mnemonic};
-use entropy_client::substrate::PairSigner;
 use hkdf::Hkdf;
 use sha2::Sha256;
 use sp_core::{sr25519, Pair};

--- a/crates/threshold-signature-server/src/signing_client/api.rs
+++ b/crates/threshold-signature-server/src/signing_client/api.rs
@@ -269,8 +269,7 @@ pub async fn get_channels(
         Err(e) => {
             let unsubscribed_peers = state.unsubscribed_peers(session_id).map_err(|_| {
                 ProtocolErr::SessionError(format!(
-                    "Unable to get unsubscribed peers for `SessionId` {:?}",
-                    session_id,
+                    "Unable to get unsubscribed peers for `SessionId` {session_id:?}",
                 ))
             })?;
             Err(ProtocolErr::Timeout { source: e, inactive_peers: unsubscribed_peers })

--- a/crates/threshold-signature-server/src/user/api.rs
+++ b/crates/threshold-signature-server/src/user/api.rs
@@ -404,7 +404,7 @@ async fn handle_protocol_errors(
         if let Err(tx_error) =
             submit_transaction(api, rpc, signer, &report_unstable_peer_tx, None).await
         {
-            failed_reports.push(format!("{}", tx_error));
+            failed_reports.push(format!("{tx_error}"));
         }
     }
 


### PR DESCRIPTION
This applies fixes for the new clippy rules for rust 1.88 (which is now `stable`)