### PR TITLE
When entropy-tss is built in production mode, entropy-client should be built in production mode

### DIFF
--- a/crates/threshold-signature-server/Cargo.toml
+++ b/crates/threshold-signature-server/Cargo.toml
@@ -108,7 +108,7 @@ default     =["std", "dep:tdx-quote"]
 std         =["sp-core/std"]
 test_helpers=["dep:project-root"]
 unsafe      =[]
-production  =["std", "entropy-shared/production"]
+production  =["std", "entropy-shared/production", "entropy-client/production"]
 alice       =[]
 bob         =[]
 # Enable this feature to run the integration tests for the wasm API of entropy-protocol


### PR DESCRIPTION
Otherwise entropy-tss fails to compile in production mode, see https://github.com/entropyxyz/entropy-core/actions/runs/16616462687/job/47010141118

Relates to https://github.com/entropyxyz/entropy-core/issues/1502 and https://github.com/entropyxyz/entropy-core/pull/1505