### PR TITLE
Check that production mode compiles in CI

### DIFF
--- a/.github/workflows/lint-and-check-licenses.yaml
+++ b/.github/workflows/lint-and-check-licenses.yaml
@@ -18,6 +18,8 @@ jobs:
           cargo fmt --check
           taplo fmt --check
           cargo clippy -- -D warnings
+          cargo check -p entropy-client --tests -F "production"
+          cargo check -p entropy-runtime --tests -F "production"
   check-licenses:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This adds a `cargo check` for production mode.  I put it in the lint and check licenses, workflow.  Not sure if that makes sense logically but its where the other compiler error will pop due to running clippy.