### PR TITLE
Fix change_threshold benchmark

### DIFF
--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -259,14 +259,14 @@ mod benchamrks {
             RawOrigin::Signed(_bonder.clone()),
             new_threshold.clone(),
             x25519_public_key.clone(),
-            quote,
+            quote.clone(),
         );
 
         let server_info = ServerInfo {
             endpoint: b"http://localhost:3001".to_vec(),
             tss_account: new_threshold.clone(),
-            x25519_public_key: NULL_ARR,
-            tdx_quote: NULL_ARR.to_vec(),
+            x25519_public_key: x25519_public_key.clone(),
+            tdx_quote: quote,
         };
 
         assert_last_event::<T>(Event::<T>::ThresholdAccountChanged(bonder, server_info).into());


### PR DESCRIPTION
Threshold would pass in test but fail in running benchmark, this is because instead of control we have in test to set it to null, the quote would be randomly generate, this is mitigated by manually insterting the quote instead of assuming it is null