### PR TITLE
Force node key generation in docker-compose local devnet

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
       - "--rpc-cors"
       - "all"
       - "--unsafe-rpc-external" # Intentional, for TSS's access.
+      - "--unsafe-force-node-key-generation" # Intentional - see #1513
       - "--node-key=0000000000000000000000000000000000000000000000000000000000000001"
       - "--tss-server-endpoint"
       - "http://alice-tss-server:3001"
@@ -82,6 +83,7 @@ services:
       - "--rpc-cors"
       - "all"
       - "--unsafe-rpc-external" # Intentional, for TSS's access.
+      - "--unsafe-force-node-key-generation" # Intentional - see #1513
       - "--bootnodes"
       - "/dns4/alice-chain-node/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
       - "--tss-server-endpoint"
@@ -119,6 +121,7 @@ services:
       - "--rpc-cors"
       - "all"
       - "--unsafe-rpc-external" # Intentional, for TSS's access.
+      - "--unsafe-force-node-key-generation" # Intentional - see #1513
       - "--bootnodes"
       - "/dns4/alice-chain-node/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
       - "--tss-server-endpoint"
@@ -156,6 +159,7 @@ services:
       - "--rpc-cors"
       - "all"
       - "--unsafe-rpc-external" # Intentional, for TSS's access.
+      - "--unsafe-force-node-key-generation" # Intentional - see #1513
       - "--bootnodes"
       - "/dns4/alice-chain-node/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
       - "--tss-server-endpoint"


### PR DESCRIPTION
Closes #1513

See also https://github.com/entropyxyz/devops-infrastructure/issues/121

On this branch i am now able to have all 4 chain nodes run successfully with the docker-compose local devnet.  But i am not sure if there are some cases where it would cause a problem that the chain nodes cannot be re-started without generating a new node key (which i think is the libp2p id used in discovery).

But i propose to merge this for now, as without it the docker-compose setup does not work at all (for me at least).

@entropyxyz/system-reliability-engineers   